### PR TITLE
fix(es_extended/client/modules/actions): player health regeneration

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -30,6 +30,9 @@ CreateThread(function()
             ESX.SetPlayerData('ped', playerPed)
             TriggerEvent('esx:playerPedChanged', playerPed)
             TriggerServerEvent('esx:playerPedChanged', PedToNet(playerPed))
+            if Config.DisableHealthRegeneration then
+		        SetPlayerHealthRechargeMultiplier(PlayerId(), 0.0)
+	        end
         end
 
         if IsPedJumping(playerPed) and not isJumping then


### PR DESCRIPTION
Player health regenerating even when it's disabled. It needs to be re-setted on ped change.