### PR TITLE
feat(es_extended) Add ESX.Await function

### DIFF
--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -192,6 +192,7 @@ function ESX.Await(conditionFunc, errorMessage, timeoutMs)
         ESX.AssertType(errorMessage, "string", "errorMessage should be a string.")
     end
 
+    local invokingResource = GetInvokingResource()
     local startTimeMs = GetGameTimer()
     while GetGameTimer() - startTimeMs < timeoutMs do
         local result = conditionFunc()
@@ -204,7 +205,7 @@ function ESX.Await(conditionFunc, errorMessage, timeoutMs)
     end
 
     if errorMessage then
-        error(("[%s] -> %s"):format(GetInvokingResource(), errorMessage))
+        error(("[%s] -> %s"):format(invokingResource, errorMessage))
     end
 
     return false

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -189,18 +189,16 @@ ESX.Await = function(conditionFunc, errorMessage, timeout)
         error('Condition Function should be a function reference.')
     end
 
+    -- since errorMessage is optional, we only validate it if the user provided it.
+    if errorMessage then
+        ESX.AssertType(errorMessage, 'string', 'errorMessage should be a string.')
+    end
+
     local startTime = GetGameTimer()
     local prefix = ('[%s] -> '):format(GetInvokingResource())
 
     while GetGameTimer() - startTime < timeout do
-        local success, result = pcall(conditionFunc)
-
-        if not success then
-            local conditionErrorMessage = ('%s Error while calling conditionFunc! Result: %s'):format(prefix, result)
-            print(conditionErrorMessage)
-            local elapsedTime = GetGameTimer() - startTime
-            return false, elapsedTime
-        end
+        local result = conditionFunc()
 
         if result then
             local elapsedTime = GetGameTimer() - startTime
@@ -211,10 +209,8 @@ ESX.Await = function(conditionFunc, errorMessage, timeout)
     end
 
     if errorMessage then
-        ESX.AssertType(errorMessage, 'string', 'errorMessage should be a string.')
-
         local formattedErrorMessage = ('%s %s'):format(prefix, errorMessage)
-        print(formattedErrorMessage)
+        error(formattedErrorMessage)
     end
 
     return false, timeout


### PR DESCRIPTION
This PR adds a utility function, ESX.Await, to simplify waiting for a condition without the need for manual loops. It checks a condition repeatedly until it’s met or the timeout is reached.

Example usage:

```lua
local networkId = ESX.AwaitServerCallback('spawnVehicle')

local function awaitExistence()
    return NetworkDoesEntityExistWithNetworkId(networkId)
end

-- timeElapsed value in MS
local success, timeElapsed = ESX.Await(awaitExistence, 'Timed out :(', 3000)

-- we can now mess with the vehicle spawned server-side on the client-side
```

