### PR TITLE
feat(es_extended/client/modules/actions): track vehicle seat & add weapon playerdata

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -130,6 +130,20 @@ function Actions:TrackVehicle()
         end
     elseif self.inVehicle then
         self:ExitVehicle()
+        self:TrackSeat()
+    end
+end
+
+function Actions:TrackSeat()
+    if not self.inVehicle then
+        return
+    end
+
+    local newSeat = self:GetSeatPedIsIn()
+    if newSeat ~= self.seat then
+        self.seat = newSeat
+        ESX.SetPlayerData("seat", self.seat)
+        TriggerEvent("esx:vehicleSeatChanged", self.seat)
     end
 end
 

--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -154,6 +154,7 @@ function Actions:TrackWeapon()
 
     if newWeapon ~= self.currentWeapon then
         self.currentWeapon = newWeapon
+        ESX.SetPlayerData("weapon", self.currentWeapon)
         TriggerEvent("esx:weaponChanged", self.currentWeapon)
     end
 end


### PR DESCRIPTION
### Description

This PR ensures that the vehicle seat  in the player data is properly updated when a seat change occurs, such as through shuffling or seat-switching scripts. Additionally, the player's current weapon has been added to the player data.

---
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.