### PR TITLE
fix(esx_skin/client/modules/menu): clear old menu items before inserting new ones

### DIFF
--- a/[core]/esx_skin/client/modules/menu.lua
+++ b/[core]/esx_skin/client/modules/menu.lua
@@ -37,7 +37,7 @@ end
 
 function Menu:InsertElements()
     local playerPed = PlayerPedId()
-    
+
     self.elements = {}
     for i = 1, #self.components, 1 do
         local value = self.components[i].value
@@ -52,9 +52,6 @@ function Menu:InsertElements()
         data.type = "slider"
         data.max = self.maxValues[self.components[i].name]
 
-        if not self.elements then
-            self.elements = {}
-        end
         self.elements[#self.elements + 1] = data
     end
 end

--- a/[core]/esx_skin/client/modules/menu.lua
+++ b/[core]/esx_skin/client/modules/menu.lua
@@ -37,7 +37,8 @@ end
 
 function Menu:InsertElements()
     local playerPed = PlayerPedId()
-
+    
+    self.elements = {}
     for i = 1, #self.components, 1 do
         local value = self.components[i].value
         local componentId = self.components[i].componentId


### PR DESCRIPTION
### Description
This PR resolves a bug mentioned in [#1491](https://github.com/esx-framework/esx_core/issues/1491) where components from a previous skin menu persist when switching between menus (e.g., hair options showing in the clothing shop).  

