### PR TITLE
refactor(es_extended/client/functions.lua) and (es_extended/client/modules/streaming.lua)

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -24,8 +24,15 @@ function ESX.GetPlayerData()
     return ESX.PlayerData
 end
 
+local addonResourcesState = {
+    ['esx_progressbar'] = GetResourceState('esx_progressbar') ~= 'missing',
+    ['esx_notify'] = GetResourceState('esx_notify') ~= 'missing',
+    ['esx_textui'] = GetResourceState('esx_textui') ~= 'missing',
+    ['esx_context'] = GetResourceState('esx_context') ~= 'missing'
+}
+
 local function IsResourceFound(resource)
-	return GetResourceState(resource) ~= 'missing' or print(('[^1ERROR^7] ^5%s^7 is Missing!'):format(resource))
+	return addonResourcesState[resource] or print(('[^1ERROR^7] ^5%s^7 is Missing!'):format(resource))
 end
 
 function ESX.SearchInventory(items, count)

--- a/[core]/es_extended/client/modules/streaming.lua
+++ b/[core]/es_extended/client/modules/streaming.lua
@@ -1,85 +1,37 @@
 function ESX.Streaming.RequestModel(modelHash, cb)
-    modelHash = (type(modelHash) == "number" and modelHash or joaat(modelHash))
-
-    if not HasModelLoaded(modelHash) and IsModelInCdimage(modelHash) then
-        RequestModel(modelHash)
-
-        while not HasModelLoaded(modelHash) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+    modelHash = type(modelHash) == "number" and modelHash or joaat(modelHash)
+    if not IsModelInCdimage(modelHash) then return end
+	RequestModel(modelHash)
+	while not HasModelLoaded(modelHash) do Wait() end
+	return cb and cb(modelHash) or modelHash
 end
 
 function ESX.Streaming.RequestStreamedTextureDict(textureDict, cb)
-    if not HasStreamedTextureDictLoaded(textureDict) then
-        RequestStreamedTextureDict(textureDict)
-
-        while not HasStreamedTextureDictLoaded(textureDict) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+	RequestStreamedTextureDict(textureDict)
+	while not HasStreamedTextureDictLoaded(textureDict) do Wait() end
+	return cb and cb(textureDict) or textureDict
 end
 
 function ESX.Streaming.RequestNamedPtfxAsset(assetName, cb)
-    if not HasNamedPtfxAssetLoaded(assetName) then
-        RequestNamedPtfxAsset(assetName)
-
-        while not HasNamedPtfxAssetLoaded(assetName) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+	RequestNamedPtfxAsset(assetName)
+	while not HasNamedPtfxAssetLoaded(assetName) do Wait() end
+	return cb and cb(assetName) or assetName
 end
 
 function ESX.Streaming.RequestAnimSet(animSet, cb)
-    if not HasAnimSetLoaded(animSet) then
-        RequestAnimSet(animSet)
-
-        while not HasAnimSetLoaded(animSet) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+	RequestAnimSet(animSet)
+	while not HasAnimSetLoaded(animSet) do Wait() end
+	return cb and cb(animSet) or animSet
 end
 
 function ESX.Streaming.RequestAnimDict(animDict, cb)
-    if not HasAnimDictLoaded(animDict) then
-        RequestAnimDict(animDict)
-
-        while not HasAnimDictLoaded(animDict) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+	RequestAnimDict(animDict)
+	while not HasAnimDictLoaded(animDict) do Wait() end
+	return cb and cb(animDict) or animDict
 end
 
 function ESX.Streaming.RequestWeaponAsset(weaponHash, cb)
-    if not HasWeaponAssetLoaded(weaponHash) then
-        RequestWeaponAsset(weaponHash)
-
-        while not HasWeaponAssetLoaded(weaponHash) do
-            Wait(0)
-        end
-    end
-
-    if cb ~= nil then
-        cb()
-    end
+	RequestWeaponAsset(weaponHash)
+	while not HasWeaponAssetLoaded(weaponHash) do Wait() end
+	return cb and cb(weaponHash) or weaponHash
 end


### PR DESCRIPTION
Big refactor to client functions with no breaking changes (allegedly).
Except for ESX.Game.SpawnObject that returns the object synchronous if no callback provided.
(Just a new behaviour, keeps working as used to)

Added new functions:
 · ESX.DrawMissionText
 · ESX.Game.GetShapeTestResultSync **
 · ESX.Game.RaycastScreen **
** Last two are used to improve the performance of ESX.Game.GetVehicleInDirection
It already uses a Synchronous Shape Test Result less performant than solution provided.

In streaming functions, ff no callback provided, functions will return the first argument synchronously.
if not, first argument will be passed to the callback.