### PR TITLE
feat(es_extended/client/modules/adjustments): add adjustment DisableRadio

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -215,6 +215,15 @@ function Adjustments:WantedLevel()
     end
 end
 
+function Adjustments:DisableRadio()
+    if Config.RemoveHudComponents[16] then
+        AddEventHandler("esx:enteredVehicle", function(vehicle, plate, seat, displayName, netId)
+            SetVehRadioStation(vehicle,"OFF")
+            SetUserRadioControlEnabled(false)
+        end)
+    end
+end
+
 function Adjustments:Load()
     self:RemoveHudComponents()
     self:DisableAimAssist()
@@ -228,4 +237,5 @@ function Adjustments:Load()
     self:LicensePlates()
     self:DiscordPresence()
     self:WantedLevel()
+    self:DisableRadio()
 end


### PR DESCRIPTION
### Key Changes
- Properly disable radio stations if the `RADIO_STATIONS` hud component is removed.