### PR TITLE
fix(es_extended): eliminate ESX.PlayerData race condition for esx:playerLoaded event

### DIFF
--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -14,7 +14,7 @@ local function ApplyMetadata(metadata)
     end
 end
 
-ESX.SecureNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
+RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
     ESX.PlayerData = xPlayer
 
     if not Config.Multichar then

--- a/[core]/es_extended/client/modules/npwd.lua
+++ b/[core]/es_extended/client/modules/npwd.lua
@@ -9,7 +9,7 @@ local function checkPhone()
     npwd:setPhoneDisabled((phoneItem and phoneItem.count or 0) <= 0)
 end
 
-ESX.SecureNetEvent("esx:playerLoaded", checkPhone)
+RegisterNetEvent("esx:playerLoaded", checkPhone)
 
 AddEventHandler("onClientResourceStart", function(resource)
     if resource ~= "npwd" then

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -12,9 +12,11 @@ if not IsDuplicityVersion() then -- Only register this event for the client
         end
     end)
 
-    ESX.SecureNetEvent("esx:playerLoaded", function(xPlayer)
+    ESX.SecureNetEvent("esx:playerLoaded:internal", function(xPlayer, isNew, playerSkin)
         ESX.PlayerData = xPlayer
         ESX.PlayerLoaded = true
+
+        TriggerEvent("esx:playerLoaded", xPlayer, isNew, playerSkin)
     end)
 
     ESX.SecureNetEvent("esx:onPlayerLogout", function()

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -290,7 +290,7 @@ function loadESXPlayer(identifier, playerId, isNew)
     TriggerEvent("esx:playerLoaded", playerId, xPlayer, isNew)
     userData.money = xPlayer.getMoney()
     userData.maxWeight = xPlayer.getMaxWeight()
-    xPlayer.triggerEvent("esx:playerLoaded", userData, isNew, userData.skin)
+    xPlayer.triggerEvent("esx:playerLoaded:internal", userData, isNew, userData.skin)
 
     if not Config.CustomInventory then
         xPlayer.triggerEvent("esx:createMissingPickups", Core.Pickups)

--- a/[core]/esx_multicharacter/client/main.lua
+++ b/[core]/esx_multicharacter/client/main.lua
@@ -33,7 +33,7 @@ ESX.SecureNetEvent("esx_multicharacter:SetupUI", function(data, slots)
     Multicharacter:SetupUI(data, slots)
 end)
 
-ESX.SecureNetEvent('esx:playerLoaded', function(playerData, isNew, skin)
+RegisterNetEvent('esx:playerLoaded', function(playerData, isNew, skin)
     Multicharacter:PlayerLoaded(playerData, isNew, skin)
 end)
 

--- a/[core]/esx_skin/client/main.lua
+++ b/[core]/esx_skin/client/main.lua
@@ -70,7 +70,7 @@ AddEventHandler("esx_skin:playerRegistered", function()
     end)
 end)
 
-ESX.SecureNetEvent("esx:playerLoaded", function(_, _, skin)
+RegisterNetEvent("esx:playerLoaded", function(_, _, skin)
     ESX.PlayerLoaded = true
     TriggerServerEvent("esx_skin:setWeight", skin)
 end)


### PR DESCRIPTION
### Description
This PR addresses a race condition where the `esx:playerLoaded` is triggered before `ESX.PlayerData` is fully initialized, leading to inconsistencies in scripts relying on this data. It also resolves the issue described in [#1454](https://github.com/esx-framework/esx_core/issues/1454).

---

### Changes
- Reverted `esx:playerLoaded` to use `RegisterNetEvent` instead of `ESX.SecureNetEvent`.
- Added a new secure net event `esx:playerLoaded:internal`.
   - Responsible for triggering `esx:playerLoaded` only after `PlayerData` has been fully initialized.

---

### Impact
- Resolves the issue in [#1454](https://github.com/esx-framework/esx_core/issues/1454).
- Ensures that `esx:playerLoaded` is only triggered once `PlayerData` is properly initialized, eliminating potential race conditions.
- Improves reliability for scripts dependent on the `esx:playerLoaded` event.

---

### Testing
- Verified that `esx:playerLoaded` is only emitted after `PlayerData` initialization is complete.
- Tested compatibility with existing client scripts to ensure no breaking changes.
