### PR TITLE
fix(esx_menu_default): jquery handling element id

### DIFF
--- a/[core]/esx_menu_default/html/js/app.js
+++ b/[core]/esx_menu_default/html/js/app.js
@@ -62,7 +62,7 @@
         });
 
         ESX_MENU.render();
-        $("#menu_" + namespace + "_" + name)
+        $(document.getElementById("menu_" + namespace + "_" + name))
             .find(".menu-item.selected")[0]
             .scrollIntoView();
     };
@@ -121,7 +121,7 @@
         }
 
         if (typeof focused != "undefined") {
-            $("#menu_" + focused.namespace + "_" + focused.name).show();
+            $(document.getElementById("menu_" + focused.namespace + "_" + focused.name)).show();
         }
 
         $(menuContainer).show();
@@ -231,7 +231,7 @@
                             ESX_MENU.change(focused.namespace, focused.name, elem);
                             ESX_MENU.render();
 
-                            $("#menu_" + focused.namespace + "_" + focused.name)
+                            $(document.getElementById("menu_" + focused.namespace + "_" + focused.name))
                                 .find(".menu-item.selected")[0]
                                 .scrollIntoView();
                         }
@@ -266,7 +266,7 @@
                             ESX_MENU.change(focused.namespace, focused.name, elem);
                             ESX_MENU.render();
 
-                            $("#menu_" + focused.namespace + "_" + focused.name)
+                            $(document.getElementById("menu_" + focused.namespace + "_" + focused.name))
                                 .find(".menu-item.selected")[0]
                                 .scrollIntoView();
                         }
@@ -302,7 +302,7 @@
                                     break;
                             }
 
-                            $("#menu_" + focused.namespace + "_" + focused.name)
+                            $(document.getElementById("menu_" + focused.namespace + "_" + focused.name))
                                 .find(".menu-item.selected")[0]
                                 .scrollIntoView();
                         }
@@ -341,7 +341,7 @@
                                     break;
                             }
 
-                            $("#menu_" + focused.namespace + "_" + focused.name)
+                            $(document.getElementById("menu_" + focused.namespace + "_" + focused.name))
                                 .find(".menu-item.selected")[0]
                                 .scrollIntoView();
                         }


### PR DESCRIPTION
jQuery can't handle getting elements with `$("#...")` if the name contains a colon and takes it as another query. By getting the element via `document.getElementById` and wrapping it with `$(...)`, the functionality remains the same, but menu names can have a colon and other characters in them and the menu will open and not throw an error saying it didn't find the element.

Previously it was throwing `Uncaught TypeError: Cannot read properties of undefined (reading 'scrollIntoView') (@esx_menu_default/html/js/app.js:67)` because it couldn't find the element. 