### PR TITLE
fix(es_extended/client/functions.lua) RegisterInput and HashString bug

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -120,7 +120,7 @@ function ESX.DrawMissionText(msg, time)
 end
 
 function ESX.HashString(str)
-    return ('~INPUT_%s~'):format(('%x'):format(joaat(str)):upper())
+    return ('~INPUT_%s~'):format(('%x'):format(joaat(str) & 0x7fffffff + 2 ^ 31):upper())
 end
 
 function ESX.OpenContext(...)
@@ -140,12 +140,12 @@ function ESX.RefreshContext(...)
 end
 
 function ESX.RegisterInput(command_name, label, input_group, key, on_press, on_release)
-    RegisterCommand("+" .. command_name, on_press)
-    Core.Input[command_name] = ESX.HashString("+" .. command_name)
+    RegisterCommand(on_release and '+' .. command_name or command_name, on_press)
+    Core.Input[command_name] = ESX.HashString(command_name)
     if on_release then
-        RegisterCommand("-" .. command_name, on_release)
+        RegisterCommand('-' .. command_name, on_release)
     end
-    RegisterKeyMapping("+" .. command_name, label or '', input_group or 'keyboard', key or '')
+    RegisterKeyMapping(command_name, label or '', input_group or 'keyboard', key or '')
 end
 
 function ESX.UI.Menu.RegisterType(menuType, open, close)


### PR DESCRIPTION
In the last update, **RegisterInput** tries to execute the command on key release due some checks removal in #1303. The check was restored and tested.

**HashString** breaks when the joaat returns a hash bigger than 2^31. It was fix using a [shift mask](https://stackoverflow.com/a/20294714).