### PR TITLE
refactor(locales): Remove unused duty locales

### DIFF
--- a/[core]/es_extended/locales/es.lua
+++ b/[core]/es_extended/locales/es.lua
@@ -396,8 +396,4 @@ Locales["es"] = {
     ["tint_metallic_blue"] = "azul metálico",
     ["tint_metallic_white_aqua"] = "blanco aqua metálico",
     ["tint_metallic_red_yellow"] = "rojo amarillo metálico",
-
-    -- Duty related
-    ["stopped_duty"] = "Has salido de servicio.",
-    ["started_duty"] = "Has entrado de servicio.",
 }

--- a/[core]/es_extended/locales/hu.lua
+++ b/[core]/es_extended/locales/hu.lua
@@ -407,8 +407,4 @@ Locales["hu"] = {
     ["tint_metallic_blue"] = "metál kék",
     ["tint_metallic_white_aqua"] = "metál fehér aqua",
     ["tint_metallic_red_yellow"] = "metál piros sárga",
-
-    -- Duty related
-    ["stopped_duty"] = "Leadtad a szolgálatot.",
-    ["started_duty"] = "Szolgálatba álltál.",
 }


### PR DESCRIPTION
### Description

This PR removes unused duty locales from the Spanish and Hungarian locale files.