### PR TITLE
fix(esx_multichar/server/modules/multicharacter.lua): Added missing parameter

### DIFF
--- a/[core]/esx_multicharacter/server/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/server/modules/multicharacter.lua
@@ -13,7 +13,7 @@ function Multicharacter:SetupCharacters(source)
     local identifier = Server:GetIdentifier(source)
     ESX.Players[identifier] = true
 
-    local slots = Database:GetPlayerSlots()
+    local slots = Database:GetPlayerSlots(identifier)
     identifier = Server.prefix .. "%:" .. identifier
 
     local rawCharacters = Database:GetPlayerInfo(identifier, slots)


### PR DESCRIPTION
Added a missing parameter that wouldnt allow users to have custom charSlots