### PR TITLE
Prevent Integer Underflow in Account Balance Update

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -310,6 +310,10 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 			if account then
 				money = account.round and ESX.Math.Round(money) or money
+                if self.accounts[account.index].money - money > self.accounts[account.index].money then
+				    print(('[^1ERROR^7] Tried To Underflow Account ^5%s^0 For Player ^5%s^0!'):format(accountName, self.playerId))
+                    return
+                end
 				self.accounts[account.index].money = self.accounts[account.index].money - money
 
 				self.triggerEvent('esx:setAccountMoney', account)


### PR DESCRIPTION
## Prevent Integer Underflow in Account Balance Update

### **Description:**

This pull request addresses an issue related to integer underflow in the code for updating player account balances. The issue could potentially allow the account balance to go below the minimum representable value for integers and underflow to the maximum representable value. To mitigate this problem, the following changes have been made:

- Added an additional check to ensure that the subtraction of `money` from the account balance won't result in a balance higher than the current value.

```lua
if self.accounts[account.index].money - money > self.accounts[account.index].money then
    print(('[^1ERROR^7] Tried to underflow account ^5%s^0 for Player ^5%s^0!'):format(accountName, self.playerId))
    return
end
````


### **Attack Vector:**

An attacker could potentially exploit this vulnerability in the following manner:

- The attacker identifies a script or event that allows them to remove a specific amount of money from their account.

- The attacker sets up a malicious script or program that triggers this money removal event in a loop, decrementing their account balance by a specific amount each time.

- Since the subtraction operation was not adequately checked in the original code, the account balance could be decremented repeatedly until it exceeds the `INT_MIN` value.

- When the account balance reaches the minimum representable value for integers, any further substraction will result in a wrap around to a very large positive value (the most positive integer value, often referred to as `INT_MAX`).

- This effectively results in the attacker having an unexpectedly large account balance, which can lead to various issues such as exploiting in-game rewards or privileges associated with high account balances.