### PR TITLE
fix(ESX.UI): Close Opened Menus on Resource Stop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,8 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
+  pull_request_target:
+    types: 
       - opened
 
 jobs:
@@ -15,14 +15,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Get event creation date
+      - name: Get current date
         id: date
-        run: |
-          if [[ "${{ github.event_name }}" == "issues" ]]; then
-            echo "date=${{ github.event.issue.created_at }}" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "date=${{ github.event.pull_request.created_at }}" >> $GITHUB_ENV
-          fi
+        run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       - name: Add to project
         uses: actions/add-to-project@v0.5.0
         with:
@@ -35,5 +30,5 @@ jobs:
           project-url: https://github.com/orgs/esx-framework/projects/9
           github-token: ${{ secrets.MY_GITHUB_TOKEN }}
           item-id: ${{ steps.add-project.outputs.itemId }}
-          field-keys: Date
-          field-values: ${{ env.date }},
+          field-keys: Date,Priority
+          field-values: ${{ env.date }},Unrealised

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -196,6 +196,7 @@ function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, c
 
     menu.type = type
     menu.namespace = namespace
+    menu.resourceName = (GetInvokingResource() or "Unknown")
     menu.name = name
     menu.data = data
     menu.submit = submit
@@ -1346,7 +1347,7 @@ end)
 AddEventHandler('onResourceStop', function(resourceName)
     for i = 1, #ESX.UI.Menu.Opened, 1 do
         if ESX.UI.Menu.Opened[i] then
-            if ESX.UI.Menu.Opened[i].namespace == resourceName then
+            if ESX.UI.Menu.Opened[i].resourceName == resourceName or ESX.UI.Menu.Opened[i].namespace == resourceName then
                 ESX.UI.Menu.Opened[i].close()
                 ESX.UI.Menu.Opened[i] = nil
             end

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1343,6 +1343,17 @@ AddEventHandler('esx:showHelpNotification', function(msg, thisFrame, beep, durat
     ESX.ShowHelpNotification(msg, thisFrame, beep, duration)
 end)
 
+AddEventHandler('onResourceStop', function(resourceName)
+    for i = 1, #ESX.UI.Menu.Opened, 1 do
+        if ESX.UI.Menu.Opened[i] then
+            if ESX.UI.Menu.Opened[i].namespace == resourceName then
+                ESX.UI.Menu.Opened[i].close()
+                ESX.UI.Menu.Opened[i] = nil
+            end
+        end
+    end
+end)
+
 ---@param model number|string
 ---@return string
 function ESX.GetVehicleType(model)


### PR DESCRIPTION
I have encountered several frustrating instances when accidentally restarting a script that still had an open ESX UI. This situation prevents the UI from closing properly and leads to a cascade of errors, ultimately forcing a game restart. To address this issue, I propose the following code changes.

The code introduces an event handler for the onResourceStop event, enabling us to loop through all open ESX UIs and identify any opened menus within the same namespace as the resource name. Following the best practice, the namespace should ideally align with the resource name.

I believe implementing these changes will provide a smoother user experience. I look forward to your feedback and merging these improvements into the main branch.