### PR TITLE
:ambulance: fix register commands handle optional args

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -117,7 +117,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
 						end
 
 						--backwards compatibility
-						if not v.validate and not v.type then
+						if v.validate ~= nil and not v.validate then
 							error = nil
 						end
 


### PR DESCRIPTION
/dv command radius args now optional