### PR TITLE
refactor(es_extended/client/modules/death): replace gameEventTriggered

### DIFF
--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -44,12 +44,6 @@ function Death:Natural()
 end
 
 function Death:Damaged(victim)
-    local victimId = NetworkGetPlayerIndexFromPed(victim)
-    local isDead = IsPedDeadOrDying(victim, true) or IsPedFatallyInjured(victim)
-    if victimId ~= ESX.playerId or not isDead then
-        return
-    end
-
     self.killerEntity = GetPedSourceOfDeath(ESX.PlayerData.ped)
     self.deathCause = GetPedCauseOfDeath(ESX.PlayerData.ped)
     self.killerId = NetworkGetPlayerIndexFromPed(self.killerEntity)
@@ -69,7 +63,7 @@ end
 AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
         while not ESX.PlayerData.dead do
-            if IsPedDeadOrDying(ESX.PlayerData.ped, true) then
+            if IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped) then
                 Death:Damaged(ESX.PlayerData.ped)
                 break
             end

--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -29,7 +29,7 @@ function Death:ByPlayer()
     TriggerServerEvent("esx:onPlayerDeath", data)
 end
 
-function Death:Natual()
+function Death:Natural()
     local coords = GetEntityCoords(ESX.PlayerData.ped)
 
     local data = {
@@ -60,7 +60,7 @@ function Death:Damaged(victim)
     if self.killerEntity ~= ESX.PlayerData.ped and self.killerId and isActive then
         self:ByPlayer()
     else
-        self:Natual()
+        self:Natural()
     end
 
     self:ResetValues()

--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -43,7 +43,7 @@ function Death:Natural()
     TriggerServerEvent("esx:onPlayerDeath", data)
 end
 
-function Death:Damaged(victim)
+function Death:Damaged()
     self.killerEntity = GetPedSourceOfDeath(ESX.PlayerData.ped)
     self.deathCause = GetPedCauseOfDeath(ESX.PlayerData.ped)
     self.killerId = NetworkGetPlayerIndexFromPed(self.killerEntity)
@@ -64,7 +64,7 @@ AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
         while not ESX.PlayerData.dead do
             if IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped) then
-                Death:Damaged(ESX.PlayerData.ped)
+                Death:Damaged()
                 break
             end
             Citizen.Wait(250)

--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -43,19 +43,7 @@ function Death:Natual()
     TriggerServerEvent("esx:onPlayerDeath", data)
 end
 
-function Death:Damaged(victim, victimDied)
-    if not victimDied then
-        return
-    end
-
-    if not IsEntityAPed(victim) then
-        return
-    end
-
-    if not IsPedAPlayer(victim) then
-        return
-    end
-
+function Death:Damaged(victim)
     local victimId = NetworkGetPlayerIndexFromPed(victim)
     local isDead = IsPedDeadOrDying(victim, true) or IsPedFatallyInjured(victim)
     if victimId ~= ESX.playerId or not isDead then
@@ -78,9 +66,14 @@ function Death:Damaged(victim, victimDied)
     self:ResetValues()
 end
 
-AddEventHandler("gameEventTriggered", function(event, data)
-    if event ~= "CEventNetworkEntityDamage" then
-        return
-    end
-    Death:Damaged(data[1], data[4])
+AddEventHandler("esx:onPlayerSpawn", function()
+    Citizen.CreateThreadNow(function()
+        while not ESX.PlayerData.dead do
+            if IsPedDeadOrDying(ESX.PlayerData.ped, true) then
+                Death:Damaged(ESX.PlayerData.ped)
+                break
+            end
+            Citizen.Wait(250)
+        end
+    end)
 end)

--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -43,7 +43,7 @@ function Death:Natural()
     TriggerServerEvent("esx:onPlayerDeath", data)
 end
 
-function Death:Damaged()
+function Death:Died()
     self.killerEntity = GetPedSourceOfDeath(ESX.PlayerData.ped)
     self.deathCause = GetPedCauseOfDeath(ESX.PlayerData.ped)
     self.killerId = NetworkGetPlayerIndexFromPed(self.killerEntity)
@@ -64,7 +64,7 @@ AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
         while not ESX.PlayerData.dead do
             if IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped) then
-                Death:Damaged()
+                Death:Died()
                 break
             end
             Citizen.Wait(250)


### PR DESCRIPTION
### Description
This refactor replaces the use of `gameEventTriggered` with a more efficient, thread-based solution for handling player deaths. The previous approach relied on the `CEventNetworkEntityDamage` event, which was triggered too often, specifically for non-lethal events like vehicle crashes, causing unnecessary performance overhead. The new solution checks for player death deterministically in a thread, only triggering the death event when a player is confirmed dead.

Additionally, the typo in the `Natual` function name was corrected to `Natural` for consistency.

--- 

### Motivation
This change was motivated by concerns raised by @Gellipapa about the inefficiency of using `CEventNetworkEntityDamage` for detecting player deaths. 

