### PR TITLE
feat(es_extended/client/blips): add Blip class

### DIFF
--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -1,24 +1,25 @@
 Blip = ESX.Class()
 
 function Blip:constructor(properties)
-    self.coords = type(properties.coords) == "vector3" and properties.coords or vector3(properties.coords.x, properties.coords.y, properties.coords.z)
+    self.coords = type(properties.coords) == "vector3" and properties.coords or
+        vector3(properties.coords.x, properties.coords.y, properties.coords.z)
     self.sprite = type(properties.sprite) == "number" and properties.sprite or 1
     self.colour = type(properties.colour) == "number" and properties.colour or 0
     self.label = type(properties.label) == "string" and properties.label or "Unknown"
     self.scale = type(properties.scale) == "number" and properties.scale or 1.0
     self.display = type(properties.display) == "number" and properties.display or 4
-    self.shortRange = type(properties.shortRange) == "boolean" and properties.shortRange or true 
+    self.shortRange = type(properties.shortRange) == "boolean" and properties.shortRange or true
     self.resource = GetInvokingResource() or GetCurrentResourceName() or "es_extended"
 
-    local handle = ESX.CreateBlipInternal(coords, sprite, colour, label, scale, display, shortRange, resource)
-    self.handle = handle 
-
+    local handle = ESX.CreateBlipInternal(self.coords, self.sprite, self.colour, self.label, self.scale, self.display,
+        self.shortRange, self.resource)
+    self.handle = handle
     return handle
 end
 
 function Blip:setCoords(coords)
     self.coords = type(coords) == "vector3" and coords or vector3(coords.x, coords.y, coords.z)
-    
+
     ESX.SetBlipCoords(self.handle, self.coords)
 end
 
@@ -53,7 +54,7 @@ function Blip:setDisplay(display)
 end
 
 function Blip:setShortRange(shortRange)
-    self.shortRange = type(shortRange) == "boolean" and shortRange or true 
+    self.shortRange = type(shortRange) == "boolean" and shortRange or true
 
     ESX.SetBlipShortRange(self.handle, self.shortRange)
 end

--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -1,0 +1,65 @@
+Blip = ESX.Class()
+
+function Blip:constructor(properties)
+    self.coords = type(properties.coords) == "vector3" and properties.coords or vector3(properties.coords.x, properties.coords.y, properties.coords.z)
+    self.sprite = type(properties.sprite) == "number" and properties.sprite or 1
+    self.colour = type(properties.colour) == "number" and properties.colour or 0
+    self.label = type(properties.label) == "string" and properties.label or "Unknown"
+    self.scale = type(properties.scale) == "number" and properties.scale or 1.0
+    self.display = type(properties.display) == "number" and properties.display or 4
+    self.shortRange = type(properties.shortRange) == "boolean" and properties.shortRange or true 
+    self.resource = GetInvokingResource() or GetCurrentResourceName() or "es_extended"
+
+    local handle = ESX.CreateBlipInternal(coords, sprite, colour, label, scale, display, shortRange, resource)
+    self.handle = handle 
+
+    return handle
+end
+
+function Blip:setCoords(coords)
+    self.coords = type(coords) == "vector3" and coords or vector3(coords.x, coords.y, coords.z)
+    
+    ESX.SetBlipCoords(self.handle, self.coords)
+end
+
+function Blip:setSprite(sprite)
+    self.sprite = type(sprite) == "number" and sprite or 1
+
+    ESX.SetBlipSprite(self.handle, self.sprite)
+end
+
+function Blip:setColour(colour)
+    self.colour = type(colour) == "number" and colour or 0
+
+    ESX.SetBlipColour(self.handle, self.colour)
+end
+
+function Blip:setLabel(label)
+    self.label = type(label) == "string" and label or "Unknown"
+
+    ESX.SetBlipLabel(self.handle, self.label)
+end
+
+function Blip:setScale(scale)
+    self.scale = type(scale) == "number" and scale or 0
+
+    ESX.SetBlipScale(self.handle, self.scale)
+end
+
+function Blip:setDisplay(display)
+    self.display = type(display) == "number" and display or 4
+
+    ESX.SetBlipDisplay(self.handle, self.display)
+end
+
+function Blip:setShortRange(shortRange)
+    self.shortRange = type(shortRange) == "boolean" and shortRange or true 
+
+    ESX.SetBlipShortRange(self.handle, self.shortRange)
+end
+
+function Blip:delete()
+    ESX.RemoveBlip(self.handle)
+end
+
+return Blip

--- a/[core]/es_extended/client/modules/blips.lua
+++ b/[core]/es_extended/client/modules/blips.lua
@@ -1,0 +1,90 @@
+local blips = {}
+
+function ESX.CreateBlipInternal(coords, sprite, colour, label, scale, display, shortRange, resource)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+
+    SetBlipSprite(blip, sprite)
+    SetBlipColour(blip, colour)
+    SetBlipScale(blip, scale)
+    SetBlipDisplay(blip, display)
+    SetBlipAsShortRange(blip, shortRange)
+    BeginTextCommandSetBlipName("STRING")
+    AddTextComponentString(label)
+    EndTextCommandSetBlipName(blip)
+
+    local handle = ESX.Table.SizeOf(blips) + 1
+	blips[handle] = {
+        blip = blip,
+        resource = resource
+    }
+
+    return id
+end
+
+function ESX.RemoveBlip(id)
+    local blipData = blips[id]
+
+    if blipData then
+        RemoveBlip(blipData.blip)
+
+        blips[id] = nil
+    end
+end
+
+function ESX.SetBlipCoords(id, coords)
+    local blipData = blips[id]
+
+    if blipData then 
+        SetBlipCoords(blipData.blip, coords.xyz)
+    end
+end
+
+function ESX.SetBlipColour(id, colour)
+    local blipData = blips[id]
+
+    if blipData then 
+        SetBlipColour(blipData.blip, colour)
+    end
+end
+
+function ESX.SetBlipLabel(id, label)
+    local blipData = blips[id]
+
+    if blipData then 
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentString(label)
+        EndTextCommandSetBlipName(blipData.blip)
+    end
+end
+
+function ESX.SetBlipScale(id, scale)
+    local blipData = blips[id]
+
+    if blipData then 
+        SetBlipScale(blipData.blip, scale)
+    end
+end
+
+function ESX.SetBlipDisplay(id, display)
+    local blipData = blips[id]
+
+    if blipData then 
+        SetBlipDisplay(blipData.blip, display)
+    end
+end
+
+function ESX.SetBlipShortRange(id, shortRange)
+    local blipData = blips[id]
+
+    if blipData then 
+        SetBlipAsShortRange(blipData.blip, shortRange)
+    end
+end
+
+AddEventHandler("onResourceStop", function(resource)
+    for id, blip in pairs(blips) do
+        if blip.resource == resource then
+            ESX.RemoveBlip(id)
+        end
+    end
+end)

--- a/[core]/es_extended/client/modules/blips.lua
+++ b/[core]/es_extended/client/modules/blips.lua
@@ -1,6 +1,8 @@
 local blips = {}
 
 function ESX.CreateBlipInternal(coords, sprite, colour, label, scale, display, shortRange, resource)
+    local handle = ESX.Table.SizeOf(blips) + 1
+
     local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
 
     SetBlipSprite(blip, sprite)
@@ -8,17 +10,20 @@ function ESX.CreateBlipInternal(coords, sprite, colour, label, scale, display, s
     SetBlipScale(blip, scale)
     SetBlipDisplay(blip, display)
     SetBlipAsShortRange(blip, shortRange)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentString(label)
+
+    local TEXT_ENTRY = ("ESX_BLIP_%s"):format(handle)
+
+    AddTextEntry(TEXT_ENTRY, label)
+
+    BeginTextCommandSetBlipName(TEXT_ENTRY)
     EndTextCommandSetBlipName(blip)
 
-    local handle = ESX.Table.SizeOf(blips) + 1
-	blips[handle] = {
+    blips[handle] = {
         blip = blip,
         resource = resource
     }
 
-    return id
+    return handle
 end
 
 function ESX.RemoveBlip(id)
@@ -34,15 +39,23 @@ end
 function ESX.SetBlipCoords(id, coords)
     local blipData = blips[id]
 
-    if blipData then 
+    if blipData then
         SetBlipCoords(blipData.blip, coords.xyz)
+    end
+end
+
+function ESX.SetBlipSprite(id, sprite)
+    local blipData = blips[id]
+
+    if blipData then
+        SetBlipSprite(blipData.blip, sprite)
     end
 end
 
 function ESX.SetBlipColour(id, colour)
     local blipData = blips[id]
 
-    if blipData then 
+    if blipData then
         SetBlipColour(blipData.blip, colour)
     end
 end
@@ -50,9 +63,12 @@ end
 function ESX.SetBlipLabel(id, label)
     local blipData = blips[id]
 
-    if blipData then 
-        BeginTextCommandSetBlipName("STRING")
-        AddTextComponentString(label)
+    if blipData then
+        local TEXT_ENTRY = ("ESX_BLIP_%s"):format(blipData.id)
+
+        AddTextEntry(TEXT_ENTRY, label)
+
+        BeginTextCommandSetBlipName(TEXT_ENTRY)
         EndTextCommandSetBlipName(blipData.blip)
     end
 end
@@ -60,7 +76,7 @@ end
 function ESX.SetBlipScale(id, scale)
     local blipData = blips[id]
 
-    if blipData then 
+    if blipData then
         SetBlipScale(blipData.blip, scale)
     end
 end
@@ -68,7 +84,7 @@ end
 function ESX.SetBlipDisplay(id, display)
     local blipData = blips[id]
 
-    if blipData then 
+    if blipData then
         SetBlipDisplay(blipData.blip, display)
     end
 end
@@ -76,7 +92,7 @@ end
 function ESX.SetBlipShortRange(id, shortRange)
     local blipData = blips[id]
 
-    if blipData then 
+    if blipData then
         SetBlipAsShortRange(blipData.blip, shortRange)
     end
 end

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -46,6 +46,7 @@ client_scripts {
 	'client/modules/callback.lua',
     'client/modules/adjustments.lua',
 	'client/modules/points.lua',
+	'client/modules/blips.lua',
 
 	'client/main.lua',
 

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -29,7 +29,7 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 
         local file = LoadResourceFile("es_extended", path)
         if file then
-            local fn, err = load(file, ('@es_extended/%s'):format(path))
+            local fn, err = load(file, ('@@es_extended/%s'):format(path))
 
             if not fn or err then
                 return error(('\n^1Error importing module (%s)'):format(external[i]))

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -29,7 +29,7 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 
         local file = LoadResourceFile("es_extended", path)
         if file then
-            local fn, err = load(file, ('@@es_extended/%s'):format(path))
+            local fn, err = load(file, ('@es_extended/%s'):format(path))
 
             if not fn or err then
                 return error(('\n^1Error importing module (%s)'):format(external[i]))

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -22,7 +22,7 @@ if not IsDuplicityVersion() then -- Only register this event for the client
         ESX.PlayerData = {}
     end)
 
-    local external = {{"Class", "class.lua"}, {"Point", "point.lua"}}
+    local external = {{"Class", "class.lua"}, {"Point", "point.lua"}, {"Blip", "blip.lua"}}
     for i=1, #external do
         local module = external[i]
         local path = string.format("client/imports/%s", module[2])


### PR DESCRIPTION
This pull request introduces a new `Blip` class to simplify the management of blips. The class encapsulates all functionalities related to blip creation, updates, and deletion, providing an easy-to-use interface for developers.

# Benefits
- Simplifies blip management
- Improves readability and maintainability of the codebase
- Reduces code repetition by encapsulating blip operations into reusable methods

# Example:

```lua
CreateThread(function()
    local blip = ESX.Blip:new({
        coords = vec3(202.50, -841.45, 30.67),
        sprite = 23,
        colour = 2,
        label = "Test Blip",
        scale = 1.5,
        display = 4,
        shortRange = true
    })

    Wait(1000)

    blip:setColour(3)

    Wait(1000)

    blip:setLabel("Test Blip 2")

    Wait(1000)

    blip:setScale(2.0)

    Wait(1000)

    blip:setDisplay(2)

    Wait(1000)

    blip:setShortRange(false)

    Wait(1000)

    blip:setCoords(vec3(202.50, -845.45, 30.67))
end)
```

# Impact on Existing Code
This addition is fully backward-compatible. It does not alter any existing functionality within the framework but provides a modular approach for future blip-related operations.

# Next Steps
- Extend the `Blip` class with more options to modfiy a blip