### PR TITLE
fix(esx_skin/client/modules/menu): set initial camera offsets properly

### DIFF
--- a/[core]/esx_skin/client/modules/menu.lua
+++ b/[core]/esx_skin/client/modules/menu.lua
@@ -122,8 +122,8 @@ function Menu:Open(submit, cancel, restrict)
 
     self:InsertElements()
 
-    self.zoomOffset = self.components[1].zoomOffset
-    self.camOffset = self.components[1].camOffset
+    Skin.zoomOffset = self.components[1].zoomOffset
+    Skin.camOffset = self.components[1].camOffset
     Camera:Create()
 
     self:ESXMenu()


### PR DESCRIPTION
### Description
This PR addresses an issue where the initial camera offsets were not set properly when opening a skin menu.