### PR TITLE
ESX.OneSync.SpawnVehicle and Command rewrite

### DIFF
--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -60,7 +60,7 @@ Config.RemoveHudCommonents = {
 	[22] = false, --HUD_WEAPONS
 }
 
-Config.MaxAdminVehicles = false -- admin vehicles spawn with max vehcle settings
+Config.MaxAdminVehicles = true -- admin vehicles spawn with max vehcle settings
 Config.CustomAIPlates = 'ESX.A111' -- Custom plates for AI vehicles 
 -- Pattern string format
 --1 will lead to a random number from 0-9.

--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -60,7 +60,7 @@ Config.RemoveHudCommonents = {
 	[22] = false, --HUD_WEAPONS
 }
 
-Config.MaxAdminVehicles = true -- admin vehicles spawn with max vehcle settings
+Config.SpawnVehMaxUpgrades = true -- admin vehicles spawn with max vehcle settings
 Config.CustomAIPlates = 'ESX.A111' -- Custom plates for AI vehicles 
 -- Pattern string format
 --1 will lead to a random number from 0-9.

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -35,45 +35,45 @@ local upgrades = Config.SpawnVehMaxUpgrades and
     } or {}
 
 ESX.RegisterCommand('car', 'admin', function(xPlayer, args, showError)
-	if xPlayer then
-		local playerPed = GetPlayerPed(xPlayer.source)
-		local playerCoords = GetEntityCoords(playerPed)
-		local playerHeading = GetEntityHeading(playerPed)
-		local playerVehicle = GetVehiclePedIsIn(playerPed)
+	if not xPlayer then
+		return print('[^1ERROR^7] The xPlayer value is nil')
+	end
+	
+	local playerPed = GetPlayerPed(xPlayer.source)
+	local playerCoords = GetEntityCoords(playerPed)
+	local playerHeading = GetEntityHeading(playerPed)
+	local playerVehicle = GetVehiclePedIsIn(playerPed)
 
-		if not args.car or type(args.car) ~= 'string' then
-			args.car = 'adder'
-		end
+	if not args.car or type(args.car) ~= 'string' then
+		args.car = 'adder'
+	end
 
-		if playerVehicle then
-			DeleteEntity(playerVehicle)
-		end
+	if playerVehicle then
+		DeleteEntity(playerVehicle)
+	end
 
-		ESX.DiscordLogFields("UserActions", "/car Triggered", "pink", {
-			{name = "Player", value = xPlayer.name, inline = true},
-			{name = "ID", value = xPlayer.source, inline = true},
-			{name = "Vehicle", value = args.car, inline = true}
-		})
+	ESX.DiscordLogFields("UserActions", "/car Triggered", "pink", {
+		{name = "Player", value = xPlayer.name, inline = true},
+		{name = "ID", value = xPlayer.source, inline = true},
+		{name = "Vehicle", value = args.car, inline = true}
+	})
 
-		ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
-			if networkId then
-				local vehicle = NetworkGetEntityFromNetworkId(networkId)
-				for i = 1, 20 do
-					Wait(0)
-					SetPedIntoVehicle(playerPed, vehicle, -1)
+	ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
+		if networkId then
+			local vehicle = NetworkGetEntityFromNetworkId(networkId)
+			for i = 1, 20 do
+				Wait(0)
+				SetPedIntoVehicle(playerPed, vehicle, -1)
 		
-					if GetVehiclePedIsIn(playerPed, false) == vehicle then
-						break
-					end
-				end
-				if GetVehiclePedIsIn(playerPed, false) ~= vehicle then
-					print('[^1ERROR^7] The player could not be seated in the vehicle')
+				if GetVehiclePedIsIn(playerPed, false) == vehicle then
+					break
 				end
 			end
-		end)
-	else
-		print('[^1ERROR^7] The xplayer value is nil')
-	end
+			if GetVehiclePedIsIn(playerPed, false) ~= vehicle then
+				print('[^1ERROR^7] The player could not be seated in the vehicle')
+			end
+		end
+	end)
 end, false, {help = TranslateCap('command_car'), validate = false, arguments = {
 	{name = 'car',validate = false, help = TranslateCap('command_car_car'), type = 'string'}
 }}) 

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -23,7 +23,7 @@ end, true, {help = TranslateCap('command_setjob'), validate = true, arguments = 
 	{name = 'grade', help = TranslateCap('command_setjob_grade'), type = 'number'}
 }})
 
-local upgrades = Config.MaxAdminVehicles and
+local upgrades = Config.SpawnVehMaxUpgrades and
     {
         plate = "ADMINCAR",
         modEngine = 3,

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -35,41 +35,45 @@ local upgrades = Config.SpawnVehMaxUpgrades and
     } or {}
 
 ESX.RegisterCommand('car', 'admin', function(xPlayer, args, showError)
-	local playerPed = GetPlayerPed(xPlayer.source)
-	local playerCoords = GetEntityCoords(playerPed)
-	local playerHeading = GetEntityHeading(playerPed)
-    local playerVehicle = GetVehiclePedIsIn(playerPed)
+	if xPlayer then
+		local playerPed = GetPlayerPed(xPlayer.source)
+		local playerCoords = GetEntityCoords(playerPed)
+		local playerHeading = GetEntityHeading(playerPed)
+		local playerVehicle = GetVehiclePedIsIn(playerPed)
 
-	if not args.car or type(args.car) ~= 'string' then
-		args.car = 'adder'
-	end
+		if not args.car or type(args.car) ~= 'string' then
+			args.car = 'adder'
+		end
 
-	if playerVehicle then
-		DeleteEntity(playerVehicle)
-	end
+		if playerVehicle then
+			DeleteEntity(playerVehicle)
+		end
 
-	ESX.DiscordLogFields("UserActions", "/car Triggered", "pink", {
-		{name = "Player", value = xPlayer.name, inline = true},
-		{name = "ID", value = xPlayer.source, inline = true},
-    	{name = "Vehicle", value = args.car, inline = true}
-	})
+		ESX.DiscordLogFields("UserActions", "/car Triggered", "pink", {
+			{name = "Player", value = xPlayer.name, inline = true},
+			{name = "ID", value = xPlayer.source, inline = true},
+			{name = "Vehicle", value = args.car, inline = true}
+		})
 
-	ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
-		if networkId then
-			local vehicle = NetworkGetEntityFromNetworkId(networkId)
-			for i = 1, 20 do
-				Wait(0)
-				SetPedIntoVehicle(playerPed, vehicle, -1)
-	
-				if GetVehiclePedIsIn(playerPed, false) == vehicle then
-					break
+		ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
+			if networkId then
+				local vehicle = NetworkGetEntityFromNetworkId(networkId)
+				for i = 1, 20 do
+					Wait(0)
+					SetPedIntoVehicle(playerPed, vehicle, -1)
+		
+					if GetVehiclePedIsIn(playerPed, false) == vehicle then
+						break
+					end
+				end
+				if GetVehiclePedIsIn(playerPed, false) ~= vehicle then
+					print('[^1ERROR^7] The player could not be seated in the vehicle')
 				end
 			end
-			if GetVehiclePedIsIn(playerPed, false) ~= vehicle then
-				print('[^1ERROR^7] The player could not be seated in the vehicle')
-			end
-		end
-	end)
+		end)
+	else
+		print('[^1ERROR^7] The xplayer value is nil')
+	end
 end, false, {help = TranslateCap('command_car'), validate = false, arguments = {
 	{name = 'car',validate = false, help = TranslateCap('command_car_car'), type = 'string'}
 }}) 

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -65,6 +65,9 @@ ESX.RegisterCommand('car', 'admin', function(xPlayer, args, showError)
 					break
 				end
 			end
+			if GetVehiclePedIsIn(playerPed, false) ~= vehicle then
+				print('[^1ERROR^7] The player could not be seated in the vehicle')
+			end
 		end
 	end)
 end, false, {help = TranslateCap('command_car'), validate = false, arguments = {

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -23,29 +23,49 @@ end, true, {help = TranslateCap('command_setjob'), validate = true, arguments = 
 	{name = 'grade', help = TranslateCap('command_setjob_grade'), type = 'number'}
 }})
 
+local upgrades = Config.MaxAdminVehicles and
+    {
+        plate = "ADMINCAR",
+        modEngine = 3,
+        modBrakes = 2,
+        modTransmission = 2,
+        modSuspension = 3,
+        modArmor = true,
+        windowTint = 1
+    } or {}
+
 ESX.RegisterCommand('car', 'admin', function(xPlayer, args, showError)
-	local GameBuild = tonumber(GetConvar("sv_enforceGameBuild", 1604))
-	if not args.car then args.car = GameBuild >= 2699 and "draugur" or "prototipo" end
+	local playerPed = GetPlayerPed(xPlayer.source)
+	local playerCoords = GetEntityCoords(playerPed)
+	local playerHeading = GetEntityHeading(playerPed)
+    local playerVehicle = GetVehiclePedIsIn(playerPed)
+
+	if not args.car or type(args.car) ~= 'string' then
+		args.car = 'adder'
+	end
+
+	if playerVehicle then
+		DeleteEntity(playerVehicle)
+	end
+
 	ESX.DiscordLogFields("UserActions", "/car Triggered", "pink", {
 		{name = "Player", value = xPlayer.name, inline = true},
 		{name = "ID", value = xPlayer.source, inline = true},
-    {name = "Vehicle", value = args.car, inline = true}
+    	{name = "Vehicle", value = args.car, inline = true}
 	})
-	local upgrades = Config.MaxAdminVehicles and {
-		plate = "ADMINCAR", 
-		modEngine = 3,
-		modBrakes = 2,
-		modTransmission = 2,
-		modSuspension = 3,
-		modArmor = true,
-		windowTint = 1,
-	} or {}
-	local coords = xPlayer.getCoords(true)
-	local PlayerPed = GetPlayerPed(xPlayer.source)
-	ESX.OneSync.SpawnVehicle(args.car, coords - vector3(0,0, 0.9), GetEntityHeading(PlayerPed), upgrades, function(networkId)
-		local vehicle = NetworkGetEntityFromNetworkId(networkId)
-		Wait(250)
-		TaskWarpPedIntoVehicle(PlayerPed, vehicle, -1)
+
+	ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
+		if networkId then
+			local vehicle = NetworkGetEntityFromNetworkId(networkId)
+			for i = 1, 20 do
+				Wait(0)
+				SetPedIntoVehicle(playerPed, vehicle, -1)
+	
+				if GetVehiclePedIsIn(playerPed, false) == vehicle then
+					break
+				end
+			end
+		end
 	end)
 end, false, {help = TranslateCap('command_car'), validate = false, arguments = {
 	{name = 'car',validate = false, help = TranslateCap('command_car_car'), type = 'string'}

--- a/[core]/es_extended/server/onesync.lua
+++ b/[core]/es_extended/server/onesync.lua
@@ -61,29 +61,29 @@ end
 ---@param heading number
 ---@param Properties table
 ---@param cb function
-	function ESX.OneSync.SpawnVehicle(model, coords, heading, Properties, cb)
-		local veh_model = type(model) == 'string' and joaat(model) or model
-		Properties = Properties or {}
-		local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-		TriggerClientEvent("esx:requestModel", -1, model)
-		CreateThread(function()
-			local xPlayer = ESX.OneSync.GetClosestPlayer(vector, 300)
-			ESX.GetVehicleType(veh_model, xPlayer.id, function(Type)
-				if Type then
-					local SpawnedEntity = CreateVehicleServerSetter(veh_model, Type, vector, heading)
-					local NetworkId = NetworkGetNetworkIdFromEntity(SpawnedEntity)
-					while not DoesEntityExist(SpawnedEntity) do 
-						Wait(100)
-					end
-					Properties.NetId = NetworkId
-					Entity(SpawnedEntity).state:set('VehicleProperties', Properties, true)
-					cb(NetworkId)
-				else 
-					print(('[^1ERROR^7] Tried to spawn invalid vehicle - ^5%s^7!'):format(model))
+function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
+	local vehicleModel = joaat(model)
+	local vehicleProperties = properties
+
+	CreateThread(function()
+		local xPlayer = ESX.OneSync.GetClosestPlayer(coords, 300)
+		ESX.GetVehicleType(vehicleModel, xPlayer.id, function(vehicleType)
+			if vehicleType then
+				local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords, heading)
+				if DoesEntityExist(createdVehicle) then
+					local networkId = NetworkGetNetworkIdFromEntity(createdVehicle)
+					vehicleProperties.NetId = networkId
+					Entity(createdVehicle).state:set('VehicleProperties', vehicleProperties, true)
+					cb(networkId)
+				else
+					print('[^1ERROR^7] Unfortunately, this vehicle has not spawned')
 				end
-			end)
+			else 
+				print(('[^1ERROR^7] Tried to spawn invalid vehicle - ^5%s^7!'):format(model))
+			end
 		end)
-	end
+	end)
+end
 
 
 ---@param model number|string


### PR DESCRIPTION
Some changes on ESX.OneSync.SpawnVehicle
- If you now sitting in vehicle and use command your vehicle will be deleted
- Default vehicle is now adder
- Vehicles are displayed immediately without delay. And it doesn't bug and throw people away.
- esx:requestModel was deleted because this function does not need it... Mycroft Mycroft.
