### PR TITLE
Spawn vehicle in right routing bucket

### DIFF
--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -78,6 +78,7 @@ ESX.RegisterCommand(
         local playerCoords = GetEntityCoords(playerPed)
         local playerHeading = GetEntityHeading(playerPed)
         local playerVehicle = GetVehiclePedIsIn(playerPed, false)
+        local sourceBucket = GetPlayerRoutingBucket(xPlayer.source)
 
         if not args.car or type(args.car) ~= "string" then
             args.car = "adder"
@@ -98,6 +99,8 @@ ESX.RegisterCommand(
         ESX.OneSync.SpawnVehicle(args.car, playerCoords, playerHeading, upgrades, function(networkId)
             if networkId then
                 local vehicle = NetworkGetEntityFromNetworkId(networkId)
+                SetEntityRoutingBucket(vehicle, sourceBucket)
+
                 for _ = 1, 20 do
                     Wait(0)
                     SetPedIntoVehicle(playerPed, vehicle, -1)


### PR DESCRIPTION
# Fix Routing Bucket Issue in /car command
## Description
This pull request resolves an issue where a vehicle spawned for a player in a different routing bucket (e.g., when the player is in a non-default bucket) results in the error:  
**"The player could not be seated in the vehicle".**  

The issue occurs because the spawned vehicle is created in the default bucket (bucket 0) while the player resides in another bucket.  

---

## Changes Made
- Fetching the player's current routing bucket using `GetPlayerRoutingBucket()`.
- Set the routing bucket of the spawned vehicle to match the player's routing bucket using `SetEntityRoutingBucket()`.
