### PR TITLE
feat(es_extended/server/functions): add ESX.TriggerClientEvent

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -14,11 +14,11 @@ function ESX.TriggerClientEvent(eventName, playerIds, ...)
         return
     end
 
-    local Payload = msgpack.pack_args(...)
-    local payloadLength = #Payload
+    local payload = msgpack.pack_args(...)
+    local payloadLength = #payload
 
     for i = 1, #playerIds do
-        TriggerClientEventInternal(eventName, playerIds[i], Payload, payloadLength)
+        TriggerClientEventInternal(eventName, playerIds[i], payload, payloadLength)
     end
 end
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -4,6 +4,24 @@ function ESX.Trace(msg)
     end
 end
 
+--- Triggers an event for one or more clients.
+---@param eventName string The name of the event to trigger.
+---@param playerIds table|number If a number, represents a single player ID. If a table, represents an array of player IDs.
+---@param ... any Additional arguments to pass to the event handler.
+function ESX.TriggerClientEvent(eventName, playerIds, ...)
+    if type(playerIds) == "number" then
+        TriggerClientEvent(eventName, playerIds, ...)
+        return
+    end
+
+    local Payload = msgpack.pack_args(...)
+    local payloadLength = #Payload
+
+    for i = 1, #playerIds do
+        TriggerClientEventInternal(eventName, playerIds[i], Payload, payloadLength)
+    end
+end
+
 function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
     if type(name) == "table" then
         for _, v in ipairs(name) do


### PR DESCRIPTION
### Description
This pull request introduces a new function `ESX.TriggerClientEvent` to the ESX framework. In the FiveM environment, the native `TriggerClientEvent` is limited to triggering events for a single player ID at a time. This limitation incurs significant overhead when sending events to multiple clients, as the data must be re-serialized for each client. The new function addresses this issue by serializing the data once using msgpack and efficiently triggering events for multiple clients using the internal native `TriggerClientEventInternal`.

### Changes Made
- Added `ESX.TriggerClientEvent` function to the ESX framework.
- Utilized msgpack for serializing additional arguments once, reducing overhead.
- Implemented logic to trigger events for multiple clients using the internal native `TriggerClientEventInternal`.

### Motivation
In my experience, many scripts resort to inefficient practices when sending data to multiple clients. Some scripts send data to all clients to avoid the overhead of serialization, disregarding the principle that clients should only receive data relevant to them. Others use the `TriggerClientEvent` native for multiple clients, leading to significant performance implications such as server thread hitches. These practices are not only inefficient but can also degrade server performance and overall player experience.

Introducing `ESX.TriggerClientEvent` aims to address these challenges by providing developers with a unified solution within the ESX framework. By serializing data once and efficiently triggering events for multiple clients using the internal native, this function ensures that clients receive only the data relevant to them while minimizing performance overhead. This not only promotes best practices in script development but also enhances the overall performance and stability of FiveM servers utilizing the ESX framework.


### Testing
~~As I am currently on vacation and unable to conduct testing, the implementation of the `ESX.TriggerClientEvent` function has not undergone direct testing. However, testing by a maintainer would be greatly appreciated to ensure the reliability and effectiveness of the new function. Alternatively, I will be back in a couple of days and can perform the testing myself.~~

Has been tested locally on a single, and multiple clients. Work as expected.



