### PR TITLE
Validate player skin before saving to db

### DIFF
--- a/[core]/esx_skin/server/main.lua
+++ b/[core]/esx_skin/server/main.lua
@@ -1,4 +1,7 @@
 RegisterNetEvent("esx_skin:save", function(skin)
+    if not skin or type(skin) ~= "table" then
+        return
+    end
     local xPlayer = ESX.GetPlayerFromId(source)
 
     if not ESX.GetConfig().CustomInventory then


### PR DESCRIPTION
This PR adds at least a little validation before saving the contents of the 'skin' net event parameter to the database. You could previously save basically anything to the db that could be stringified as json, which isn't optimal.