### PR TITLE
fix(esx_skin/client/modules/menu): fix texture variations not updating

### DIFF
--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -164,3 +164,10 @@ function ESX.AssertType(...)
 
     return matches
 end
+
+---@param val unknown
+function ESX.IsFunctionReference(val)
+    local typeVal = type(val)
+
+    return typeVal == "function" or (typeVal == "table" and type(getmetatable(val)?.__call) == "function")
+end

--- a/[core]/esx_skin/client/modules/menu.lua
+++ b/[core]/esx_skin/client/modules/menu.lua
@@ -98,7 +98,7 @@ function Menu:Change(data, menu)
         if element.textureof == data.current.name then
             local component = self.components[i]
 
-            if (ESX.IsFunctionReference(component.max)) then
+            if ESX.IsFunctionReference(component.max) then
                 self.elements[i].max = component.max(PlayerPedId(), skin)
             end
             self.elements[i].value = 0

--- a/[core]/esx_skin/client/modules/menu.lua
+++ b/[core]/esx_skin/client/modules/menu.lua
@@ -47,7 +47,7 @@ function Menu:InsertElements()
             value = GetPedPropIndex(playerPed, self.components[i].componentId)
         end
 
-        local data = self.components[i]
+        local data = table.clone(self.components[i])
         data.value = value
         data.type = "slider"
         data.max = self.maxValues[self.components[i].name]
@@ -78,27 +78,35 @@ function Menu:Change(data, menu)
     Skin.zoomOffset = data.current.zoomOffset
     Skin.camOffset = data.current.camOffset
 
-    if skin[data.current.name] ~= data.current.value then
-        -- Change skin element
-        exports["skinchanger"]:Change(data.current.name, data.current.value)
-        skin[data.current.name] = data.current.value
+    if skin[data.current.name] == data.current.value then
+        return
+    end
 
-        local newData = {}
+    -- Change skin element
+    exports["skinchanger"]:Change(data.current.name, data.current.value)
+    skin[data.current.name] = data.current.value
 
-        for i = 1, #self.elements, 1 do
+    -- Texture variation changed. We don't have to update anything.
+    if data.current.textureof then
+        return
+    end
+
+    -- Texture changed. Update variation max value.
+    for i = 1, #self.elements, 1 do
+        local element = self.elements[i]
+
+        if element.textureof == data.current.name then
             local component = self.components[i]
 
-            newData.max = type(component.max) == "function" and component.max(PlayerPedId(), skin) or component.max
-
-            if self.elements[i].textureof ~= nil and data.current.name == self.elements[i].textureof then
-                newData.value = 0
+            if (ESX.IsFunctionReference(component.max)) then
+                self.elements[i].max = component.max(PlayerPedId(), skin)
             end
+            self.elements[i].value = 0
 
-            menu.update({ name = self.elements[i].name }, newData)
+            menu.update({ name = self.elements[i].name }, self.elements[i])
+            menu.refresh()
+            break
         end
-
-        self.elements = newData
-        menu.refresh()
     end
 end
 

--- a/[core]/skinchanger/config.lua
+++ b/[core]/skinchanger/config.lua
@@ -237,6 +237,7 @@ Config.Components = {
         min = 0,
         zoomOffset = 0.6,
         camOffset = 0.65,
+        textureof = "hair_1",
         max = function(playerPed, Character)
             return GetNumberOfPedTextureVariations(playerPed, 2, Character["hair_1"]) - 1
         end


### PR DESCRIPTION
### Key Changes:
   - In `Menu:InsertElements()`, we now clone the current component before inserting it into the menu. This prevents overwriting the max value, preserving its function reference and ensuring it can still update dynamically on menu changes.

   - Added `ESX.IsFunctionReference` to reliably determine if a value can be treated as a callable function.

   - Limited updates to `self.elements` only when a texture (not a texture variation) changes.
   - Updated only the specific texture variation's max value instead of iterating over and updating the entire menu.

- Added missing texture dependency for texture variation `hair_2`