### PR TITLE
Fixing getNearbyPlayers function source definition

### DIFF
--- a/[core]/es_extended/server/onesync.lua
+++ b/[core]/es_extended/server/onesync.lua
@@ -15,7 +15,7 @@ local function getNearbyPlayers(source, closest, distance, ignore)
 			error("Received invalid first argument (source); should be playerId or vector3 coordinates")
 		end
 
-		source = GetEntityCoords(GetPlayerPed(source))
+		source = GetEntityCoords(source)
 	end
 
 	for _, xPlayer in pairs(ESX.Players) do

--- a/[core]/es_extended/server/onesync.lua
+++ b/[core]/es_extended/server/onesync.lua
@@ -15,12 +15,14 @@ local function getNearbyPlayers(source, closest, distance, ignore)
         
 		if not source then
 			error("Received invalid first argument (source); should be playerId")
+            return result
 		end
 
 		playerCoords = GetEntityCoords(playerPed)
 
         if not playerCoords then
             error("Received nil value (playerCoords); perhaps source is nil at first place?")
+            return result
         end
 	end
 

--- a/[core]/es_extended/server/onesync.lua
+++ b/[core]/es_extended/server/onesync.lua
@@ -38,10 +38,12 @@ local function getNearbyPlayers(source, closest, distance, ignore)
 					result[count] = { id = xPlayer.source, ped = NetworkGetNetworkIdFromEntity(entity), coords = coords, dist = dist }
 				end
 			else
-				local dist = #(playerCoords - coords)
-				if dist <= (result.dist or distance) then
-					result = { id = xPlayer.source, ped = NetworkGetNetworkIdFromEntity(entity), coords = coords, dist = dist }
-				end
+                if xPlayer.source ~= source then
+				    local dist = #(playerCoords - coords)
+				    if dist <= (result.dist or distance) then
+					    result = { id = xPlayer.source, ped = NetworkGetNetworkIdFromEntity(entity), coords = coords, dist = dist }
+				    end
+                end
 			end
 		end
 	end

--- a/[core]/es_extended/server/onesync.lua
+++ b/[core]/es_extended/server/onesync.lua
@@ -7,15 +7,21 @@ ESX.OneSync = {}
 local function getNearbyPlayers(source, closest, distance, ignore)
 	local result = {}
 	local count = 0
+    local playerPed
+    local playerCoords
 	if not distance then distance = 100 end
 	if type(source) == 'number' then
-		source = GetPlayerPed(source)
-
+		playerPed = GetPlayerPed(source)
+        
 		if not source then
-			error("Received invalid first argument (source); should be playerId or vector3 coordinates")
+			error("Received invalid first argument (source); should be playerId")
 		end
 
-		source = GetEntityCoords(source)
+		playerCoords = GetEntityCoords(playerPed)
+
+        if not playerCoords then
+            error("Received nil value (playerCoords); perhaps source is nil at first place?")
+        end
 	end
 
 	for _, xPlayer in pairs(ESX.Players) do
@@ -24,13 +30,13 @@ local function getNearbyPlayers(source, closest, distance, ignore)
 			local coords = GetEntityCoords(entity)
 
 			if not closest then
-				local dist = #(source - coords)
+				local dist = #(playerCoords - coords)
 				if dist <= distance then
 					count = count + 1
 					result[count] = { id = xPlayer.source, ped = NetworkGetNetworkIdFromEntity(entity), coords = coords, dist = dist }
 				end
 			else
-				local dist = #(source - coords)
+				local dist = #(playerCoords - coords)
 				if dist <= (result.dist or distance) then
 					result = { id = xPlayer.source, ped = NetworkGetNetworkIdFromEntity(entity), coords = coords, dist = dist }
 				end


### PR DESCRIPTION
By using the function you see the following:

source = GetPlayerPed(source)
-- So source is now the playerPed

source = GetEntityCoords(GetPlayerPed(source))
-- The source is getting new defined by calling the entity coords from the playerPed and then the playerPed once again.