### PR TITLE
perf/refactor(client/functions): Refactor ESX.Game.GetClosestEntity for performance

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -496,29 +496,29 @@ function ESX.Game.IsSpawnPointClear(coords, maxDistance)
 end
 
 function ESX.Game.GetClosestEntity(entities, isPlayerEntities, coords, modelFilter)
-    local closestEntity, closestEntityDistance, filteredEntities = -1, -1, nil
+    local closestEntity, closestEntityDistance = -1, -1
 
     if not coords then
-        local playerPed = ESX.PlayerData.ped
-        coords = GetEntityCoords(playerPed)
+        local playerPed = ESX.PlayerData.ped;
+        coords = GetEntityCoords(playerPed);
     end
 
-    if modelFilter then
-        filteredEntities = {}
+    for current_entity_index = 1, #entities do
+        local current_entity = entities[current_entity_index];
 
-        for _, entity in pairs(entities) do
-            if modelFilter[GetEntityModel(entity)] then
-                filteredEntities[#filteredEntities + 1] = entity
-            end
+        -- if model filter is used and entity is not in the filter, skip it
+        if ( modelFilter and ( not modelFilter[GetEntityModel(current_entity)] ) ) then
+            goto continue
         end
-    end
 
-    for k, entity in pairs(filteredEntities or entities) do
-        local distance = #(coords - GetEntityCoords(entity))
 
+        local distance = #(coords - GetEntityCoords(current_entity));
+        
         if closestEntityDistance == -1 or distance < closestEntityDistance then
-            closestEntity, closestEntityDistance = isPlayerEntities and k or entity, distance
+            closestEntity, closestEntityDistance = isPlayerEntities and current_entity_index or current_entity, distance;
         end
+
+        ::continue::
     end
 
     return closestEntity, closestEntityDistance

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -498,9 +498,7 @@ end
 function ESX.Game.GetClosestEntity(entities, isPlayerEntities, coords, modelFilter)
     local closestEntity, closestEntityDistance, filteredEntities = -1, -1, nil
 
-    if coords then
-        coords = vector3(coords.x, coords.y, coords.z)
-    else
+    if not coords then
         local playerPed = ESX.PlayerData.ped
         coords = GetEntityCoords(playerPed)
     end


### PR DESCRIPTION
Refactored the ESX.Game.GetClosestEntity, instead of using two seperate k, v loops for filtering and distance checking i combined the logic into one faster for loop

also the coords parameter is either nil or an vector3 so if set, there is no need to parse it to an vector 3

i am not sure what the isPlayerEntities parameter is for and if true returning the index from the entities table (line 522), why?
i left that specific logic as is to not break anything