### PR TITLE
Security Enhancement: Distance Check for 'esx:onPickup' Event

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -70,17 +70,17 @@ function ESX.Progressbar(message, length, Options)
     print("[^1ERROR^7] ^5ESX Progressbar^7 is Missing!")
 end
 
-function ESX.ShowNotification(message, type, length)
+function ESX.ShowNotification(message, notifyType, length)
     if GetResourceState("esx_notify") ~= "missing" then
-        return exports["esx_notify"]:Notify(type, length, message)
+        return exports["esx_notify"]:Notify(notifyType, length, message)
     end
 
     print("[^1ERROR^7] ^5ESX Notify^7 is Missing!")
 end
 
-function ESX.TextUI(message, type)
+function ESX.TextUI(message, notifyType)
     if GetResourceState("esx_textui") ~= "missing" then
-        return exports["esx_textui"]:TextUI(message, type)
+        return exports["esx_textui"]:TextUI(message, notifyType)
     end
 
     print("[^1ERROR^7] ^5ESX TextUI^7 is Missing!")
@@ -184,17 +184,17 @@ ESX.RegisterInput = function(command_name, label, input_group, key, on_press, on
     RegisterKeyMapping(on_release ~= nil and "+" .. command_name or command_name, label, input_group, key)
 end
 
-function ESX.UI.Menu.RegisterType(type, open, close)
-    ESX.UI.Menu.RegisteredTypes[type] = {
+function ESX.UI.Menu.RegisterType(menuType, open, close)
+    ESX.UI.Menu.RegisteredTypes[menuType] = {
         open = open,
         close = close
     }
 end
 
-function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, close)
+function ESX.UI.Menu.Open(menuType, namespace, name, data, submit, cancel, change, close)
     local menu = {}
 
-    menu.type = type
+    menu.type = menuType
     menu.namespace = namespace
     menu.name = name
     menu.data = data
@@ -203,11 +203,11 @@ function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, c
     menu.change = change
 
     menu.close = function()
-        ESX.UI.Menu.RegisteredTypes[type].close(namespace, name)
+        ESX.UI.Menu.RegisteredTypes[menuType].close(namespace, name)
 
         for i = 1, #ESX.UI.Menu.Opened, 1 do
             if ESX.UI.Menu.Opened[i] then
-                if ESX.UI.Menu.Opened[i].type == type and ESX.UI.Menu.Opened[i].namespace == namespace and
+                if ESX.UI.Menu.Opened[i].type == menuType and ESX.UI.Menu.Opened[i].namespace == namespace and
                     ESX.UI.Menu.Opened[i].name == name then
                     ESX.UI.Menu.Opened[i] = nil
                 end
@@ -238,7 +238,7 @@ function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, c
     end
 
     menu.refresh = function()
-        ESX.UI.Menu.RegisteredTypes[type].open(namespace, name, menu.data)
+        ESX.UI.Menu.RegisteredTypes[menuType].open(namespace, name, menu.data)
     end
 
     menu.setElement = function(i, key, val)
@@ -267,15 +267,15 @@ function ESX.UI.Menu.Open(type, namespace, name, data, submit, cancel, change, c
     end
 
     ESX.UI.Menu.Opened[#ESX.UI.Menu.Opened + 1] = menu
-    ESX.UI.Menu.RegisteredTypes[type].open(namespace, name, data)
+    ESX.UI.Menu.RegisteredTypes[menuType].open(namespace, name, data)
 
     return menu
 end
 
-function ESX.UI.Menu.Close(type, namespace, name)
+function ESX.UI.Menu.Close(menuType, namespace, name)
     for i = 1, #ESX.UI.Menu.Opened, 1 do
         if ESX.UI.Menu.Opened[i] then
-            if ESX.UI.Menu.Opened[i].type == type and ESX.UI.Menu.Opened[i].namespace == namespace and
+            if ESX.UI.Menu.Opened[i].type == menuType and ESX.UI.Menu.Opened[i].namespace == namespace and
                 ESX.UI.Menu.Opened[i].name == name then
                 ESX.UI.Menu.Opened[i].close()
                 ESX.UI.Menu.Opened[i] = nil
@@ -293,10 +293,10 @@ function ESX.UI.Menu.CloseAll()
     end
 end
 
-function ESX.UI.Menu.GetOpened(type, namespace, name)
+function ESX.UI.Menu.GetOpened(menuType, namespace, name)
     for i = 1, #ESX.UI.Menu.Opened, 1 do
         if ESX.UI.Menu.Opened[i] then
-            if ESX.UI.Menu.Opened[i].type == type and ESX.UI.Menu.Opened[i].namespace == namespace and
+            if ESX.UI.Menu.Opened[i].type == menuType and ESX.UI.Menu.Opened[i].namespace == namespace and
                 ESX.UI.Menu.Opened[i].name == name then
                 return ESX.UI.Menu.Opened[i]
             end
@@ -308,8 +308,8 @@ function ESX.UI.Menu.GetOpenedMenus()
     return ESX.UI.Menu.Opened
 end
 
-function ESX.UI.Menu.IsOpen(type, namespace, name)
-    return ESX.UI.Menu.GetOpened(type, namespace, name) ~= nil
+function ESX.UI.Menu.IsOpen(menuType, namespace, name)
+    return ESX.UI.Menu.GetOpened(menuType, namespace, name) ~= nil
 end
 
 function ESX.UI.ShowInventoryItemNotification(add, item, count)
@@ -1182,7 +1182,7 @@ function ESX.ShowInventory()
         }
 
         ESX.OpenContext("right", elements2, function(_, element2)
-            local item, type = element2.value, element2.type
+            local item, itemType = element2.value, element2.type
 
             if element2.action == "give" then
                 local playersNearby = ESX.Game.GetPlayersInArea(GetEntityCoords(playerPed), 3.0)
@@ -1215,8 +1215,8 @@ function ESX.ShowInventory()
                                 local selectedPlayerPed = GetPlayerPed(selectedPlayer)
 
                                 if IsPedOnFoot(selectedPlayerPed) and not IsPedFalling(selectedPlayerPed) then
-                                    if type == 'item_weapon' then
-                                        TriggerServerEvent('esx:giveInventoryItem', selectedPlayerId, type, item, nil)
+                                    if itemType == 'item_weapon' then
+                                        TriggerServerEvent('esx:giveInventoryItem', selectedPlayerId, itemType, item, nil)
                                         ESX.CloseContext()
                                     else
                                         local elementsG = {
@@ -1229,7 +1229,7 @@ function ESX.ShowInventory()
                                             local quantity = tonumber(menuG.eles[2].inputValue)
 
                                             if quantity and quantity > 0 and element.count >= quantity then
-                                                TriggerServerEvent('esx:giveInventoryItem', selectedPlayerId, type, item, quantity)
+                                                TriggerServerEvent('esx:giveInventoryItem', selectedPlayerId, itemType, item, quantity)
                                                 ESX.CloseContext()
                                             else
                                                 ESX.ShowNotification(TranslateCap('amount_invalid'))
@@ -1251,12 +1251,12 @@ function ESX.ShowInventory()
                     local dict, anim = 'weapons@first_person@aim_rng@generic@projectile@sticky_bomb@', 'plant_floor'
                     ESX.Streaming.RequestAnimDict(dict)
 
-                    if type == 'item_weapon' then
+                    if itemType == 'item_weapon' then
                         ESX.CloseContext()
                         TaskPlayAnim(playerPed, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
                         RemoveAnimDict(dict)
                         Wait(1000)
-                        TriggerServerEvent('esx:removeInventoryItem', type, item)
+                        TriggerServerEvent('esx:removeInventoryItem', itemType, item)
                     else
                         local elementsR = {
                             { unselectable = true,          icon = "fas fa-trash", title = element.title },
@@ -1272,7 +1272,7 @@ function ESX.ShowInventory()
                                 TaskPlayAnim(playerPed, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
                                 RemoveAnimDict(dict)
                                 Wait(1000)
-                                TriggerServerEvent('esx:removeInventoryItem', type, item, quantity)
+                                TriggerServerEvent('esx:removeInventoryItem', itemType, item, quantity)
                             else
                                 ESX.ShowNotification(TranslateCap('amount_invalid'))
                             end
@@ -1328,8 +1328,8 @@ function ESX.ShowInventory()
 end
 
 RegisterNetEvent('esx:showNotification')
-AddEventHandler('esx:showNotification', function(msg, type, length)
-    ESX.ShowNotification(msg, type, length)
+AddEventHandler('esx:showNotification', function(msg, notifyType, length)
+    ESX.ShowNotification(msg, notifyType, length)
 end)
 
 RegisterNetEvent('esx:showAdvancedNotification')

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -349,7 +349,7 @@ end)
 
 if not Config.OxInventory then
 	RegisterNetEvent('esx:createPickup')
-	AddEventHandler('esx:createPickup', function(pickupId, label, coords, type, name, components, tintIndex)
+	AddEventHandler('esx:createPickup', function(pickupId, label, coords, itemType, name, components, tintIndex)
 		local function setObjectProperties(object)
 			SetEntityAsMissionEntity(object, true, false)
 			PlaceObjectOnGroundProperly(object)
@@ -364,7 +364,7 @@ if not Config.OxInventory then
 			}
 		end
 
-		if type == 'item_weapon' then
+		if itemType == 'item_weapon' then
 			local weaponHash = joaat(name)
 			ESX.Streaming.RequestWeaponAsset(weaponHash)
 			local pickupObject = CreateWeaponObject(weaponHash, 50, coords.x, coords.y, coords.z, true, 1.0, 0)

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -360,7 +360,7 @@ if not Config.OxInventory then
 				obj = object,
 				label = label,
 				inRange = false,
-				coords = vector3(coords.x, coords.y, coords.z)
+				coords = coords
 			}
 		end
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -564,8 +564,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		end
 	end
 
-	function self.showNotification(msg, type, length)
-		self.triggerEvent('esx:showNotification', msg, type, length)
+	function self.showNotification(msg, notifyType, length)
+		self.triggerEvent('esx:showNotification', msg, notifyType, length)
 	end
 
 	function self.showAdvancedNotification(sender, subject, msg, textureDict, iconType, flash, saveToBrief, hudColorIndex)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -469,19 +469,19 @@ function ESX.GetUsableItems()
 end
 
 if not Config.OxInventory then
-	function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex, coords)
+	function ESX.CreatePickup(itemType, name, count, label, playerId, components, tintIndex, coords)
 		local pickupId = (Core.PickupId == 65635 and 0 or Core.PickupId + 1)
 		local xPlayer = ESX.Players[playerId]
 		coords = ( (type(coords) == "vector3" or type(coords) == "vector4") and coords.xyz or xPlayer.getCoords(true))
 
-		Core.Pickups[pickupId] = { type = type, name = name, count = count, label = label, coords = coords }
+		Core.Pickups[pickupId] = { type = itemType, name = name, count = count, label = label, coords = coords }
 
-		if type == 'item_weapon' then
+		if itemType == 'item_weapon' then
 			Core.Pickups[pickupId].components = components
 			Core.Pickups[pickupId].tintIndex = tintIndex
 		end
 
-		TriggerClientEvent('esx:createPickup', -1, pickupId, label, coords, type, name, components, tintIndex)
+		TriggerClientEvent('esx:createPickup', -1, pickupId, label, coords, itemType, name, components, tintIndex)
 		Core.PickupId = pickupId
 	end
 end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -472,7 +472,7 @@ if not Config.OxInventory then
 	function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex)
 		local pickupId = (Core.PickupId == 65635 and 0 or Core.PickupId + 1)
 		local xPlayer = ESX.Players[playerId]
-		local coords = xPlayer.getCoords()
+		local coords = xPlayer.getCoords(true)
 
 		Core.Pickups[pickupId] = { type = type, name = name, count = count, label = label, coords = coords }
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -469,10 +469,10 @@ function ESX.GetUsableItems()
 end
 
 if not Config.OxInventory then
-	function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex)
+	function ESX.CreatePickup(type, name, count, label, playerId, components, tintIndex, coords)
 		local pickupId = (Core.PickupId == 65635 and 0 or Core.PickupId + 1)
 		local xPlayer = ESX.Players[playerId]
-		local coords = xPlayer.getCoords(true)
+		coords = ( (type(coords) == "vector3" or type(coords) == "vector4") and coords.xyz or xPlayer.getCoords(true))
 
 		Core.Pickups[pickupId] = { type = type, name = name, count = count, label = label, coords = coords }
 

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -584,6 +584,12 @@ if not Config.OxInventory then
 		local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)
 
 		if pickup then
+            local playerPickupDistance = #(pickup.coords - xPlayer.getCoords(true))
+            if(playerPickupDistance > 5.0) then
+			    print(('[^3WARNING^7] Player Detected Cheating (Out of range pickup): ^5%s^7'):format(xPlayer.getIdentifier()))
+                return
+            end
+
 			if pickup.type == 'item_standard' then
 				if xPlayer.canCarryItem(pickup.name, pickup.count) then
 					xPlayer.addInventoryItem(pickup.name, pickup.count)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -412,7 +412,7 @@ if not Config.OxInventory then
 	end)
 
 	RegisterNetEvent('esx:giveInventoryItem')
-	AddEventHandler('esx:giveInventoryItem', function(target, type, itemName, itemCount)
+	AddEventHandler('esx:giveInventoryItem', function(target, itemType, itemName, itemCount)
 		local playerId = source
 		local sourceXPlayer = ESX.GetPlayerFromId(playerId)
 		local targetXPlayer = ESX.GetPlayerFromId(target)
@@ -422,7 +422,7 @@ if not Config.OxInventory then
 			return
 		end
 
-		if type == 'item_standard' then
+		if itemType == 'item_standard' then
 			local sourceItem = sourceXPlayer.getInventoryItem(itemName)
 
 			if itemCount > 0 and sourceItem.count >= itemCount then
@@ -438,7 +438,7 @@ if not Config.OxInventory then
 			else
 				sourceXPlayer.showNotification(TranslateCap('imp_invalid_quantity'))
 			end
-		elseif type == 'item_account' then
+		elseif itemType == 'item_account' then
 			if itemCount > 0 and sourceXPlayer.getAccount(itemName).money >= itemCount then
 				sourceXPlayer.removeAccountMoney(itemName, itemCount, "Gave to " .. targetXPlayer.name)
 				targetXPlayer.addAccountMoney(itemName, itemCount, "Received from " .. sourceXPlayer.name)
@@ -449,7 +449,7 @@ if not Config.OxInventory then
 			else
 				sourceXPlayer.showNotification(TranslateCap('imp_invalid_amount'))
 			end
-		elseif type == 'item_weapon' then
+		elseif itemType == 'item_weapon' then
 			if sourceXPlayer.hasWeapon(itemName) then
 				local weaponLabel = ESX.GetWeaponLabel(itemName)
 				if not targetXPlayer.hasWeapon(itemName) then
@@ -482,7 +482,7 @@ if not Config.OxInventory then
 					targetXPlayer.showNotification(TranslateCap('received_weapon_hasalready', sourceXPlayer.name, weaponLabel))
 				end
 			end
-		elseif type == 'item_ammo' then
+		elseif itemType == 'item_ammo' then
 			if sourceXPlayer.hasWeapon(itemName) then
 				local _, weapon = sourceXPlayer.getWeapon(itemName)
 
@@ -509,11 +509,11 @@ if not Config.OxInventory then
 	end)
 
 	RegisterNetEvent('esx:removeInventoryItem')
-	AddEventHandler('esx:removeInventoryItem', function(type, itemName, itemCount)
+	AddEventHandler('esx:removeInventoryItem', function(itemType, itemName, itemCount)
 		local playerId = source
 		local xPlayer = ESX.GetPlayerFromId(playerId)
 
-		if type == 'item_standard' then
+		if itemType == 'item_standard' then
 			if itemCount == nil or itemCount < 1 then
 				xPlayer.showNotification(TranslateCap('imp_invalid_quantity'))
 			else
@@ -528,7 +528,7 @@ if not Config.OxInventory then
 					xPlayer.showNotification(TranslateCap('threw_standard', itemCount, xItem.label))
 				end
 			end
-		elseif type == 'item_account' then
+		elseif itemType == 'item_account' then
 			if itemCount == nil or itemCount < 1 then
 				xPlayer.showNotification(TranslateCap('imp_invalid_amount'))
 			else
@@ -543,7 +543,7 @@ if not Config.OxInventory then
 					xPlayer.showNotification(TranslateCap('threw_account', ESX.Math.GroupDigits(itemCount), string.lower(account.label)))
 				end
 			end
-		elseif type == 'item_weapon' then
+		elseif itemType == 'item_weapon' then
 			itemName = string.upper(itemName)
 
 			if xPlayer.hasWeapon(itemName) then


### PR DESCRIPTION
### Security Enhancement: Distance Check for 'esx:onPickup' Event

#### Description

This pull request introduces a critical security update for the "esx:onPickup" event to mitigate potential abuses. The update incorporates a distance check mechanism, preventing players from exploiting the event to collect pickups from excessive distances. This measure ensures fair gameplay and maintains the integrity of the event.

#### Changes Made

- Store serverside pickup coords as a vector, eliminating the need for client-side conversion, and allowing for arithmetic operations on them. 
- Implemented a distance check within the existing 'esx:onPickup' event handling code.
- If a player attempts to interact with a pickup beyond a specified distance (5.0 units), a warning is triggered, and the interaction is blocked.


The modified code snippet is as follows:
```lua
RegisterNetEvent('esx:onPickup')
AddEventHandler('esx:onPickup', function(pickupId)
    local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)

    if pickup then
        local playerPickupDistance = #(pickup.coords - xPlayer.getCoords(true))
        if(playerPickupDistance > 5.0) then
            print(('[^3WARNING^7] Player Detected Cheating (Out of range pickup): ^5%s^7'):format(xPlayer.getIdentifier()))
            return
        end

        -- Rest of the original event handling code

        if success then
            Core.Pickups[pickupId] = nil
            TriggerClientEvent('esx:removePickup', -1, pickupId)
        end
    end
end)
```

#### Reasoning

This security update is vital to prevent potential abuses of the "esx:onPickup" event. The event could potentially be exploited by malicious players to trigger unauthorized pickups using a simple code snippet like this:
```lua
RegisterNetEvent("esx:createPickup", function(pickupId)
    TriggerServerEvent("esx:onPickup", pickupId)
end)
 ```
By implementing a distance check, the update ensures that players can only interact with pickups within a reasonable range, discouraging unauthorized collection of pickups from afar.

#### Counterargument Consideration:

It's worth addressing the potential counterargument that the distance check might be unnecessary due to a player's ability to teleport to pickups, thus eliminating the need for this change. However, it's essential to recognize that third-party anticheats are designed precisely to identify players employing teleportation tactics across the map. Additionally, the presence of one form of vulnerability should not overshadow addressing another potential attack vector.

Thank you for considering these enhancements. Your feedback and suggestions are appreciated.
