### PR TITLE
fix(es_extended/client/functions): properly call SetVehicleExtra

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1019,7 +1019,7 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
         for extraId, enabled in pairs(props.extras) do
             extraId = tonumber(extraId)
             if extraId then
-                SetVehicleExtra(vehicle, extraId, enabled)
+                SetVehicleExtra(vehicle, extraId, not enabled)
             end
         end
     end


### PR DESCRIPTION
### Description
The native [SetVehicleExtra](https://docs.fivem.net/natives/?_0x7EE3A3C5E4A40CC9) dictates whether a vehicle extra should be **disabled**, while [IsVehicleExtraTurnedOn](https://docs.fivem.net/natives/?_0xD2E6822DBFD6C8BD) returns whether an extra is **enabled**. The latter is saved in the DB as vehicle properties. So we need to negate that value to properly reflect which vehicle extras we should toggle. This also fixes issues with helicopters missing key body parts when being parked out from garages, as the vehicle extras are being removed when they should not.