### PR TITLE
Feat: Dynamic xPlayer functions + Marker Interactions

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -6,6 +6,7 @@ Core.CurrentRequestId = 0
 Core.ServerCallbacks = {}
 Core.TimeoutCallbacks = {}
 Core.Input = {}
+Core.Markers = {}
 ESX.UI = {}
 ESX.UI.HUD = {}
 ESX.UI.HUD.RegisteredElements = {}
@@ -94,8 +95,7 @@ function ESX.ShowNotification(message, type, length)
 
     print("[^1ERROR^7] ^5ESX Notify^7 is Missing!")
 end
-    
-    
+       
 function ESX.TextUI(message, type)
     if GetResourceState("esx_textui") ~= "missing" then
         return exports["esx_textui"]:TextUI(message, type)
@@ -145,6 +145,33 @@ function ESX.ShowFloatingHelpNotification(msg, coords)
     SetFloatingHelpTextStyle(1, 1, 2, -1, 3, 0)
     BeginTextCommandDisplayHelp('esxFloatingHelpNotification')
     EndTextCommandDisplayHelp(2, false, false, -1)
+end
+
+--- Marker Interaction System
+
+function ESX.CreateMarker(name, coords, distance, helpText, settings, key, action)
+    local invoker = GetInvokingResource()
+    if not Core.Markers[invoker] then
+        Core.Markers[invoker] = {}
+    end
+    Core.Markers[invoker][#Core.Markers[invoker] +1] = {name = name, coords = coords, distance = distance, helpText = helpText, settings = settings,key = key, action = action}
+end
+
+function ESX.RemoveMarker(name)
+    local invoker = GetInvokingResource()
+    if not Core.Markers[invoker] then
+        return
+    end
+    for i=1, #Core.Markers[invoker] do
+        if Core.Markers[invoker][i].name == name then
+            if i == 1 then
+                Core.Markers[invoker] = nil
+            else
+                table.remove(Core.Markers[invoker], i)
+            end
+            break
+        end
+    end
 end
 
 ESX.HashString = function(str)

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -736,7 +736,7 @@ CreateThread(function()
 				local dist = #(PlayerCoords - marker.coords)
 				if dist <= marker.distance then
 					Sleep = 0
-					if marker.show then
+					if marker.settings.drawMarker then
 						DrawMarker(marker.settings.sprite, marker.coords, 0, 0, 0, 0.0, 0, 0, marker.settings.scale.x,
 							marker.settings.scale.y, marker.settings.scale.z, marker.settings.colour.r, marker.settings.colour.g,
 							marker.settings.colour.b, marker.settings.colour.a or 255, false, true, 2, false, nil, nil, false)
@@ -748,7 +748,7 @@ CreateThread(function()
 							ESX.TextUI(marker.helpText, "info")
 						end
 						if marker.action then
-							if IsControlJustPressed(0, marker.key) then
+							if IsControlJustPressed(0, marker.settings.key) then
 								local act = pcall(marker.action)
 								if not act then
 									print("[ERROR] an Error occured during interaction on marker " .. marker.name)

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -768,3 +768,10 @@ CreateThread(function()
 		Wait(Sleep)
 	end
 end)
+
+-- remove markers if the resource has stopped.
+AddEventHandler("onResourceStop", function(resourceName)
+    if Core.Markers[resourceName] then
+        Core.Markers[resourceName] = nil
+    end
+end)

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -713,3 +713,58 @@ for i=1, #DoNotUse do
 		print("[^1ERROR^7] YOU ARE USING A RESOURCE THAT WILL BREAK ^1ESX^7, PLEASE REMOVE ^5"..DoNotUse[i].."^7")
 	end
 end
+
+-- Marker Interaction System
+local DrawingTextUI = false
+CreateThread(function()
+	while not ESX.PlayerLoaded do
+		Wait(0)
+	end
+	while true do
+		local Sleep = 1000
+		local ShowTextUI = false
+		local PlayerCoords = GetEntityCoords(ESX.PlayerData.ped)
+		if ESX.Table.SizeOf(Core.Markers) < 1 then
+			goto thread_end -- skip the entire thread
+		end
+		for k, v in pairs(Core.Markers) do
+			if #v < 1 then
+				goto loop_end -- skip this index
+			end
+			for i = 1, #v do
+				local marker = v[i]
+				local dist = #(PlayerCoords - marker.coords)
+				if dist <= marker.distance then
+					Sleep = 0
+					if marker.show then
+						DrawMarker(marker.settings.sprite, marker.coords, 0, 0, 0, 0.0, 0, 0, marker.settings.scale.x,
+							marker.settings.scale.y, marker.settings.scale.z, marker.settings.colour.r, marker.settings.colour.g,
+							marker.settings.colour.b, marker.settings.colour.a or 255, false, true, 2, false, nil, nil, false)
+					end
+					if dist <= marker.settings.scale.x + 0.5 then
+						ShowTextUI = true
+						if marker.helpText and not DrawingTextUI then
+							DrawingTextUI = true
+							ESX.TextUI(marker.helpText, "info")
+						end
+						if marker.action then
+							if IsControlJustPressed(0, marker.key) then
+								local act = pcall(marker.action)
+								if not act then
+									print("[ERROR] an Error occured during interaction on marker " .. marker.name)
+								end
+							end
+						end
+					end
+				end
+			end
+			::loop_end::
+		end
+		::thread_end::
+		if DrawingTextUI and not ShowTextUI then
+			DrawingTextUI = false
+			ESX.HideUI()
+		end
+		Wait(Sleep)
+	end
+end)

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -13,6 +13,7 @@ Core.RegisteredCommands = {}
 Core.Pickups = {}
 Core.PickupId = 0
 Core.PlayerFunctionOverrides = {}
+Core.PlayerFunctions = {}
 
 AddEventHandler("esx:getSharedObject", function()
 	local Invoke = GetInvokingResource()

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -387,6 +387,17 @@ function ESX.SetPlayerFunctionOverride(index)
   Config.PlayerFunctionOverride = index
 end
 
+-- Allows dynamic xPlayer functions, like the overrides but in runtime.
+function ESX.PlayerFunction(name, cb)
+  Core.PlayerFunctions[name] = cb
+
+  for id, xPlayer in pairs(ESX.Players) do
+    ESX.Players[id][name] = function(...)
+          return cb(xPlayer, ...)
+      end
+  end
+end
+
 function ESX.GetItemLabel(item)
   if Config.OxInventory then
     item = exports.ox_inventory:Items(item)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -629,3 +629,14 @@ AddEventHandler('txAdmin:events:serverShuttingDown', function()
   Core.SavePlayers()
 end)
 
+AddEventHandler("onResourceStop", function(resourceName)
+  -- remove functions from stopped resources
+  for name, _function in pairs(Core.PlayerFunctions) do
+      if string.match(_function.__cfx_functionReference, resourceName) then -- Check if function is from the stopped resource
+        Core.PlayerFunctions[name] = nil
+          for id,_ in pairs(ESX.Players) do -- delete function for all players
+              ESX.Players[id][name] = nil
+          end
+      end
+  end
+end)


### PR DESCRIPTION
These are just some functions i did for OnlineM, and thought i would PR them in.

having ESX as a marker "host" system will heavily boost performance, since there wont be so many resources having threads that do the exact same thing, every tick, i will be doing PRs to all the addons to add this in.

Example Usage:

xPlayer functions:
```lua
-- define the function
ESX.PlayerFunction("addXP", function(self, amount)
        local CurrentXP = self.get("xp")
        local NewXP = CurrentXP + amount
        self.set("xp", NewXP)
        self.triggerEvent("onlineM:updateXP")
end)

-- call the function
xPlayer.addXP(1000)
```

Marker Interaction:
```lua
local name = "test"
local coords = vector3(0,0,0)
local draw_distance = 10
local text_ui_text = "[E] Interact"
local drawMarker = true
local key = 38
 ESX.CreateMarker(marker_name, coords, draw_distance, text_ui_text, {
           drawMarker = drawMarker,
           key = key,
            scale = {x = 0.5, y = 0.5, z = 0.5}, -- Scale of the marker
            sprite = 21, -- type of the marker
            colour = {r = 200, g = 50, b = 50, a =255} -- R, G, B, A, colour system
        }, function()
            -- on interaction
        end)

-- to remove the marker:
ESX.RemoveMarker(name)
```