### PR TITLE
fix(esx_core: Translate function) handle nil given parameter in Translate function

### DIFF
--- a/[core]/es_extended/locale.lua
+++ b/[core]/es_extended/locale.lua
@@ -1,6 +1,11 @@
 Locales = {}
 
 function Translate(str, ...)  -- Translate string
+	if not str then
+		local currentResourceName = GetCurrentResourceName()
+		print(("[^1ERROR^7] Resource ^5%s^7 You did not specify a parameter for the Translate function or the value is nil!"):format(currentResourceName))
+		return 'Given translate function parameter is nil!'
+	end
 	if Locales[Config.Locale] then
 		if Locales[Config.Locale][str] then
 			return string.format(Locales[Config.Locale][str], ...)


### PR DESCRIPTION
If you don't given parameter to function get error message "str" value is nil. This commit fix this issue. 