### PR TITLE
fix: ox_inventory setMaxWeight client-side sync

### DIFF
--- a/[core]/es_extended/server/classes/overrides/oxinventory.lua
+++ b/[core]/es_extended/server/classes/overrides/oxinventory.lua
@@ -140,7 +140,7 @@ Core.PlayerFunctionOverrides.OxInventory = {
         return function(newWeight)
             self.maxWeight = newWeight
             self.triggerEvent("esx:setMaxWeight", self.maxWeight)
-            return Inventory.Set(self.source, "maxWeight", newWeight)
+            return Inventory.SetMaxWeight(self.source, newWeight)
         end
     end,
 


### PR DESCRIPTION
Client side maxWeight in ox_inventory is not synced when setting it using .Set