### PR TITLE
refactor(SQL/legacy): Add primary key to vehicles table

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -427,12 +427,10 @@ CREATE TABLE `user_licenses` (
 --
 
 CREATE TABLE `vehicles` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(60) NOT NULL,
   `model` varchar(60) NOT NULL,
   `price` int(11) NOT NULL,
-  `category` varchar(60) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  `category` varchar(60) DEFAULT NULL
 ) ENGINE=InnoDB;
 
 --
@@ -822,6 +820,13 @@ ALTER TABLE `licenses`
 --
 ALTER TABLE `owned_vehicles`
   ADD PRIMARY KEY (`plate`);
+
+--
+--
+-- Indexes for table `vehicles`
+--
+ALTER TABLE `vehicles`
+  ADD PRIMARY KEY (`model`);
 
 --
 -- Indexes for table `rented_vehicles`

--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -427,10 +427,12 @@ CREATE TABLE `user_licenses` (
 --
 
 CREATE TABLE `vehicles` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(60) NOT NULL,
   `model` varchar(60) NOT NULL,
   `price` int(11) NOT NULL,
-  `category` varchar(60) DEFAULT NULL
+  `category` varchar(60) DEFAULT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
 --


### PR DESCRIPTION
### Description:
This PR sets the `model` column as the primary key for the existing `vehicles` table.

---

### Motivation:
- **Data Integrity**: The primary key enforces uniqueness, ensuring each vehicle can be distinctly identified.
- **Ease of Editing**: With a primary key in place, we can easily manage and edit rows in tools like phpMyAdmin.
