### PR TITLE
fix(multicharacter/config): predefined spawn with incorrent defined heading

### DIFF
--- a/[core]/esx_multicharacter/config.lua
+++ b/[core]/esx_multicharacter/config.lua
@@ -16,7 +16,7 @@ else
     -- Sets the location for the character selection scene
     -- To set the spawn location for new characters, modify the default value in the users SQL table
     Config.Spawn = {
-        { x = -284.2856, y = 562.4627, z = 172.9182, heading = 19.9895 },
+        { x = -284.2856, y = 562.4627, z = 172.9182, w = 19.9895 },
     }
     --------------------
 


### PR DESCRIPTION
there is used SpawnCoords.w in script many times but in config is value defined as heading so it ignores heading and it's set to nil