### PR TITLE
tweak: use txAdmin locale by default 

### DIFF
--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -3,7 +3,7 @@ Config = {}
 local txAdminLocale = GetConvar("txAdmin-locale", "en")
 local esxLocale = GetConvar("esx:locale", "none")
 
-Config.Locale = esxLocale == "none" and txAdminLocale or esxLocale
+Config.Locale = (esxLocale == "none" and txAdminLocale ~= "custom") and txAdminLocale or esxLocale
 
 Config.OxInventory = GetResourceState("ox_inventory") ~= 'missing'
 

--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -1,13 +1,9 @@
 Config = {}
 
 local txAdminLocale = GetConvar("txAdmin-locale", "en")
-local esxLocale = GetConvar("esx:locale", "none")
+local esxLocale = GetConvar("esx:locale", "invalid")
 
-if esxLocale == "none" then
-    Config.Locale = txAdminLocale ~= "custom" and txAdminLocale or "en"
-else
-    Config.Locale = esxLocale
-end
+Config.Locale = (esxLocale ~= "invalid") and esxLocale or (txAdminLocale ~= "custom" and txAdminLocale) or "en"
 
 Config.OxInventory = GetResourceState("ox_inventory") ~= 'missing'
 

--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -3,7 +3,11 @@ Config = {}
 local txAdminLocale = GetConvar("txAdmin-locale", "en")
 local esxLocale = GetConvar("esx:locale", "none")
 
-Config.Locale = (esxLocale == "none" and txAdminLocale ~= "custom") and txAdminLocale or esxLocale
+if esxLocale == "none" then
+    Config.Locale = txAdminLocale ~= "custom" and txAdminLocale or "en"
+else
+    Config.Locale = esxLocale
+end
 
 Config.OxInventory = GetResourceState("ox_inventory") ~= 'missing'
 


### PR DESCRIPTION
by default, use the txAdmin locale, unless a `esx:locale` is specified.
This allows people to change languages easier, since everything will be in the same place, and if they want to specify a different language for ESX, then they can do.

This also wont break anything, since it wont affect existing users whom will aready have the `esx:locale` set