### PR TITLE
fix(client/modules/points): Small improvements.

### DIFF
--- a/[core]/es_extended/client/imports/point.lua
+++ b/[core]/es_extended/client/imports/point.lua
@@ -6,7 +6,7 @@ function Point:constructor(properties)
 	self.inside = properties.inside or function() end
 	self.enter = properties.enter or function() end
 	self.leave = properties.leave or function() end
-	self.handle = ESX.CreatePointIntenal(properties.coords, properties.distance, properties.hidden, function()
+	self.handle = ESX.CreatePointInternal(properties.coords, properties.distance, properties.hidden, function()
 		self.nearby = true
 		if self.enter then
 			self:enter()

--- a/[core]/es_extended/client/modules/points.lua
+++ b/[core]/es_extended/client/modules/points.lua
@@ -1,6 +1,6 @@
 local points = {}
 
-function ESX.CreatePointIntenal(coords, distance, hidden, enter, leave)
+function ESX.CreatePointInternal(coords, distance, hidden, enter, leave)
 	local point = {
 		coords = coords,
 		distance = distance,

--- a/[core]/es_extended/client/modules/points.lua
+++ b/[core]/es_extended/client/modules/points.lua
@@ -28,8 +28,7 @@ function StartPointsLoop()
     CreateThread(function()
         while true do
             local coords = GetEntityCoords(ESX.PlayerData.ped)
-            for i=1, #points do
-                local point = points[i]
+            for i, point in pairs(points) do
                 local distance = #(coords - point.coords)
 				
                 if not point.hidden and distance <= point.distance then
@@ -50,9 +49,9 @@ end
 
 
 AddEventHandler('onResourceStop', function(resource)
-	for i=1, #points do
-		if points[i].resource == resource then
-			points[i] = nil
-		end
-	end
+    for i, point in pairs(points) do
+        if point.resource == resource then
+            points[i] = nil
+        end
+    end
 end)


### PR DESCRIPTION
## Summary  
This PR includes two key updates to the `points` module:

- Safely iterates over the sparse `points` table in `StartPointsLoop` by using `pairs` instead of `#points`, ensuring that `nil` entries are properly skipped during iteration.
- Fixes a typo in the `ESX.CreatePointIntenal` function name, correcting it to `ESX.CreatePointInternal` for consistency with the correct method name.