### PR TITLE
fixed sql query main.lua

### DIFF
--- a/[core]/esx_multicharacter/server/main.lua
+++ b/[core]/esx_multicharacter/server/main.lua
@@ -136,7 +136,7 @@ end)
 
 local function DeleteCharacter(source, charid)
     local identifier = ("%s%s:%s"):format(PREFIX, charid, GetIdentifier(source))
-    local query = "DELETE FROM %s WHERE %s = ?"
+    local query = "DELETE FROM `%s` WHERE %s = ?"
     local queries = {}
     local count = 0
 


### PR DESCRIPTION
Now the script can delete rows where the table name contains a special character like a -