### PR TITLE
fix(es_extended/client/functions.lua): bug fix with the menu close & closeall function

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -389,7 +389,12 @@ function ESX.UI.Menu.Close(menuType, namespace, name, cancel)
                 if not cancel then
                     ESX.UI.Menu.Opened[i].close()
                 else
-                    ESX.UI.Menu.Opened[i].cancel()
+                    local menu = ESX.UI.Menu.Opened[i]
+                    ESX.UI.Menu.RegisteredTypes[menu.type].close(menu.namespace, menu.name)
+    
+                    if type(menu.cancel) ~= "nil" then
+                        menu.cancel(menu.data, menu)
+                    end
                 end
                 ESX.UI.Menu.Opened[i] = nil
             end
@@ -405,7 +410,12 @@ function ESX.UI.Menu.CloseAll(cancel)
             if not cancel then
                 ESX.UI.Menu.Opened[i].close()
             else
-                ESX.UI.Menu.Opened[i].cancel()
+                local menu = ESX.UI.Menu.Opened[i]
+                ESX.UI.Menu.RegisteredTypes[menu.type].close(menu.namespace, menu.name)
+    
+                if type(menu.cancel) ~= "nil" then
+                    menu.cancel(menu.data, menu)
+                end
             end
             ESX.UI.Menu.Opened[i] = nil
         end


### PR DESCRIPTION
As the title says, this fixes a bug that occurs when using the menu- close or close all function with the cancel argument set.

The error was that the Cancel function was called without any further arguments, as it normally is.