### PR TITLE
feat(es_extended/client/modules/actions): track current ped weapon

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -4,6 +4,7 @@ Actions._index = Actions
 Actions.inVehicle = false
 Actions.enteringVehicle = false
 Actions.inPauseMenu = false
+Actions.currentWeapon = false
 
 function Actions:GetSeatPedIsIn()
     for i = -1, 16 do
@@ -132,12 +133,24 @@ function Actions:TrackVehicle()
     end
 end
 
+function Actions:TrackWeapon()
+    ---@type number|false
+    local newWeapon = GetSelectedPedWeapon(ESX.PlayerData.ped)
+    newWeapon = newWeapon ~= `WEAPON_UNARMED` and newWeapon or false
+
+    if newWeapon ~= self.currentWeapon then
+        self.currentWeapon = newWeapon
+        TriggerEvent("esx:weaponChanged", self.currentWeapon)
+    end
+end
+
 function Actions:SlowLoop()
     CreateThread(function()
         while ESX.PlayerLoaded do
             self:TrackPedCoords()
             self:TrackPauseMenu()
             self:TrackVehicle()
+            self:TrackWeapon()
             Wait(500)
         end
     end)


### PR DESCRIPTION
### Description
This PR improves the `actions` module by adding functionality to track the currently selected weapon of the player's ped. This eliminates the redundancy of multiple third-party scripts performing the same tracking, reducing overhead. Centralizing this in ESX ensures consistency and simplifies development for server owners and script developers.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.