### PR TITLE
fix(es_extended/server/classes/player.lua): Fix showNotification function parameters to correspond with esx:showNotification event

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -572,8 +572,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		end
 	end
 
-	function self.showNotification(msg)
-		self.triggerEvent('esx:showNotification', msg)
+	function self.showNotification(msg, type, length)
+		self.triggerEvent('esx:showNotification', msg, type, length)
 	end
 
 	function self.showHelpNotification(msg, thisFrame, beep, duration)


### PR DESCRIPTION
This fixes that the xPlayer.showNotification function has the same parameters as that of the esx:showNotification event on the client side allowing you to use the parameters `type` and `length` from the xPlayer object.