### PR TITLE
fix(es_extended/client/main): fix player death race condition

### DIFF
--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -4,16 +4,6 @@ ESX.SecureNetEvent("esx:requestModel", function(model)
     ESX.Streaming.RequestModel(model)
 end)
 
-local function ApplyMetadata(metadata)
-    if metadata.health then
-        SetEntityHealth(ESX.PlayerData.ped, metadata.health)
-    end
-
-    if metadata.armor and metadata.armor > 0 then
-        SetPedArmour(ESX.PlayerData.ped, metadata.armor)
-    end
-end
-
 RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
     ESX.PlayerData = xPlayer
 
@@ -33,8 +23,6 @@ RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
     end
 
     ESX.PlayerLoaded = true
-
-    ApplyMetadata(ESX.PlayerData.metadata)
 
     local timer = GetGameTimer()
     while not HaveAllStreamingRequestsCompleted(ESX.PlayerData.ped) and (GetGameTimer() - timer) < 2000 do
@@ -72,7 +60,17 @@ local function onPlayerSpawn()
 end
 
 AddEventHandler("playerSpawned", onPlayerSpawn)
-AddEventHandler("esx:onPlayerSpawn", onPlayerSpawn)
+AddEventHandler("esx:onPlayerSpawn", function()
+    onPlayerSpawn()
+
+    if ESX.PlayerData.metadata.health then
+        SetEntityHealth(ESX.PlayerData.ped, ESX.PlayerData.metadata.health)
+    end
+
+    if ESX.PlayerData.metadata.armor and ESX.PlayerData.metadata.armor > 0 then
+        SetPedArmour(ESX.PlayerData.ped, ESX.PlayerData.metadata.armor)
+    end
+end)
 
 AddEventHandler("esx:onPlayerDeath", function()
     ESX.SetPlayerData("ped", PlayerPedId())

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -68,7 +68,7 @@ AddEventHandler("esx:onPlayerSpawn", function()
     if isFirstSpawn then
         isFirstSpawn = false
 
-        if ESX.PlayerData.metadata.health then
+        if ESX.PlayerData.metadata.health and (ESX.PlayerData.metadata.health > 0 or Config.SaveDeathStatus) then
             SetEntityHealth(ESX.PlayerData.ped, ESX.PlayerData.metadata.health)
         end
 

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -46,8 +46,10 @@ RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
     StartServerSyncLoops()
 end)
 
+local isFirstSpawn = true
 ESX.SecureNetEvent("esx:onPlayerLogout", function()
     ESX.PlayerLoaded = false
+    isFirstSpawn = true
 end)
 
 ESX.SecureNetEvent("esx:setMaxWeight", function(newMaxWeight)
@@ -59,7 +61,6 @@ local function onPlayerSpawn()
     ESX.SetPlayerData("dead", false)
 end
 
-local isFirstSpawn = true
 AddEventHandler("playerSpawned", onPlayerSpawn)
 AddEventHandler("esx:onPlayerSpawn", function()
     onPlayerSpawn()

--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -59,16 +59,21 @@ local function onPlayerSpawn()
     ESX.SetPlayerData("dead", false)
 end
 
+local isFirstSpawn = true
 AddEventHandler("playerSpawned", onPlayerSpawn)
 AddEventHandler("esx:onPlayerSpawn", function()
     onPlayerSpawn()
 
-    if ESX.PlayerData.metadata.health then
-        SetEntityHealth(ESX.PlayerData.ped, ESX.PlayerData.metadata.health)
-    end
+    if isFirstSpawn then
+        isFirstSpawn = false
 
-    if ESX.PlayerData.metadata.armor and ESX.PlayerData.metadata.armor > 0 then
-        SetPedArmour(ESX.PlayerData.ped, ESX.PlayerData.metadata.armor)
+        if ESX.PlayerData.metadata.health then
+            SetEntityHealth(ESX.PlayerData.ped, ESX.PlayerData.metadata.health)
+        end
+
+        if ESX.PlayerData.metadata.armor and ESX.PlayerData.metadata.armor > 0 then
+            SetPedArmour(ESX.PlayerData.ped, ESX.PlayerData.metadata.armor)
+        end
     end
 end)
 

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -40,6 +40,7 @@ Config.LogPaycheck = false -- Logs paychecks to a nominated Discord channel via 
 Config.EnableSocietyPayouts = false -- pay from the society account that the player is employed at? Requirement: esx_society
 Config.MaxWeight = 24 -- the max inventory weight without a backpack
 Config.PaycheckInterval = 7 * 60000 -- how often to receive paychecks in milliseconds
+Config.SaveDeathStatus = true -- Save the death status of a player
 Config.EnableDebug = false -- Use Debug options?
 
 Config.DefaultJobDuty = true -- A players default duty status when changing jobs

--- a/[core]/esx_multicharacter/client/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/client/modules/multicharacter.lua
@@ -272,7 +272,6 @@ function Multicharacter:PlayerLoaded(playerData, isNew, skin)
 
         TriggerServerEvent("esx:onPlayerSpawn")
         TriggerEvent("esx:onPlayerSpawn")
-        TriggerEvent("playerSpawned")
         TriggerEvent("esx:restoreLoadout")
 
         self:Reset()


### PR DESCRIPTION
### Description
The current spawn event flow for multicharacter is structured as follows:

1. The player loads into the server, triggering the `playerSpawned` event during multichar setup.
2. On character selection, the following events are triggered in this order:
   1. `esx:playerLoaded`
   2. `playerSpawned`
   3. `esx:onPlayerSpawn`
   4. `playerSpawned` *(Redundant and removed by this PR)*

This PR addresses **two key issues**:

1. **Redundant `playerSpawned` Trigger**  
   The `playerSpawned` event was redundantly triggered in the `ESX.SpawnPlayer` function callback, even though the function itself already triggers this event. This PR eliminates the unnecessary duplication.

2. **Health & Armor Metadata Race Condition**  
   Player metadata, such as health and armor, is now applied within the `esx:onPlayerSpawn` event instead of `esx:playerLoaded`. This resolves the following issue:
   - The player's health, which could be set to 0 (causing death), was being applied **before** their death state was reset in `esx:onPlayerSpawn`. This created a race condition where a player might be killed during `esx:playerLoaded` and then have their death state reset immediately afterward in `esx:onPlayerSpawn`.

Additionally, while not explicitly targeted, this PR also appears to fix a related issue where the death screen in `esx_ambulancejob` would fail to display after combat logging. Since `esx:onPlayerSpawn` is used by `esx_ambulancejob` to remove the death screen (the same event where metadata is applied and the player could potentially die), this change indirectly resolves that behavior. 

To fully address this issue, I will submit a [separate PR to `esx_ambulancejob`](https://github.com/esx-framework/esx_ambulancejob/pull/65) to ensure the death screen logic ignores the first spawn event. This should eliminate any remaining race conditions in the handling of player states. This logic has been fragile for some time, and this PR is a step towards stabilizing it.
