### PR TITLE
Feature Request 1151: Added ESX.GetNumPlayers Function

### DIFF
--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -1,6 +1,7 @@
 ESX = {}
 ESX.Players = {}
 ESX.Jobs = {}
+ESX.JobsPlayerCount = {}
 ESX.Items = {}
 Core = {}
 Core.UsableItemsCallbacks = {}

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -261,24 +261,31 @@ end
 
 function ESX.GetNumPlayers(key, val)
     if(not key) then
-        return ESX.Table.SizeOf(ESX.Players)
+        return #ESX.GetPlayers()
     end
 
-    local isValATable = (type(val) == "table")
-    local valTable = (isValATable and val or {val})
-    local numPlayers = {}
-    for i, val in ipairs(valTable) do
-        numPlayers[val] = 0
-    end    
-
-    for i, xPlayer in pairs(ESX.Players) do
-        local value = (key == "job" and xPlayer.job.name or xPlayer[key])
-        if(numPlayers[value]) then
-            numPlayers[value] += 1
-        end 
+    if type(val) == "table" then
+        local numPlayers = {}
+        if key == "job" then
+            for _, v in ipairs(val) do
+                numPlayers[v] = (ESX.JobsPlayerCount[v] or 0)
+            end
+            return numPlayers
+        else
+            local filteredPlayers = ESX.GetExtendedPlayers(key, val)
+            for i, v in pairs(filteredPlayers) do
+                numPlayers[i] = (#v or 0)
+            end
+            return numPlayers
+        end
+    else
+        if key == "job" then
+            return (ESX.JobsPlayerCount[val] or 0)
+        else
+            local filteredPlayers = ESX.GetExtendedPlayers(key, val)
+            return #filteredPlayers
+        end
     end
-
-    return (isValATable and numPlayers or numPlayers[val])
 end
 
 function ESX.GetPlayerFromId(source)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -260,7 +260,7 @@ function ESX.GetExtendedPlayers(key, val)
 end
 
 function ESX.GetNumPlayers(key, val)
-    if(not key) then
+    if not key then
         return #ESX.GetPlayers()
     end
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -264,7 +264,8 @@ function ESX.GetNumPlayers(key, val)
         return ESX.Table.SizeOf(ESX.Players)
     end
 
-    local valTable = (type(val) == "table" and val or {val})
+    local isValATable = (type(val) == "table")
+    local valTable = (isValATable and val or {val})
     local numPlayers = {}
     for i, val in ipairs(valTable) do
         numPlayers[val] = 0
@@ -277,7 +278,7 @@ function ESX.GetNumPlayers(key, val)
         end 
     end
 
-    return numPlayers
+    return (isValATable and numPlayers or numPlayers[val])
 end
 
 function ESX.GetPlayerFromId(source)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -284,9 +284,7 @@ function ESX.GetNumPlayers(key, val)
         return (ESX.JobsPlayerCount[val] or 0)
     end
 
-    local filteredPlayers = ESX.GetExtendedPlayers(key, val)
-    return #filteredPlayers
-    end
+    return #ESX.GetExtendedPlayers(key, val)
 end
 
 function ESX.GetPlayerFromId(source)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -271,20 +271,21 @@ function ESX.GetNumPlayers(key, val)
                 numPlayers[v] = (ESX.JobsPlayerCount[v] or 0)
             end
             return numPlayers
-        else
-            local filteredPlayers = ESX.GetExtendedPlayers(key, val)
-            for i, v in pairs(filteredPlayers) do
-                numPlayers[i] = (#v or 0)
-            end
-            return numPlayers
         end
-    else
-        if key == "job" then
-            return (ESX.JobsPlayerCount[val] or 0)
-        else
-            local filteredPlayers = ESX.GetExtendedPlayers(key, val)
-            return #filteredPlayers
+
+        local filteredPlayers = ESX.GetExtendedPlayers(key, val)
+        for i, v in pairs(filteredPlayers) do
+            numPlayers[i] = (#v or 0)
         end
+        return numPlayers
+    end
+
+    if key == "job" then
+        return (ESX.JobsPlayerCount[val] or 0)
+    end
+
+    local filteredPlayers = ESX.GetExtendedPlayers(key, val)
+    return #filteredPlayers
     end
 end
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -259,6 +259,27 @@ function ESX.GetExtendedPlayers(key, val)
 	return xPlayers
 end
 
+function ESX.GetNumPlayers(key, val)
+    if(not key) then
+        return ESX.Table.SizeOf(ESX.Players)
+    end
+
+    local valTable = (type(val) == "table" and val or {val})
+    local numPlayers = {}
+    for i, val in ipairs(valTable) do
+        numPlayers[val] = 0
+    end    
+
+    for i, xPlayer in pairs(ESX.Players) do
+        local value = (key == "job" and xPlayer.job.name or xPlayer[key])
+        if(numPlayers[value]) then
+            numPlayers[value] += 1
+        end 
+    end
+
+    return numPlayers
+end
+
 function ESX.GetPlayerFromId(source)
 	return ESX.Players[tonumber(source)]
 end

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -378,7 +378,7 @@ AddEventHandler('playerDropped', function(reason)
 	if xPlayer then
 		TriggerEvent('esx:playerDropped', playerId, reason)
         local job = xPlayer.getJob().name
-        ESX.JobsPlayerCount[job] = (ESX.JobsPlayerCount[job] or 1) -1
+        ESX.JobsPlayerCount[job] = ((ESX.JobsPlayerCount[job] and ESX.JobsPlayerCount[job] > 0) and ESX.JobsPlayerCount[job] or 1) -1
 
 		Core.playersByIdentifier[xPlayer.identifier] = nil
 		Core.SavePlayer(xPlayer, function()
@@ -393,7 +393,7 @@ AddEventHandler("esx:playerLoaded", function(playerId, xPlayer, isNew)
 end)
 
 AddEventHandler("esx:setJob", function(src, job, lastJob)
-    ESX.JobsPlayerCount[lastJob.name] = (ESX.JobsPlayerCount[lastJob.name] or 1) - 1
+    ESX.JobsPlayerCount[lastJob.name] = ((ESX.JobsPlayerCount[lastJob.name] and ESX.JobsPlayerCount[lastJob.name] > 0) and ESX.JobsPlayerCount[lastJob.name] or 1) -1
     ESX.JobsPlayerCount[job.name] = (ESX.JobsPlayerCount[job.name] or 0) + 1
 end)
 

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -377,12 +377,24 @@ AddEventHandler('playerDropped', function(reason)
 
 	if xPlayer then
 		TriggerEvent('esx:playerDropped', playerId, reason)
+        local job = xPlayer.getJob().name
+        ESX.JobsPlayerCount[job] = (ESX.JobsPlayerCount[job] or 1) -1
 
 		Core.playersByIdentifier[xPlayer.identifier] = nil
 		Core.SavePlayer(xPlayer, function()
 			ESX.Players[playerId] = nil
 		end)
 	end
+end)
+
+AddEventHandler("esx:playerLoaded", function(playerId, xPlayer, isNew)
+    local job = xPlayer.getJob().name
+    ESX.JobsPlayerCount[job] = (ESX.JobsPlayerCount[job] or 0) +1
+end)
+
+AddEventHandler("esx:setJob", function(src, job, lastJob)
+    ESX.JobsPlayerCount[lastJob.name] = (ESX.JobsPlayerCount[lastJob.name] or 1) - 1
+    ESX.JobsPlayerCount[job.name] = (ESX.JobsPlayerCount[job.name] or 0) + 1
 end)
 
 AddEventHandler('esx:playerLogout', function(playerId, cb)


### PR DESCRIPTION
### Feature Request 1151: Added ESX.GetNumPlayers' Function

#### Description
This pull request introduces the [requested ](https://github.com/esx-framework/esx_core/issues/1151) ESX.GetNumPlayers function, providing improved usability and performance when retrieving player counts based on specific key-value pairs. The new function streamlines the process of counting players associated with particular attributes, eliminating the need for a double loop and offering enhanced intuitiveness in usage.

#### Changes Made
- The function ESX.GetNumPlayers has been introduced

The code snippet for the function is as follows:
```lua
function ESX.GetNumPlayers(key, val)
    if(not key) then
        return ESX.Table.SizeOf(ESX.Players)
    end

    local isValATable = (type(val) == "table")
    local valTable = (isValATable and val or {val})
    local numPlayers = {}
    for i, val in ipairs(valTable) do
        numPlayers[val] = 0
    end    

    for i, xPlayer in pairs(ESX.Players) do
        local value = (key == "job" and xPlayer.job.name or xPlayer[key])
        if(numPlayers[value]) then
            numPlayers[value] += 1
        end 
    end

    return (isValATable and numPlayers or numPlayers[val])
end
```

#### Reasoning
The new ESX.GetNumPlayers function offers an efficient and straightforward approach to obtaining player counts based on specific attributes. By eliminating the need for a double loop, this enhancement contributes to better performance and code readability. The update also aligns with the goal of creating a more intuitive experience for developers utilizing the function.

Thank you for considering this enhancement. Your feedback and suggestions are highly valued.

[Related GitHub Issue #1151](https://github.com/esx-framework/esx_core/issues/1151)