### PR TITLE
Fix error in chat with admin logs

### DIFF
--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -30,8 +30,8 @@ ESX.RegisterCommand('setjob', 'admin', function(xPlayer, args, showError)
 			{ name = "Player", value = xPlayer.name,       inline = true },
 			{ name = "ID",     value = xPlayer.source,     inline = true },
 			{ name = "Target", value = args.playerId.name, inline = true },
-			{ name = "Job",    value = args.playerId,      inline = true },
-			{ name = "Grade",  value = args.playerId,      inline = true },
+			{ name = "Job",    value = args.job,      inline = true },
+			{ name = "Grade",  value = args.grade,      inline = true },
 		})
 	end
 end, true, {


### PR DESCRIPTION
Error in chat fix --> SCRIPT ERROR : Type 'function' is not supported by json