### PR TITLE
fix(es_extended/client/functions) Fix infinite loop 

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -432,8 +432,13 @@ function ESX.Game.SpawnVehicle(vehicle, coords, heading, cb, networked)
         SetVehRadioStation(vehicle, 'OFF')
 
         RequestCollisionAtCoord(vector.xyz)
+        local tries = 0
         while not HasCollisionLoadedAroundEntity(vehicle) do
-            Wait(0)
+            if tries > 20 then
+                break
+            end
+            tries += 1
+            Wait(50)
         end
 
         if cb then


### PR DESCRIPTION
Collision detection does not always yield a result. I didn't do much testing, but it certainly always happens for non-networked addon vehicles when the player is too far away. To be safe, I suggest to just force break out of the loop after a certain amount of tries. Checking every frame seems excessive imo. 