### PR TITLE
fix(es_extended/client/modules/actions) EnterVehicle wrong variable name assign

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -65,7 +65,7 @@ function Actions:EnterVehicle()
 
     local _, netId, plate = self:GetVehicleData()
 
-    self.isEnteringVehicle = true
+    self.enteringVehicle = true
     TriggerEvent("esx:enteringVehicle", self.vehicle, plate, self.seat, netId)
     TriggerServerEvent("esx:enteringVehicle", plate, self.seat, netId)
 


### PR DESCRIPTION
This PR fixes the EnterAborted event in actions.lua. 
Previously, EnterVehicle was incorrectly setting `self.isEnteringVehicle` 
instead of `self.enteringVehicle`, causing an infinite `ESX.PlayerData.vehicle` 
state if the player aborted entering the vehicle.
