### PR TITLE
Update commands.lua

### DIFF
--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -574,11 +574,11 @@ ESX.RegisterCommand("noclip", 'admin', function(xPlayer)
 end, false)
 
 ESX.RegisterCommand('players', "admin", function()
-	local xPlayers = ESX.GetExtendedPlayers() -- Returns all xPlayers
-	print(('^5%s^2 online player(s)^0'):format(#xPlayers))
-	for i = 1, #(xPlayers) do
-		local xPlayer = xPlayers[i]
-		print(('^1[^2ID: ^5%s^0 | ^2Name : ^5%s^0 | ^2Group : ^5%s^0 | ^2Identifier : ^5%s^1]^0\n'):format(
-			xPlayer.source, xPlayer.getName(), xPlayer.getGroup(), xPlayer.identifier))
-	end
+    local xPlayers = ESX.GetExtendedPlayers() -- Returns all xPlayers
+    local count = 0 
+    for _, xPlayer in pairs(xPlayers) do
+        count += 1 
+        print(('^1[^2ID: ^5%s^0 | ^2Name : ^5%s^0 | ^2Group : ^5%s^0 | ^2Identifier : ^5%s^1]^0\n'):format(xPlayer.source, xPlayer.getName(), xPlayer.getGroup(), xPlayer.identifier))     
+    end 
+    print(('^5%s^2 online player(s)^0'):format(count))
 end, true)


### PR DESCRIPTION
this command would break if someone leaves and would  stop counting at the first nil value in the list. 

you can get the length of the table to get the online players message in front but that would be less performant.