### PR TITLE
feat(esx_multicharacter): Use dummy identifier for multicharacter when in fxdk mode

### DIFF
--- a/[core]/esx_multicharacter/server/main.lua
+++ b/[core]/esx_multicharacter/server/main.lua
@@ -26,6 +26,10 @@ elseif ESX.GetConfig().Multichar == true then
 	local PRIMARY_IDENTIFIER = ESX.GetConfig().Identifier or GetConvar('sv_lan', '') == 'true' and 'ip' or "license"
 
 	local function GetIdentifier(source)
+		local fxDk = GetConvarInt('sv_fxdkMode', 0) 
+		if fxDk == 1 then
+			return "ESX-DEBUG-LICENCE"
+		end
 		local identifier = PRIMARY_IDENTIFIER..':'
 		for _, v in pairs(GetPlayerIdentifiers(source)) do
 			if string.match(v, identifier) then


### PR DESCRIPTION
Use dummy identifier in the multicharacter resource when determining player identifier. This syncs the functionality to what already is happening in `es_extended/server/functions.lua` `ESX.GetIdentifier` method.

Without this, multicharacter resource does not detect existing characters when running under fxdk and will always prompt the user to create a new one, which will fail on the INSERT query due to duplicate primary keys.