### PR TITLE
feat(es_extended/server/common): add JobsPlayers cache

### DIFF
--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -1,6 +1,7 @@
 ESX.Players = {}
 ESX.Jobs = {}
 ESX.JobsPlayerCount = {}
+ESX.JobsPlayers = {}
 ESX.Items = {}
 Core = {}
 Core.UsableItemsCallbacks = {}

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -283,8 +283,38 @@ local function checkTable(key, val, xPlayer, xPlayers)
             xPlayers[value] = {}
         end
 
-        if (key == "job" and xPlayer.job.name == value) or xPlayer[key] == value then
+        if xPlayer[key] == value then
             xPlayers[value][#xPlayers[value] + 1] = xPlayer
+        end
+    end
+end
+
+local function getExtendedPlayersByJob(job, xPlayers)
+    local isValTable = type(job) == "table"
+
+    if not isValTable then
+        if not ESX.JobPlayers[job] then
+            return
+        end
+
+        for i, src in pairs(ESX.JobPlayers[job]) do
+            if ESX.Players[src] then
+                xPlayers[#xPlayers + 1] = ESX.Players[src]
+            end
+        end
+
+        return
+    end
+
+    for i, currentJob in ipairs(job) do
+        if ESX.JobPlayers[currentJob] then
+            xPlayers[currentJob] = {}
+
+            for j, src in pairs(ESX.JobPlayers[currentJob]) do
+                if ESX.Players[src] then
+                    xPlayers[#xPlayers + 1] = ESX.Players[src]
+                end
+            end
         end
     end
 end
@@ -298,7 +328,15 @@ function ESX.GetExtendedPlayers(key, val)
     end
 
     local xPlayers = {}
-    if type(val) == "table" then
+
+    if key == "job" then
+        getExtendedPlayersByJob(val, xPlayers)
+
+        return xPlayers
+    end
+
+    local isValTable = type(val) == "table"
+    if isValTable then
         for i, xPlayer in pairs(ESX.Players) do
             checkTable(key, val, xPlayer, xPlayers)
         end
@@ -307,7 +345,7 @@ function ESX.GetExtendedPlayers(key, val)
     end
 
     for i, xPlayer in pairs(ESX.Players) do
-        if (key == "job" and xPlayer.job.name == val) or xPlayer[key] == val then
+        if xPlayer[key] == val then
             xPlayers[#xPlayers + 1] = xPlayer
         end
     end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -276,15 +276,15 @@ end
 
 ESX.GetPlayers = GetPlayers
 
-local function checkTable(key, val, player, xPlayers)
+local function checkTable(key, val, xPlayer, xPlayers)
     for valIndex = 1, #val do
         local value = val[valIndex]
         if not xPlayers[value] then
             xPlayers[value] = {}
         end
 
-        if (key == "job" and player.job.name == value) or player[key] == value then
-            xPlayers[value][#xPlayers[value] + 1] = player
+        if (key == "job" and xPlayer.job.name == value) or xPlayer[key] == value then
+            xPlayers[value][#xPlayers[value] + 1] = xPlayer
         end
     end
 end
@@ -293,20 +293,22 @@ end
 ---@param val? string|table
 ---@return table
 function ESX.GetExtendedPlayers(key, val)
+    if not key then
+        return ESX.Table.ToArray(ESX.Players)
+    end
+
     local xPlayers = {}
     if type(val) == "table" then
-        for _, v in pairs(ESX.Players) do
-            checkTable(key, val, v, xPlayers)
+        for i, xPlayer in pairs(ESX.Players) do
+            checkTable(key, val, xPlayer, xPlayers)
         end
-    else
-        for _, v in pairs(ESX.Players) do
-            if key then
-                if (key == "job" and v.job.name == val) or v[key] == val then
-                    xPlayers[#xPlayers + 1] = v
-                end
-            else
-                xPlayers[#xPlayers + 1] = v
-            end
+
+        return xPlayers
+    end
+
+    for i, xPlayer in pairs(ESX.Players) do
+        if (key == "job" and xPlayer.job.name == val) or xPlayer[key] == val then
+            xPlayers[#xPlayers + 1] = xPlayer
         end
     end
 

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -320,6 +320,7 @@ AddEventHandler("playerDropped", function(reason)
         local job = xPlayer.getJob().name
         local currentJob = ESX.JobsPlayerCount[job]
         ESX.JobsPlayerCount[job] = ((currentJob and currentJob > 0) and currentJob or 1) - 1
+        ESX.JobsPlayers[job][playerId] = nil
 
         GlobalState[("%s:count"):format(job)] = ESX.JobsPlayerCount[job]
         Core.playersByIdentifier[xPlayer.identifier] = nil
@@ -337,15 +338,22 @@ AddEventHandler("esx:playerLoaded", function(_, xPlayer)
 
     ESX.JobsPlayerCount[job] = (ESX.JobsPlayerCount[job] or 0) + 1
     GlobalState[jobKey] = ESX.JobsPlayerCount[job]
+
+    ESX.JobsPlayers[job] = ESX.JobsPlayers[job] or {}
+    ESX.JobsPlayers[job][xPlayer.source] = true
 end)
 
-AddEventHandler("esx:setJob", function(_, job, lastJob)
+AddEventHandler("esx:setJob", function(src, job, lastJob)
     local lastJobKey = ("%s:count"):format(lastJob.name)
     local jobKey = ("%s:count"):format(job.name)
     local currentLastJob = ESX.JobsPlayerCount[lastJob.name]
 
     ESX.JobsPlayerCount[lastJob.name] = ((currentLastJob and currentLastJob > 0) and currentLastJob or 1) - 1
     ESX.JobsPlayerCount[job.name] = (ESX.JobsPlayerCount[job.name] or 0) + 1
+
+    ESX.JobsPlayers[lastJob.name][src] = nil
+    ESX.JobsPlayers[job.name] = ESX.JobsPlayers[job.name] or {}
+    ESX.JobsPlayers[job.name][src] = true
 
     GlobalState[lastJobKey] = ESX.JobsPlayerCount[lastJob.name]
     GlobalState[jobKey] = ESX.JobsPlayerCount[job.name]

--- a/[core]/es_extended/shared/modules/table.lua
+++ b/[core]/es_extended/shared/modules/table.lua
@@ -223,3 +223,11 @@ function ESX.Table.Sort(t, order)
         end
     end
 end
+
+function ESX.Table.ToArray(table)
+    local array = {}
+    for _, v in pairs(table) do
+        array[#array + 1] = v
+    end
+    return array
+end


### PR DESCRIPTION
### Key Changes
- Added `ESX.Table.ToArray` util function
- Added `ESX.JobsPlayers` cache
- Refactored `ESX.GetExtendedPlayers`
- Added param `minimal` for `ESX.GetExtendedPlayers` to only return serverIds. Useful when only interested in using `ESX.TriggerClientEvent`.

---

### Note
This code has not been tested yet, at all. Hence why it is a draft PR. I was hoping to get some feedback on the changes first before testing it.