### PR TITLE
feat(es_extended/server/classes/vehicle): Add Vehicle Class

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -25,6 +25,7 @@ server_scripts {
 	'server/common.lua',
 	'server/modules/callback.lua',
 	'server/classes/player.lua',
+	'server/classes/vehicle.lua',
 	'server/classes/overrides/*.lua',
 	'server/functions.lua',
 	'server/modules/onesync.lua',

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -21,47 +21,44 @@
 ---@field setOwner fun(self:VehicleClass, owner:string):nil
 ---@field despawn fun(self:VehicleClass):nil
 
----@type table<number, VehicleData>
-local vehicles = {}
 
----@type VehicleClass
-local vehicleClass = {
+Core.vehicleClass = {
 	plate = "",
 	getNetId = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].netId
+		return Core.vehicles[self.plate].netId
 	end,
 	getEntity = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].entity
+		return Core.vehicles[self.plate].entity
 	end,
 	getPlate = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].plate
+		return Core.vehicles[self.plate].plate
 	end,
 	getModelHash = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].modelHash
+		return Core.vehicles[self.plate].modelHash
 	end,
 	getProps = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].props
+		return Core.vehicles[self.plate].props
 	end,
 	getOwner = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		return vehicles[self.plate].owner
+		return Core.vehicles[self.plate].owner
 	end,
 	setPlate = function(self, plate, apply)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 		assert(type(plate) == "string", "Expected 'plate' to be a string")
 
-		local vehicle = vehicles[self.plate]
+		local vehicle = Core.vehicles[self.plate]
 		if apply and vehicle.owner then
 			SetVehicleNumberPlateText(vehicle.entity, plate)
 			MySQL.prepare("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", plate, vehicle.plate, vehicle.owner)
@@ -69,10 +66,10 @@ local vehicleClass = {
 		vehicle.plate = plate
 	end,
 	setProps = function(self, props, apply)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 		assert(type(props) == "table", "Expected 'props' to be a table")
 
-		local vehicle = vehicles[self.plate]
+		local vehicle = Core.vehicles[self.plate]
 		if apply and vehicle.owner then
 			Entity(vehicle.entity).state:set("VehicleProperties", props, true)
 			MySQL.prepare("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ?", json.encode(props), vehicle.plate)
@@ -81,22 +78,22 @@ local vehicleClass = {
 		vehicle.props = props
 	end,
 	setOwner = function(self, owner)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 		assert(type(owner) == "string", "Expected 'owner' to be a string")
 
-		local vehicle = vehicles[self.plate]
+		local vehicle = Core.vehicles[self.plate]
 		if (vehicle.owner == owner) then
 			return
 		end
 
 		MySQL.prepare("UPDATE `owned_vehicles` SET `owner` = ? WHERE `plate` = ?", owner, vehicle.plate)
 
-		vehicles[self.plate].owner = owner
+		Core.vehicles[self.plate].owner = owner
 	end,
 	despawn = function(self)
-		assert(vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
+		assert(Core.vehicles[self.plate] ~= nil, "Attempted to access invalid vehicle")
 
-		local vehicle = vehicles[self.plate]
+		local vehicle = Core.vehicles[self.plate]
 		if DoesEntityExist(vehicle.entity) then
 			DeleteEntity(vehicle.entity)
 		end
@@ -104,63 +101,6 @@ local vehicleClass = {
 
 		MySQL.prepare("UPDATE `owned_vehicles` SET `stored` = 1 WHERE `plate` = ?", vehicle.plate)
 
-		vehicles[self.plate] = nil
+		Core.vehicles[self.plate] = nil
 	end,
 }
-
----@param plate string
----@param entity number
----@param model string|number
----@param props table
----@param owner string
----@return VehicleClass
-function ESX.CreateExtendedVehicle(plate, entity, model, props, owner)
-	assert(type(plate) == "string", "Expected 'plate' to be a string")
-	assert(type(entity) == "number", "Expected 'entity' to be a number")
-	assert(type(model) == "string" or type(model) == "number", "Expected 'model' to be a string or number")
-	assert(type(props) == "table", "Expected 'props' to be a table")
-	assert(type(owner) == "string", "Expected 'owner' to be a string")
-	assert(DoesEntityExist(entity) == true, "Entity does not exist")
-	assert(GetEntityType(entity) == 2, "Entity is not a vehicle")
-
-	if vehicles[plate] then
-		local obj = table.clone(vehicleClass)
-		obj.plate = plate
-		return obj
-	end
-
-	if type(model) ~= "number" then
-		model = GetHashKey(model)
-	end
-
-	local netId = NetworkGetNetworkIdFromEntity(entity)
-	---@type VehicleData
-	local vehicle = {
-		plate = plate,
-		entity = entity,
-		netId = netId,
-		modelHash = model,
-		props = props,
-		owner = owner,
-	}
-	vehicles[netId] = vehicle
-
-	local obj = table.clone(vehicleClass)
-	obj.plate = plate
-	TriggerEvent("esx:vehicleSpawned", obj)
-	MySQL.prepare("UPDATE `owned_vehicles` SET `stored` = 0 WHERE `plate` = ?", plate)
-
-	return obj
-end
-
----@param plate string
----@return VehicleClass|nil
-function ESX.GetVehicleFromPlate(plate)
-	assert(type(plate) == "string", "Expected 'plate' to be a string")
-
-	if vehicles[plate] then
-		local obj = table.clone(vehicleClass)
-		obj.plate = plate
-		return obj
-	end
-end

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -1,0 +1,173 @@
+-- Inspired by https://github.com/overextended/ox_core/blob/main/server/vehicle/class.ts
+
+---@class VehicleData
+---@field netId number
+---@field entity number
+---@field plate string
+---@field modelHash number
+---@field props table
+---@field owner string|false
+
+---@class VehicleClass
+---@field netId number
+---@field getNetId fun(self:VehicleClass):number
+---@field getEntity fun(self:VehicleClass):number
+---@field getPlate fun(self:VehicleClass):string
+---@field getModelHash fun(self:VehicleClass):number
+---@field getProps fun(self:VehicleClass):table
+---@field getOwner fun(self:VehicleClass):string|false
+---@field setPlate fun(self:VehicleClass, plate:string, apply:boolean):nil
+---@field setProps fun(self:VehicleClass, props:table, apply:boolean):nil
+---@field setOwner fun(self:VehicleClass, owner:string|false):nil
+---@field despawn fun(self:VehicleClass):nil
+
+---@type table<number, VehicleData>
+local vehicles = {}
+
+---@type VehicleClass
+local vehicleClass = {
+	netId = -1,
+	getNetId = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].netId
+	end,
+	getEntity = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].entity
+	end,
+	getPlate = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].plate
+	end,
+	getModelHash = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].modelHash
+	end,
+	getProps = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].props
+	end,
+	getOwner = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		return vehicles[self.netId].owner
+	end,
+	setPlate = function(self, plate, apply)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+		assert(type(plate) == "string", "Expected 'plate' to be a string")
+
+		local vehicle = vehicles[self.netId]
+		if apply and vehicle.owner then
+			SetVehicleNumberPlateText(vehicle.entity, plate)
+			MySQL.prepare("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", plate, vehicle.plate, vehicle.owner)
+		end
+		vehicle.plate = plate
+	end,
+	setProps = function(self, props, apply)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+		assert(type(props) == "table", "Expected 'props' to be a table")
+
+		local vehicle = vehicles[self.netId]
+		if apply and vehicle.owner then
+			Entity(vehicle.entity).state:set("VehicleProperties", props, true)
+			MySQL.prepare("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ?", json.encode(props), vehicle.plate)
+		end
+
+		vehicle.props = props
+	end,
+	setOwner = function(self, owner)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+		assert(type(owner) == "string" or owner == false, "Expected 'owner' to be a string or false")
+
+		local vehicle = vehicles[self.netId]
+		if (vehicle.owner == owner) then return end
+
+		if owner then
+			---@TODO: Insert if not exists?
+			MySQL.prepare("UPDATE `owned_vehicles` SET `owner` = ? WHERE `plate` = ?", owner, vehicle.plate)
+		else
+			MySQL.prepare("DELETE FROM `owned_vehicles` WHERE `owner` = ? AND `plate` = ?", vehicle.owner, vehicle.plate)
+		end
+
+		vehicles[self.netId].owner = owner
+	end,
+	despawn = function(self)
+		assert(vehicles[self.netId] ~= nil, "Attempted to access invalid vehicle")
+
+		local vehicle = vehicles[self.netId]
+		if DoesEntityExist(vehicle.entity) then
+			DeleteEntity(vehicle.entity)
+		end
+		TriggerEvent("esx:vehicleDespawned", self.netId)
+
+		MySQL.prepare("UPDATE `owned_vehicles` SET `stored` = 1 WHERE `plate` = ?", vehicle.plate)
+
+		vehicles[self.netId] = nil
+	end,
+}
+
+---@param plate string
+---@param entity number
+---@param model string|number
+---@param props table
+---@param owner string|false
+---@return VehicleClass
+function ESX.CreateExtendedVehicle(plate, entity, model, props, owner)
+	assert(type(plate) == "string", "Expected 'plate' to be a string")
+	assert(type(entity) == "number", "Expected 'entity' to be a number")
+	assert(type(model) == "string" or type(model) == "number", "Expected 'model' to be a string or number")
+	assert(type(props) == "table", "Expected 'props' to be a table")
+	assert(type(owner) == "string" or owner == false, "Expected 'owner' to be a string or false")
+	assert(DoesEntityExist(entity) == true, "Entity does not exist")
+	assert(GetEntityType(entity) == 2, "Entity is not a vehicle")
+
+	local netId = NetworkGetNetworkIdFromEntity(entity)
+
+	if vehicles[netId] then
+		local obj = table.clone(vehicleClass)
+		obj.netId = netId
+		return obj
+	end
+
+	if type(model) ~= "number" then
+		model = GetHashKey(model)
+	end
+
+	---@type VehicleData
+	local vehicle = {
+		plate = plate,
+		entity = entity,
+		netId = netId,
+		modelHash = model,
+		props = props,
+		owner = owner,
+	}
+	vehicles[netId] = vehicle
+
+	if owner then
+		---@TODO: Insert to db if not exists?
+	end
+
+	local obj = table.clone(vehicleClass)
+	obj.netId = netId
+	TriggerEvent("esx:vehicleCreated", obj)
+
+	MySQL.prepare("UPDATE `owned_vehicles` SET `stored` = 0 WHERE `plate` = ?", plate)
+
+	return obj
+end
+
+---@param netId number
+---@return VehicleClass|nil
+function ESX.GetVehicleFromNetId(netId)
+	if vehicles[netId] then
+		local obj = table.clone(vehicleClass)
+		obj.netId = netId
+		return obj
+	end
+end

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -12,6 +12,8 @@ Core.DatabaseConnected = false
 Core.playersByIdentifier = {}
 
 Core.vehicleTypesByModel = {}
+---@type table<number, VehicleData>
+Core.vehicles = {}
 
 RegisterNetEvent("esx:onPlayerSpawn", function()
     ESX.Players[source].spawned = true

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -405,7 +405,7 @@ function ESX.CreateExtendedVehicle(plate, entity, model, props, owner)
         props = props,
         owner = owner,
     }
-    Core.vehicles[netId] = vehicle
+    Core.vehicles[plate] = vehicle
 
     local obj = table.clone(Core.vehicleClass)
     obj.plate = plate


### PR DESCRIPTION
### Overview
This is a draft implementation of a **Vehicle Class** for the ESX framework. The goal is to provide an object-oriented way to handle vehicle data, including attributes like `netId`, `entity`, `plate`, and `owner`, and actions such as setting properties, despawning, and updating vehicle data in the database.

---

### Current Status
This implementation is still in its early stages. It has **not been tested** yet and is currently more of a **proof of concept** to explore the direction I want to take with this feature. As such, **feedback would be greatly appreciated** to help refine the approach and address any potential issues early on.

---

### Key Features:
- **Vehicle Data**: Stores essential vehicle information (e.g., `netId`, `plate`, `props`, `owner`).
- **Vehicle Methods**: Includes methods to get and set vehicle properties, owner, and despawn the vehicle.
- **Database Interaction**: Updates the database (`owned_vehicles`) when properties or owner information is changed.

---

### Notable Code References
- The structure and design of this class are **inspired by the Vehicle class** from the ox_core framework. You can check it out [here](https://github.com/overextended/ox_core/blob/main/server/vehicle/class.ts).

---

### TODO:
- **Testing**: This draft has not yet been tested, and the methods likely need some refinement.
- **Error Handling**: There might be areas to improve error handling and validation.

---

Any feedback on the design, performance, or implementation would be **greatly appreciated**!
