### PR TITLE
Fixed the spawn of vehicle with "Utility" class

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1355,7 +1355,7 @@ function ESX.GetVehicleType(model)
     local vehicleType = GetVehicleClassFromName(model)
     local types = {
         [8] = "bike",
-        [11] = "trailer",
+        --[11] = "trailer",
         [13] = "bike",
         [14] = "boat",
         [15] = "heli",

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1355,7 +1355,6 @@ function ESX.GetVehicleType(model)
     local vehicleType = GetVehicleClassFromName(model)
     local types = {
         [8] = "bike",
-        --[11] = "trailer",
         [13] = "bike",
         [14] = "boat",
         [15] = "heli",


### PR DESCRIPTION
The gas tank trailer replaces all vehicles with the "Utility" class (number 11). 
I fixed the spawn by removing the number 11 from the list to spawn these vehicles as "automobile" and not as "trailer".