### PR TITLE
feat(es_extended/shared/main): restore backwards compat

### DIFF
--- a/[core]/es_extended/shared/main.lua
+++ b/[core]/es_extended/shared/main.lua
@@ -4,9 +4,12 @@ exports("getSharedObject", function()
     return ESX
 end)
 
-AddEventHandler("esx:getSharedObject", function()
-    local Invoke = GetInvokingResource()
-    error(("Resource ^5%s^1 Used the ^5getSharedObject^1 Event, this event ^1no longer exists!^1 Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent for how to fix!"):format(Invoke))
+AddEventHandler("esx:getSharedObject", function(cb)
+    if ESX.IsFunctionReference(cb) then
+        cb(ESX)
+    end
+    local invokingResource = GetInvokingResource()
+    print(("^3[WARNING]^0 Resource ^5%s^0 used the ^5getSharedObject^0 event. This is not the recommended way to import ESX. Visit https://documentation.esx-framework.org/tutorials/tutorials-esx/sharedevent to find out why."):format(invokingResource))
 end)
 
 -- backwards compatibility (DO NOT TOUCH !) 


### PR DESCRIPTION
### Description

This PR brings back the `esx:getSharedObject` event, a key feature that was removed in ESX 1.9 after being deprecated in 1.8.5. The removal of this event caused compatibility issues with many legacy scripts, leading to frustration in the community.

The proposed solution restores the event and includes a **warning message** encouraging developers to migrate to newer methods. This approach keeps backward compatibility for existing resources while gently guiding the community toward best practices.

---

### Justification

1. **No Good Reason for Removal**  
   - The removal of the `esx:getSharedObject` event didn't come with a clear, justified reason. It was widely used across the ESX ecosystem, and removing it created unnecessary issues. The lack of a technical need for this change meant that many developers and server owners were left with broken setups for no good reason.

2. **Preserving Backward Compatibility**  
   - While using imports is now the preferred method for accessing ESX, one of the core philosophies of ESX has always been to avoid breaking backward compatibility without a valid reason. By removing the event, we risked sending the message that ESX could remove features at will, which undermines the trust that developers and server owners have in the framework.  
   - ESX should be a stable framework that evolves without breaking existing setups. Reintroducing this event helps restore that trust and shows that we’re committed to supporting older systems while promoting newer best practices.

3. **Supporting Legacy and Abandoned Scripts**  
   - Many older scripts, especially paid or escrowed ones that are no longer maintained, still rely on the `esx:getSharedObject` event. These scripts can't be easily updated to the new import system, and removing the event effectively rendered them useless.  
   - Server owners should have the freedom to use older scripts if they choose, without being forced into major changes. Bringing this event back ensures that these older resources continue to work, offering a smoother experience for server owners who prefer or need to use them.

4. **Clear Communication for a Smooth Transition**  
   - It’s important to encourage the community to adopt newer methods, but we also need to respect that many developers and server owners are still using older practices. It's not our place to dictate a switch to imports. We provide the best practices and and communicate them as such, but ultimately, it's up to the server owners to decide what works best for them.
   - The warning encourages developers to migrate to the newer import methods, while also linking to the documentation for further guidance. This provides a clear and accessible way forward for those who want to upgrade.

### Conclusion

Bringing back the `esx:getSharedObject` event is an important step in rebuilding trust with the community and ensuring compatibility with older scripts. While we continue to encourage the adoption of better practices, it's essential that ESX evolves in a way that doesn’t break existing functionality. By doing this, we show that we value developer confidence, backward compatibility, and a smooth transition for all users of the ESX framework.

---
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
