### PR TITLE
Adding a option to disable a paycheck for a specific user

### DIFF
--- a/[core]/es_extended/server/paycheck.lua
+++ b/[core]/es_extended/server/paycheck.lua
@@ -1,8 +1,10 @@
 function StartPayCheck()
     local disabledPaycheckUsers = {}
 
-    function ESX.SetPaycheckState(source, state)
+    function ESX.SetPaycheckDisabled(source, state)
         local source = tostring(source)
+
+        if type(state) ~= "boolean" then state = false end
         if type(disabledPaycheckUsers[source]) == "nil" then disabledPaycheckUsers[source] = false end
         disabledPaycheckUsers[source] = state -- true: paycheck disabled | false: paycheck enabled
     end

--- a/[core]/es_extended/server/paycheck.lua
+++ b/[core]/es_extended/server/paycheck.lua
@@ -1,4 +1,12 @@
 function StartPayCheck()
+    local disabledPaycheckUsers = {}
+
+    function ESX.SetPaycheckState(source, state)
+        local source = tostring(source)
+        if type(disabledPaycheckUsers[source]) == "nil" then disabledPaycheckUsers[source] = false
+        disabledPaycheckUsers[source] = state -- true: paycheck disabled | false: paycheck enabled
+    end
+    
     CreateThread(function()
         while true do
             Wait(Config.PaycheckInterval)
@@ -6,9 +14,8 @@ function StartPayCheck()
                 local jobLabel = xPlayer.job.label
                 local job = xPlayer.job.grade_name
                 local salary = xPlayer.job.grade_salary
-                local givePaycheck = xPlayer.paycheck or true
 
-                if salary > 0 and givePaycheck then
+                if salary > 0 and not disabledPaycheckUsers[tostring(xPlayer.source)] then
                     if job == "unemployed" then -- unemployed
                         xPlayer.addAccountMoney("bank", salary, "Welfare Check")
                         TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)

--- a/[core]/es_extended/server/paycheck.lua
+++ b/[core]/es_extended/server/paycheck.lua
@@ -6,8 +6,9 @@ function StartPayCheck()
                 local jobLabel = xPlayer.job.label
                 local job = xPlayer.job.grade_name
                 local salary = xPlayer.job.grade_salary
+                local givePaycheck = xPlayer.paycheck or true
 
-                if salary > 0 then
+                if salary > 0 and givePaycheck then
                     if job == "unemployed" then -- unemployed
                         xPlayer.addAccountMoney("bank", salary, "Welfare Check")
                         TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)

--- a/[core]/es_extended/server/paycheck.lua
+++ b/[core]/es_extended/server/paycheck.lua
@@ -3,7 +3,7 @@ function StartPayCheck()
 
     function ESX.SetPaycheckState(source, state)
         local source = tostring(source)
-        if type(disabledPaycheckUsers[source]) == "nil" then disabledPaycheckUsers[source] = false
+        if type(disabledPaycheckUsers[source]) == "nil" then disabledPaycheckUsers[source] = false end
         disabledPaycheckUsers[source] = state -- true: paycheck disabled | false: paycheck enabled
     end
     


### PR DESCRIPTION
# Explanation:
Adding an option to prevent a specific user from receiving their paychecks

# Why?
Since some servers have the function to disable the paycheck for a user if the user is AFK for more than ... minutes/hours.. , and since this function is not implemented directly in ESX, it has to be added manually, which becomes annoying over time because you always have to add the function again when you update ESX, so it would make sense to simply add a function that allows this