### PR TITLE
Remove weapon using rpc

### DIFF
--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -332,9 +332,7 @@ if not Config.OxInventory then
 
 	RegisterNetEvent('esx:removeWeapon')
 	AddEventHandler('esx:removeWeapon', function(weapon)
-		local playerPed = ESX.PlayerData.ped
-		RemoveWeaponFromPed(playerPed, joaat(weapon))
-		SetPedAmmo(ESX.PlayerData.ped, joaat(weapon), 0)
+		print("[^1ERROR^7] event ^5'esx:removeWeapon'^7 Has Been Removed. Please use ^5xPlayer.removeWeapon^7 Instead!")
 	end)
 
 	RegisterNetEvent('esx:removeWeaponComponent')

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -470,13 +470,17 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 					self.removeWeaponComponent(weaponName, v2)
 				end
 
+				local weaponHash = joaat(weaponName)
+				
+				RemoveWeaponFromPed(GetPlayerPed(self.source), weaponHash)
+				SetPedAmmo(GetPlayerPed(self.source), weaponHash, 0)
+
 				table.remove(self.loadout, k)
 				break
 			end
 		end
 
 		if weaponLabel then
-			self.triggerEvent('esx:removeWeapon', weaponName)
 			self.triggerEvent('esx:removeInventoryItem', weaponLabel, false, true)
 		end
 	end

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -460,7 +460,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.removeWeapon(weaponName)
-		local weaponLabel
+		local weaponLabel, weaponHash
+		local weaponHash = joaat(weaponName)
 
 		for k, v in ipairs(self.loadout) do
 			if v.name == weaponName then
@@ -469,8 +470,6 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 				for _, v2 in ipairs(v.components) do
 					self.removeWeaponComponent(weaponName, v2)
 				end
-
-				local weaponHash = joaat(weaponName)
 				
 				RemoveWeaponFromPed(GetPlayerPed(self.source), weaponHash)
 				SetPedAmmo(GetPlayerPed(self.source), weaponHash, 0)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -460,7 +460,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.removeWeapon(weaponName)
-		local weaponLabel, weaponHash
+		local weaponLabel = nil
 		local weaponHash = joaat(weaponName)
         local playerPed = GetPlayerPed(self.source)
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -460,9 +460,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	function self.removeWeapon(weaponName)
-		local weaponLabel = nil
-		local weaponHash = joaat(weaponName)
-        local playerPed = GetPlayerPed(self.source)
+		local weaponLabel, playerPed = nil, GetPlayerPed(self.source)
+
+		if not playerPed then 
+			return print("[^1ERROR^7] xPlayer.removeWeapon ^5invalid^7 player ped!")
+		end
 
 		for k, v in ipairs(self.loadout) do
 			if v.name == weaponName then
@@ -472,6 +474,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 					self.removeWeaponComponent(weaponName, v2)
 				end
 				
+				local weaponHash = joaat(v.name)
+
 				RemoveWeaponFromPed(playerPed, weaponHash)
 				SetPedAmmo(playerPed, weaponHash, 0)
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -462,6 +462,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	function self.removeWeapon(weaponName)
 		local weaponLabel, weaponHash
 		local weaponHash = joaat(weaponName)
+        local playerPed = GetPlayerPed(self.source)
 
 		for k, v in ipairs(self.loadout) do
 			if v.name == weaponName then
@@ -471,8 +472,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 					self.removeWeaponComponent(weaponName, v2)
 				end
 				
-				RemoveWeaponFromPed(GetPlayerPed(self.source), weaponHash)
-				SetPedAmmo(GetPlayerPed(self.source), weaponHash, 0)
+				RemoveWeaponFromPed(playerPed, weaponHash)
+				SetPedAmmo(playerPed, weaponHash, 0)
 
 				table.remove(self.loadout, k)
 				break


### PR DESCRIPTION
This pr changes the function for xPlayer.removeWeapon by using rpc natives to remove the weapon serverside instead of using a client event.