### PR TITLE
feat(server/classes/player): Add job duty

### DIFF
--- a/[core]/es_extended/config.lua
+++ b/[core]/es_extended/config.lua
@@ -47,6 +47,7 @@ Config.EnableDebug = false -- Use Debug options?
 Config.EnableDefaultInventory = true -- Display the default Inventory ( F2 )
 Config.EnableWantedLevel = false -- Use Normal GTA wanted Level?
 Config.EnablePVP = true -- Allow Player to player combat
+Config.DefaultJobDuty = true -- A players default duty status when changing jobs
 
 Config.Multichar = GetResourceState("esx_multicharacter") ~= "missing"
 Config.Identity = true -- Select a character identity data before they have loaded in (this happens by default with multichar)

--- a/[core]/es_extended/server/commands.lua
+++ b/[core]/es_extended/server/commands.lua
@@ -544,7 +544,9 @@ ESX.RegisterCommand("group", { "user", "admin" }, function(xPlayer, _, _)
 end, true)
 
 ESX.RegisterCommand("job", { "user", "admin" }, function(xPlayer, _, _)
-    print(("%s, your job is: ^5%s^0 - ^5%s^0"):format(xPlayer.getName(), xPlayer.getJob().name, xPlayer.getJob().grade_label))
+	local job = xPlayer.getJob()
+
+    print(("%s, your job is: ^5%s^0 - ^5%s^0 - ^5%s^0"):format(xPlayer.getName(), job.name, job.grade_label, job.onDuty and "On Duty" or "Off Duty"))
 end, false)
 
 ESX.RegisterCommand("info", { "user", "admin" }, function(xPlayer)


### PR DESCRIPTION
### Description
This pull request enhances the player function, `xPlayer.setJob`, within the ESX framework to accept an optional boolean parameter `onDuty`. If the parameter is not set, we fall back on a config-specified default value. This effectively implements a complete job duty system, eliminating the clutter of unnecessary job variations such as "off_police" in your jobs table.

Additionally, developers can now listen for on/off duty changes using the existing `esx:setJob` event. The updated job object includes a new boolean property, `onDuty`, and for ease of use and compatibility, the `jobDuty` property is stored as metadata for each player.

---

### Changes Made
- Enhanced the `xPlayer.setJob` function to handle the new optional `onDuty` parameter.
- Introduced a new `onDuty` property in the job object to accurately reflect on/off duty changes.
- Implemented the storage of the `jobDuty` property in the players' metadata.
- Adjusted the `job` command to display the player's current duty state.
- Added a new config entry, `Config.DefaultJobDuty`, to specify a default duty state for a player after using the `xPlayer.setJob()` function.

---

### Motivation
Developers working with the ESX framework have often faced challenges due to the absence of a standardized method for setting and retrieving job duties. This PR aims to bridge that gap by offering a consistent and reliable approach to managing job duties.

---

### Testing
The `xPlayer.setJob` method has been tested locally and performs as expected with both single and multiple clients. It accurately manages job duty states and reflects the intended changes within the job object.