### PR TITLE
fix(es_extended/client/modules/death): fix death event for multichar relog

### DIFF
--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -62,7 +62,7 @@ end
 
 AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
-        while not ESX.PlayerData.dead do
+        while ESX.PlayerLoaded and not ESX.PlayerData.dead do
             if IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped) then
                 Death:Died()
                 break


### PR DESCRIPTION
### Description
This PR resolves an issue with death detection during multicharacter relogging. Previously, relogging could incorrectly trigger the death event, causing the death screen to appear unexpectedly. Additionally, this PR ensures that no concurrent threads are created during relogging, preventing the death event from being triggered multiple times.

---
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.