### PR TITLE
Remove '/native:0x6AE51D4B' dependency

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -74,7 +74,6 @@ files {
 }
 
 dependencies {
-	'/native:0x6AE51D4B',
 	'oxmysql',
 	'spawnmanager',
 }


### PR DESCRIPTION
This was causing the script not to run due to a "Native 0x6AE51D4B not supported" error that would basically brick the entire server on the latest recommend FxServer Artifacts