### PR TITLE
feat: add TypeCheck to check value types

### DIFF
--- a/[core]/es_extended/common/functions.lua
+++ b/[core]/es_extended/common/functions.lua
@@ -106,3 +106,25 @@ end
 function ESX.Round(value, numDecimalPlaces)
     return ESX.Math.Round(value, numDecimalPlaces)
 end
+
+function ESX.TypeCheck(value, ...)
+    local types = { ... }
+
+    if (#types == 0) then return true end
+
+    local mapType = {}
+    for i = 1, #types, 1 do
+        mapType[types[i]] = true
+    end
+
+    local valueType = type(value)
+    local requireTypes = table.concat(types, " or ")
+    local errorMessage = ("bad value (%s expected, got %s)"):format(requireTypes, valueType)
+    local matches = mapType[valueType] ~= nil
+
+    -- Need feedback on this one, should we assert or return false and error message?
+    -- i prefer assert, but i'm open to suggestions
+    assert(matches, errorMessage)
+
+    return matches, errorMessage
+end

--- a/[core]/es_extended/common/functions.lua
+++ b/[core]/es_extended/common/functions.lua
@@ -107,24 +107,35 @@ function ESX.Round(value, numDecimalPlaces)
     return ESX.Math.Round(value, numDecimalPlaces)
 end
 
-function ESX.TypeCheck(value, ...)
+function ESX.ValidateType(value, ...)
     local types = { ... }
-
     if (#types == 0) then return true end
 
     local mapType = {}
     for i = 1, #types, 1 do
-        mapType[types[i]] = true
+        local validateType = types[i]
+        assert(type(validateType) == "string", "bad argument types, only expected string") -- should never use anyhing else than string
+        mapType[validateType] = true
     end
 
     local valueType = type(value)
-    local requireTypes = table.concat(types, " or ")
-    local errorMessage = ("bad value (%s expected, got %s)"):format(requireTypes, valueType)
-    local matches = mapType[valueType] ~= nil
 
-    -- Need feedback on this one, should we assert or return false and error message?
-    -- i prefer assert, but i'm open to suggestions
+    local matches = (mapType[valueType] ~= nil)
+
+    if not (matches) then
+        local requireTypes = table.concat(types, " or ")
+        local errorMessage = ("bad value (%s expected, got %s)"):format(requireTypes, valueType)
+
+        return false, errorMessage
+    end
+
+    return true
+end
+
+function ESX.AssertType(...)
+    local matches, errorMessage = ESX.ValidateType(...)
+
     assert(matches, errorMessage)
 
-    return matches, errorMessage
+    return matches
 end

--- a/[core]/es_extended/common/functions.lua
+++ b/[core]/es_extended/common/functions.lua
@@ -109,7 +109,7 @@ end
 
 function ESX.ValidateType(value, ...)
     local types = { ... }
-    if (#types == 0) then return true end
+    if #types == 0 then return true end
 
     local mapType = {}
     for i = 1, #types, 1 do
@@ -120,9 +120,9 @@ function ESX.ValidateType(value, ...)
 
     local valueType = type(value)
 
-    local matches = (mapType[valueType] ~= nil)
+    local matches = mapType[valueType] ~= nil
 
-    if not (matches) then
+    if not matches then
         local requireTypes = table.concat(types, " or ")
         local errorMessage = ("bad value (%s expected, got %s)"):format(requireTypes, valueType)
 


### PR DESCRIPTION
Add a utility function that allow to check value types

as I say in source code
Need feedback on this one, should we assert or return false and error message?
I prefer assert, but I'm open to suggestions

Thank you.

Here an examples

Example: 1
```lua
local value = 1
ESX.TypeCheck(value, "number") -- true
```

Example: 2
```lua
local value = "hello"
ESX.TypeCheck(value, "number", "string") -- true
```

Example: 3
```lua
local value = "hello"
ESX.TypeCheck(value, "number") -- false, "bad value (number expected, got string)"
```

Example: 4
```lua
local value = "hello"
ESX.TypeCheck(value, "boolean", "number", "table") -- false, "bad value (boolean or number or table expected, got string)"
```

Example: 5
```lua
local value = nil
ESX.TypeCheck(value, "boolean", "number", "table") -- false, "bad value (boolean or number or table expected, got nil)"
```

Example: 6
```lua
local value = nil
ESX.TypeCheck(value, "boolean", "number", "table", "nil") -- true
```