### PR TITLE
remove principals after player quit

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -352,6 +352,8 @@ AddEventHandler('playerDropped', function(reason)
   if xPlayer then
     TriggerEvent('esx:playerDropped', playerId, reason)
 
+	ExecuteCommand(('remove_principal identifier.%s group.%s'):format(xPlayer.identifier, xPlayer.group))
+
     Core.playersByIdentifier[xPlayer.identifier] = nil
     Core.SavePlayer(xPlayer, function()
       ESX.Players[playerId] = nil


### PR DESCRIPTION
The CreateExtendedPlayer function assigns permissions every time a player enters the server, so when we want to change the permissions for a given player, for example through the database, it will not be possible because the player will still have permissions assigned