### PR TITLE
feat(es_extended/client/main): sync where players look at

### DIFF
--- a/[core]/es_extended/client/main.lua
+++ b/[core]/es_extended/client/main.lua
@@ -44,6 +44,7 @@ RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
     Actions:Init()
     StartPointsLoop()
     StartServerSyncLoops()
+    NetworkSetLocalPlayerSyncLookAt(true)
 end)
 
 local isFirstSpawn = true


### PR DESCRIPTION
### Description
Introduced [`NetworkSetLocalPlayerSyncLookAt`](https://docs.fivem.net/natives/?_0x524FF0AEFF9C3973), enabling synchronization of where players are looking between clients.

---

### Credits
Discovered while exploring the [Cfx Discord](https://discord.com/channels/192358910387159041/1219992387833561119/1224296191320395786). Special thanks to @glowicosahedron for sharing this information and providing the demonstration video.

[Video Preview](https://github.com/user-attachments/assets/23a6a37b-9ac9-4554-ae07-1de8e562bcea)
