### PR TITLE
feat(es_extended/server/modules/commands): add /setdim cmd

### DIFF
--- a/[core]/es_extended/locales/en.lua
+++ b/[core]/es_extended/locales/en.lua
@@ -114,9 +114,11 @@ Locales["en"] = {
     ["commanderror_invalidcommand"] = "Invalid Command - /%s",
     ["commanderror_invalidplayerid"] = "Specified Player is not online",
     ["commandgeneric_playerid"] = "Player`s Server Id",
+    ["commandgeneric_dimension"] = "Target Dimension",
     ["command_giveammo_noweapon_found"] = "%s does not have that weapon",
     ["command_giveammo_weapon"] = "Weapon name",
     ["command_giveammo_ammo"] = "Ammo Quantity",
+    ["command_setdim"] = "Set a players dimension",
     ["tpm_nowaypoint"] = "No Waypoint Set.",
     ["tpm_success"] = "Successfully Teleported",
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -299,14 +299,14 @@ function ESX.GetExtendedPlayers(key, val)
 
     local xPlayers = {}
     if type(val) == "table" then
-        for i, xPlayer in pairs(ESX.Players) do
+        for _, xPlayer in pairs(ESX.Players) do
             checkTable(key, val, xPlayer, xPlayers)
         end
 
         return xPlayers
     end
 
-    for i, xPlayer in pairs(ESX.Players) do
+    for _, xPlayer in pairs(ESX.Players) do
         if (key == "job" and xPlayer.job.name == val) or xPlayer[key] == val then
             xPlayers[#xPlayers + 1] = xPlayer
         end

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -593,9 +593,12 @@ ESX.RegisterCommand(
     "admin",
     function(xPlayer, args)
         local targetCoords = args.playerId.getCoords()
+        local srcDim = GetPlayerRoutingBucket(xPlayer.source)
         local targetDim = GetPlayerRoutingBucket(args.playerId.source)
 
-        SetPlayerRoutingBucket(xPlayer.source, targetDim)
+        if srcDim ~= targetDim then
+            SetPlayerRoutingBucket(xPlayer.source, targetDim)
+        end
         xPlayer.setCoords(targetCoords)
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "Admin Teleport /goto Triggered!", "pink", {
@@ -622,9 +625,12 @@ ESX.RegisterCommand(
     function(xPlayer, args)
         local targetCoords = args.playerId.getCoords()
         local playerCoords = xPlayer.getCoords()
+        local targetDim = GetPlayerRoutingBucket(args.playerId.source)
         local srcDim = GetPlayerRoutingBucket(xPlayer.source)
 
-        SetPlayerRoutingBucket(args.playerId.source, srcDim)
+        if targetDim ~= srcDim then
+            SetPlayerRoutingBucket(args.playerId.source, srcDim)
+        end
         args.playerId.setCoords(playerCoords)
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "Admin Teleport /bring Triggered!", "pink", {

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -732,3 +732,28 @@ ESX.RegisterCommand("players", "admin", function()
         print(("^1[^2ID: ^5%s^0 | ^2Name : ^5%s^0 | ^2Group : ^5%s^0 | ^2Identifier : ^5%s^1]^0\n"):format(xPlayer.source, xPlayer.getName(), xPlayer.getGroup(), xPlayer.identifier))
     end
 end, true)
+
+ESX.RegisterCommand(
+    {"setdim", "setbucket"},
+    "admin",
+    function(xPlayer, args)
+        SetPlayerRoutingBucket(args.playerId.source, args.dimension)
+        if Config.AdminLogging then
+            ESX.DiscordLogFields("UserActions", "Admin Set Dim /setdim Triggered!", "pink", {
+                { name = "Player", value = xPlayer and xPlayer.name or "Server Console", inline = true },
+                { name = "ID", value = xPlayer and xPlayer.source or "Unknown ID", inline = true },
+                { name = "Target", value = args.playerId.name, inline = true },
+                { name = "Dimension", value = args.dimension, inline = true },
+            })
+        end
+    end,
+    true,
+    {
+        help = TranslateCap("command_setdim"),
+        validate = true,
+        arguments = {
+            { name = "playerId", help = TranslateCap("commandgeneric_playerid"), type = "player" },
+            { name = "dimension", help = TranslateCap("commandgeneric_dimension"), type = "number" },
+        },
+    }
+)

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -593,6 +593,9 @@ ESX.RegisterCommand(
     "admin",
     function(xPlayer, args)
         local targetCoords = args.playerId.getCoords()
+        local targetDim = GetPlayerRoutingBucket(args.playerId.source)
+
+        SetPlayerRoutingBucket(xPlayer.source, targetDim)
         xPlayer.setCoords(targetCoords)
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "Admin Teleport /goto Triggered!", "pink", {
@@ -619,6 +622,9 @@ ESX.RegisterCommand(
     function(xPlayer, args)
         local targetCoords = args.playerId.getCoords()
         local playerCoords = xPlayer.getCoords()
+        local srcDim = GetPlayerRoutingBucket(xPlayer.source)
+
+        SetPlayerRoutingBucket(args.playerId.source, srcDim)
         args.playerId.setCoords(playerCoords)
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "Admin Teleport /bring Triggered!", "pink", {


### PR DESCRIPTION
### Description
This PR resolves an issue where teleporting to another player or bringing a player to you as an admin did not ensure that both players were in the same dimension. This behavior is counterintuitive, as admins would expect the player to appear directly in front of them, not in a different dimension. To address this, the commands now automatically set both players to the same dimension during teleportation. Additionally, a `/setdim` admin command has been added to allow manual dimension adjustments if necessary.

### Key Changes
- Added the `/setdim <targetSrc> <targetDim>` admin command, allowing admins to manually set a player's dimension.
- Updated the `/goto` and `/bring` admin commands to ensure both players are placed in the same dimension during teleportation.

---
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.