### PR TITLE
fix(createJob): skin error

### DIFF
--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -22,7 +22,7 @@ end
 local function generateNewJobTable(name, label, grades)
     local job = { name = name, label = label, grades = {} }
     for _, v in pairs(grades) do
-        job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = {}, skin_female = {} }
+        job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = v.skin_male or '{}', skin_female = v.skin_female or '{}' }
     end
 
     return job


### PR DESCRIPTION
self.setJob in es_extended/server/classes/player.lua decodes skin data, which means skin data should be a string and not a table. When creating shops in run time and setting this job, it would throw error.  Modified so it's a string and also added compatibility to parse skin_data directly into the job grade.