### PR TITLE
Feature Request 1156: Added CheckDuplicateLicense Config Entry

### DIFF
--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -32,7 +32,7 @@ Config.AdminGroups = {
 	['admin'] = true
 }
 
-
+Config.CheckDuplicateLicense     = true      -- Allows duplicate identifiers for development purposes if set to false. Should be set to true for production!
 Config.EnablePaycheck            = true      -- enable paycheck
 Config.LogPaycheck               = false     -- Logs paychecks to a nominated Discord channel via webhook (default is false)
 Config.EnableSocietyPayouts      = false     -- pay from the society account that the player is employed at? Requirement: esx_society

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -45,24 +45,33 @@ else
 end
 
 function onPlayerJoined(playerId)
-	local identifier = ESX.GetIdentifier(playerId)
-	if identifier then
-		if ESX.GetPlayerFromIdentifier(identifier) then
-			DropPlayer(playerId,
-				('there was an error loading your character!\nError code: identifier-active-ingame\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same Rockstar account.\n\nYour Rockstar identifier: %s'):format(
-					identifier))
-		else
-			local result = MySQL.scalar.await('SELECT 1 FROM users WHERE identifier = ?', { identifier })
-			if result then
-				loadESXPlayer(identifier, playerId, false)
-			else
-				createESXPlayer(identifier, playerId)
-			end
-		end
-	else
-		DropPlayer(playerId,
-			'there was an error loading your character!\nError code: identifier-missing-ingame\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.')
-	end
+    local function handleESXPlayer(identifier)
+        local result = MySQL.scalar.await('SELECT 1 FROM users WHERE identifier = ?', {identifier})
+        if result then
+            loadESXPlayer(identifier, playerId, false)
+        else
+            createESXPlayer(identifier, playerId)
+        end
+    end
+
+    local identifier = ESX.GetIdentifier(playerId)
+    if identifier then
+        if ESX.GetPlayerFromIdentifier(identifier) then
+            if (Config.CheckDuplicateLicense) then
+                DropPlayer(playerId,
+                    ('there was an error loading your character!\nError code: identifier-active-ingame\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same Rockstar account.\n\nYour Rockstar identifier: %s'):format(
+                        identifier))
+            else
+                identifier = string.format("cl2:%s", identifier)
+                handleESXPlayer(identifier)
+            end
+        else
+            handleESXPlayer(identifier)
+        end
+    else
+        DropPlayer(playerId,
+            'there was an error loading your character!\nError code: identifier-missing-ingame\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.')
+    end
 end
 
 function createESXPlayer(identifier, playerId, data)
@@ -105,7 +114,7 @@ if not Config.Multichar then
 		end
 
 		if identifier then
-			if ESX.GetPlayerFromIdentifier(identifier) then
+			if Config.CheckDuplicateLicense and ESX.GetPlayerFromIdentifier(identifier) then
 				return deferrals.done(
 					('[ESX] There was an error loading your character!\nError code: identifier-active\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same account.\n\nYour identifier: %s'):format(
 						identifier))


### PR DESCRIPTION
### Feature Enhancement: Introducing 'CheckDuplicateLicense' Config Entry

#### Description
This pull request introduces a new configuration entry, CheckDuplicateLicense, that enhances the identifier management system. When set to true, the system enforces its current behavior by blocking the presence of duplicate identifiers on the server. Conversely, when set to false, the system allows duplicate identifiers for development purposes. The prefix "cl2" is added to the player's identifier, allowing them to connect as a distinct player instance. 

#### Changes Made
- Added a new configuration entry, CheckDuplicateLicense, to the configuration file.
- When CheckDuplicateLicense is set to true, the system retains its current behavior of blocking duplicate identifiers.
- When CheckDuplicateLicense is set to false, duplicate identifiers are allowed on the server. Players are identified by adding the - "cl2" prefix to their identifier, enabling them to connect as a separate player entity.

The code snippet for handling this behaviour has been enhanced as follows:
```lua
function onPlayerJoined(playerId)
    local function handleESXPlayer(identifier)
        local result = MySQL.scalar.await('SELECT 1 FROM users WHERE identifier = ?', {identifier})
        if result then
            loadESXPlayer(identifier, playerId, false)
        else
            createESXPlayer(identifier, playerId)
        end
    end

    local identifier = ESX.GetIdentifier(playerId)
    if identifier then
        if ESX.GetPlayerFromIdentifier(identifier) then
            if (Config.CheckDuplicateLicense) then
                DropPlayer(playerId,
                    ('there was an error loading your character!\nError code: identifier-active-ingame\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same Rockstar account.\n\nYour Rockstar identifier: %s'):format(
                        identifier))
            else
                identifier = string.format("cl2:%s", identifier)
                handleESXPlayer(identifier)
            end
        else
            handleESXPlayer(identifier)
        end
    else
        DropPlayer(playerId,
            'there was an error loading your character!\nError code: identifier-missing-ingame\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.')
    end
end
```

#### Reasoning
The introduction of the CheckDuplicateLicense configuration entry offers enhanced control over identifier management. By allowing or disallowing duplicate identifiers based on this setting, the feature caters to both development requirements and server stability. The choice of "cl2" as the prefix is consistent with the convention used by FiveM to permit two concurrent instances.

Thank you for considering this enhancement to the setcoords command. Your feedback and suggestions are appreciated.

[Related GitHub Issue #1156](https://github.com/esx-framework/esx_core/issues/1156)