### PR TITLE
feat(common/modules/math): Add ESX.Math.GetHeadingFromCoords

### DIFF
--- a/[core]/es_extended/common/modules/math.lua
+++ b/[core]/es_extended/common/modules/math.lua
@@ -36,3 +36,15 @@ function ESX.Math.Random(minRange, maxRange)
     return math.random(minRange or 1, maxRange or 10)
 end
 
+---@param origin vector
+---@param target vector
+---@return number
+function ESX.Math.GetHeadingFromCoords(origin, target)
+	local dx = target.x - origin.x
+    local dy = target.y - origin.y
+
+    local heading = math.deg(math.atan(dy, dx)) + 90
+
+    return (heading + 360) % 360
+end
+

--- a/[core]/es_extended/common/modules/math.lua
+++ b/[core]/es_extended/common/modules/math.lua
@@ -40,8 +40,8 @@ end
 ---@param target vector
 ---@return number
 function ESX.Math.GetHeadingFromCoords(origin, target)
-	local dx = target.x - origin.x
-    local dy = target.y - origin.y
+	local dx = origin.x - target.x
+    local dy = origin.y - target.y
 
     local heading = math.deg(math.atan(dy, dx)) + 90
 


### PR DESCRIPTION
### Description
This PR adds `ESX.Math.GetHeadingFromCoords`, a utility function to get the heading in degrees from one coordinate to another.

---

### Changes Made
- Added `ESX.Math.GetHeadingFromCoords` for quick heading calculations between two vector coordinates.
- Uses trigonometry to calculate direction and normalizes the output between 0° and 360°.

---

### Motivation
This utility is handy for any direction-based checks in ESX, making it easier for devs to get accurate headings without reinventing the wheel.

---

### Testing
Tested locally with various coordinate pairs; consistently returns correct headings. Handles all directional variations as expected.

---

### Possible Concerns
An alternative method could be using the `GetHeadingFromVector_2d` native, as discussed [here](https://forum.cfx.re/t/help-how-to-set-ped-looking-at-position/19294/6). However, using Lua's math module for this calculation keeps it lightweight and removes the dependency on additional natives for simple vector math.

---

### Example Usage
Here's an example of how `ESX.Math.GetHeadingFromCoords` can be used to make a player face another entity:

```lua
local function faceEntity(targetEntity)
    local srcPed = PlayerPedId()
    local srcPedCoords = GetEntityCoords(srcPed)
    local targetEntityCoords = GetEntityCoords(targetEntity)

    local heading = ESX.Math.GetHeadingFromCoords(srcPedCoords, targetEntityCoords)
    SetEntityHeading(srcPed, heading)
end
