### PR TITLE
chore(es_extended/server): add missing identifier config

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -368,8 +368,8 @@ function ESX.GetIdentifier(playerId)
 
     playerId = tostring(playerId)
 
-    local identifier = GetPlayerIdentifierByType(playerId, "license")
-    return identifier and identifier:gsub("license:", "")
+    local identifier = GetPlayerIdentifierByType(playerId, Config.Identifier)
+    return identifier and identifier:gsub(("%s:"):format(Config.Identifier), "")
 end
 
 ---@param model string|number

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -1,5 +1,8 @@
 Config = {}
 
+-- Identifier type for the player (e.g., license, steam, discord). See https://docs.fivem.net/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers/ for more details.
+Config.Identifier = "license"
+
 -- for ox inventory, use Config.CustomInventory = "ox", for others, set to "resource_name"
 Config.CustomInventory = false
 


### PR DESCRIPTION
I noticed that the Config.Identifier was being used in esx_multicharacter but not existing on es_extended config so i added it.

https://github.com/esx-framework/esx_core/blob/efafa58eb2e24c3bd0464d50ae86f9639da52b67/%5Bcore%5D/esx_multicharacter/server/main.lua#L7