### PR TITLE
fix(notify): no valid icon

### DIFF
--- a/[core]/esx_notify/nui/js/script.js
+++ b/[core]/esx_notify/nui/js/script.js
@@ -60,7 +60,7 @@ notification = (data) => {
     const notification = $(`
         <div class="notify ${data.type}">
             <div class="innerText">
-                <span class="material-symbols-outlined icon">${types[data.type]["icon"]}</span>
+                <span class="material-symbols-outlined icon">${types[data.type] ? types[data.type]["icon"] : types["info"]["icon"]}</span>
                 <p class="text">${data["message"]}</p>
             </div>
         </div>


### PR DESCRIPTION
If invalid notify type is provided, it throws an error to console