### PR TITLE
feat(es_extended): add promise support for vehicle spawn functions

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -532,7 +532,7 @@ end
 ---@param heading number The heading of the vehicle
 ---@param cb? function The callback function
 ---@param networked? boolean Whether the vehicle should be networked
----@return nil
+---@return number? vehicle
 function ESX.Game.SpawnVehicle(vehicleModel, coords, heading, cb, networked)
     local model = type(vehicleModel) == "number" and vehicleModel or joaat(vehicleModel)
     local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -530,10 +530,14 @@ end
 ---@param vehicleModel integer | string The vehicle to spawn
 ---@param coords table | vector3 The coords to spawn the vehicle at
 ---@param heading number The heading of the vehicle
----@param cb? function The callback function
+---@param cb? fun(vehicle: number) The callback function
 ---@param networked? boolean Whether the vehicle should be networked
 ---@return number? vehicle
 function ESX.Game.SpawnVehicle(vehicleModel, coords, heading, cb, networked)
+    if cb and not ESX.IsFunctionReference(cb) then
+        error("Invalid callback function")
+    end
+
     local model = type(vehicleModel) == "number" and vehicleModel or joaat(vehicleModel)
     local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
     local isNetworked = networked == nil or networked

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -549,6 +549,7 @@ function ESX.Game.SpawnVehicle(vehicleModel, coords, heading, cb, networked)
         return error(("Resource ^5%s^1 Tried to spawn vehicle on the client but the position is too far away (Out of onesync range)."):format(executingResource))
     end
 
+    local promise = not cb and promise.new()
     CreateThread(function()
         ESX.Streaming.RequestModel(model)
 
@@ -569,10 +570,16 @@ function ESX.Game.SpawnVehicle(vehicleModel, coords, heading, cb, networked)
             Wait(0)
         end
 
-        if cb then
+        if promise then
+            promise:resolve(vehicle)
+        elseif cb then
             cb(vehicle)
         end
     end)
+
+    if promise then
+        return Citizen.Await(promise)
+    end
 end
 
 ---@param vehicle integer The vehicle to spawn

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -551,7 +551,13 @@ function ESX.Game.SpawnVehicle(vehicleModel, coords, heading, cb, networked)
 
     local promise = not cb and promise.new()
     CreateThread(function()
-        ESX.Streaming.RequestModel(model)
+        local modelHash = ESX.Streaming.RequestModel(model)
+        if not modelHash then
+            if promise then
+                return promise:reject(("Tried to spawn invalid vehicle - ^5%s^7!"):format(model))
+            end
+           error(("Tried to spawn invalid vehicle - ^5%s^7!"):format(model))
+        end
 
         local vehicle = CreateVehicle(model, vector.x, vector.y, vector.z, heading, isNetworked, true)
 

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -123,9 +123,9 @@ function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
             local networkId = NetworkGetNetworkIdFromEntity(createdVehicle)
             Entity(createdVehicle).state:set("VehicleProperties", vehicleProperties, true)
             if promise then
-                return promise:resolve(networkId)
+                promise:resolve(networkId)
             elseif cb then
-                return cb(networkId)
+                cb(networkId)
             end
         end)
     end)

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -83,7 +83,7 @@ end
 ---@param heading number
 ---@param properties table
 ---@param cb? fun(netId: number)
----@return number|nil netId
+---@return number? netId
 function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
     if cb and not ESX.IsFunctionReference(cb) then
         error("Invalid callback function")

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -82,35 +82,57 @@ end
 ---@param coords vector3|table
 ---@param heading number
 ---@param properties table
----@param cb function
+---@param cb? fun(netId: number)
+---@return number|nil netId
 function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
+    if cb and not ESX.IsFunctionReference(cb) then
+        error("Invalid callback function")
+    end
+
+
     local vehicleModel = joaat(model)
     local vehicleProperties = properties
 
+    local promise = not cb and promise.new()
     CreateThread(function()
         local xPlayer = ESX.OneSync.GetClosestPlayer(coords, 300)
         ESX.GetVehicleType(vehicleModel, xPlayer.id, function(vehicleType)
-            if vehicleType then
-                local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
-                local tries = 0
-
-                while not createdVehicle or createdVehicle == 0 or not GetEntityCoords(createdVehicle) do
-                    Wait(200)
-                    tries = tries + 1
-                    if tries > 20 then
-                        return  error(("Could not spawn vehicle - ^5%s^7!"):format(model))
-                    end
+            if not vehicleType then
+                if (promise) then
+                    return promise:reject(("Tried to spawn invalid vehicle - ^5%s^7!"):format(model))
                 end
-                -- luacheck: ignore
-                SetEntityOrphanMode(createdVehicle, 2)
-                local networkId = NetworkGetNetworkIdFromEntity(createdVehicle)
-                Entity(createdVehicle).state:set("VehicleProperties", vehicleProperties, true)
-                cb(networkId)
-            else
                 error(("Tried to spawn invalid vehicle - ^5%s^7!"):format(model))
+            end
+
+            local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
+            local tries = 0
+
+            while not createdVehicle or createdVehicle == 0 or not GetEntityCoords(createdVehicle) do
+                Wait(200)
+                tries = tries + 1
+                if tries > 20 then
+                    if promise then
+                        return promise:reject(("Could not spawn vehicle - ^5%s^7!"):format(model))
+                    end
+                    error(("Could not spawn vehicle - ^5%s^7!"):format(model))
+                end
+            end
+
+            -- luacheck: ignore
+            SetEntityOrphanMode(createdVehicle, 2)
+            local networkId = NetworkGetNetworkIdFromEntity(createdVehicle)
+            Entity(createdVehicle).state:set("VehicleProperties", vehicleProperties, true)
+            if promise then
+                return promise:resolve(networkId)
+            elseif cb then
+                return cb(networkId)
             end
         end)
     end)
+
+    if promise then
+        return Citizen.Await(promise)
+    end
 end
 
 ---@param model number|string


### PR DESCRIPTION
### Description
This PR enhances the ESX vehicle spawn functions to allow waiting for vehicle creation using promises, instead of requiring a callback function. Additionally, a resource leak in the `ESX.Game.SpawnVehicle` function has been addressed. The function now returns immediately when an invalid vehicle is requested instead of creating stale threads.

### Example
```lua
local vehicle = ESX.Game.SpawnVehicle(model, coords, heading)
local vehNetId = ESX.OneSync.SpawnVehicle(model, coords, heading, vehProps)
```

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.