### PR TITLE
refactor(sharedObject): Add event back to es_extended.

### DIFF
--- a/[core]/es_extended/client/common.lua
+++ b/[core]/es_extended/client/common.lua
@@ -6,7 +6,11 @@ if GetResourceState('ox_inventory') ~= 'missing' then
 	Config.OxInventory = true
 end
 
-AddEventHandler("esx:getSharedObject", function()
-	local Invoke = GetInvokingResource()
-	print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix!"):format(Invoke))
+AddEventHandler("esx:getSharedObject", function(cb)
+	if Config.EnableGetSharedObjectEvent then
+		cb(ESX)
+	else
+		local Invoke = GetInvokingResource()
+		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix! Alternativly you can enable the config option for it!"):format(Invoke))
+	end
 end)

--- a/[core]/es_extended/client/common.lua
+++ b/[core]/es_extended/client/common.lua
@@ -11,6 +11,6 @@ AddEventHandler("esx:getSharedObject", function(cb)
 		cb(ESX)
 	else
 		local Invoke = GetInvokingResource()
-		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix! Alternativly you can enable the config option for it!"):format(Invoke))
+		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, This Is NOT Recommended and is very bad for performance! Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent For More details"):format(Invoke))
 	end
 end)

--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -63,7 +63,7 @@ Config.RemoveHudCommonents = {
 	[22] = false, --HUD_WEAPONS
 }
 
-Config.EnableGetSharedObjectEvent = false -- This is not recommended, Enables old getSharedObject event.
+Config.EnableGetSharedObjectEvent = false -- Warning: Enabling This WILL massively hurt and decrease your servers performance, use this at your own precaution.
 
 Config.SpawnVehMaxUpgrades = true -- admin vehicles spawn with max vehcle settings
 Config.CustomAIPlates = 'ESX.A111' -- Custom plates for AI vehicles 

--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -63,6 +63,8 @@ Config.RemoveHudCommonents = {
 	[22] = false, --HUD_WEAPONS
 }
 
+Config.EnableGetSharedObjectEvent = false -- This is not recommended, Enables old getSharedObject event.
+
 Config.SpawnVehMaxUpgrades = true -- admin vehicles spawn with max vehcle settings
 Config.CustomAIPlates = 'ESX.A111' -- Custom plates for AI vehicles 
 -- Pattern string format

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -11,12 +11,15 @@ Core.RegisteredCommands = {}
 Core.Pickups = {}
 Core.PickupId = 0
 Core.PlayerFunctionOverrides = {}
-
 Core.playersByIdentifier = {}
 
-AddEventHandler("esx:getSharedObject", function()
-	local Invoke = GetInvokingResource()
-	print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix!"):format(Invoke))
+AddEventHandler("esx:getSharedObject", function(cb)
+	if Config.EnableGetSharedObjectEvent then
+		cb(ESX)
+	else
+		local Invoke = GetInvokingResource()
+		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix! Alternativly you can enable the config option for it!"):format(Invoke))
+	end
 end)
 
 exports('getSharedObject', function()

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -18,7 +18,7 @@ AddEventHandler("esx:getSharedObject", function(cb)
 		cb(ESX)
 	else
 		local Invoke = GetInvokingResource()
-		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, this event ^1no longer exists!^7 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix! Alternativly you can enable the config option for it!"):format(Invoke))
+		print(("[^1ERROR^7] Resource ^5%s^7 Used the ^5getSharedObject^7 Event, This Is NOT Recommended and is very bad for performance! Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent For More details"):format(Invoke))
 	end
 end)
 


### PR DESCRIPTION
This pull requests adds a config option to enable the old getSharedObject event. The amount of people who do not know how to use the the new export is ridiculous and we all know things wont change. Script developers wont change their escrowed code either, meaning people cannot use scripts that they have paid for. 

I believe this will solve a lot of our problems with backwards compatibility as well as minimise the amount of people asking about the error in our discord.

Feel free to roast the idea or put your opinions/thoughts in the comments. Please no smart ass or rude comments, be respectful! :) 