### PR TITLE
fix(es_extended/client/modules/actions): correctly update ped reference in TrackPed

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -45,9 +45,9 @@ function Actions:TrackPed()
 
     if playerPed ~= newPed then
         ESX.PlayerData.ped = newPed
-        ESX.SetPlayerData("ped", playerPed)
+        ESX.SetPlayerData("ped", newPed)
 
-        TriggerEvent("esx:playerPedChanged", playerPed)
+        TriggerEvent("esx:playerPedChanged", newPed)
     end
 end
 


### PR DESCRIPTION
### Summary
This PR fixes an issue in the `TrackPed` function where the new ped ID (`PlayerPedId()`) was not being correctly saved to `ESX.PlayerData.ped`. As a result, the loop in the function detected constant changes and triggered unnecessary events.

--- 

### Changes
- Updated `TrackPed` to properly save the new ped ID.
- Ensured `ESX.SetPlayerData` uses the updated ped reference.
- Passed the new ped to the `esx:playerPedChanged` event.

---

### Testing
- Verified that the new ped ID is updated in `ESX.PlayerData.ped` as expected.
- Confirmed that the loop no longer runs indefinitely once the ped is updated.
- Checked that the `esx:playerPedChanged` event fires correctly with the new ped data.

---

### Impact
This fix resolves unnecessary resource usage caused by continuous ped tracking and improves overall performance.
