### PR TITLE
fix(esx_multicharacter/server/modules/database): improve database name extraction

### DIFF
--- a/[core]/esx_multicharacter/server/modules/database.lua
+++ b/[core]/esx_multicharacter/server/modules/database.lua
@@ -13,17 +13,11 @@ function Database:GetConnection()
 
         self.name = connectionString:sub(connectionString:find("/") + 1, -1):gsub("[%?]+[%w%p]*$", "")
         self.found = true
+    elseif connectionString:find("database=") then
+        self.name = connectionString:match("database=([^;?]+)"):gsub("[%?]+[%w%p]*$", "")
+        self.found = true
     else
-        local connectionExtracted = { string.strsplit(";", connectionString) }
-
-        for i = 1, #connectionExtracted do
-            local v = connectionExtracted[i]
-            if v:match("database") then
-                self.name = connectionString:sub(connectionString:find("/") + 1, -1):gsub("[%?]+[%w%p]*$", "")
-                self.found = true
-                break
-            end
-        end
+        error(connectionString .. "\n^1Unable to start Multicharacter - unable to get database name from mysql_connection_string^0", 0)
     end
 end
 


### PR DESCRIPTION
This fix resolves an issue where parsing the `mysql_connection_string` in the format `user=root;password=12345;host=localhost;port=3306;database=fivem` would throw an error `attempt to perform arithmetic on a nil value`. Additionally, i added a error log if database name is not found in the `mysql_connection_string`