### PR TITLE
feat(es_extended/shared): add ox inventory detection back

### DIFF
--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -51,9 +51,13 @@ Config.DistanceGive = 4.0 -- Max distance when giving items, weapons etc.
 
 Config.AdminLogging = false -- Logs the usage of certain commands by those with group.admin ace permissions (default is false)
 
---------------------------------------------------------------------
--- DO NOT CHANGE BELOW THIS LINE UNLESS YOU KNOW WHAT YOU ARE DOING
---------------------------------------------------------------------
+-------------------------------------
+-- DO NOT CHANGE BELOW THIS LINE !!!
+-------------------------------------
+if GetResourceState("ox_inventory") ~= "missing" then
+    Config.CustomInventory = "ox"
+end
+
 Config.EnableDefaultInventory = Config.CustomInventory == false -- Display the default Inventory ( F2 )
 
 local txAdminLocale = GetConvar("txAdmin-locale", "en")

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -1,6 +1,6 @@
 Config = {}
 
--- for ox inventory, use Config.CustomInventory = "ox", for others, set to "resource_name"
+-- for ox inventory, this will automatically be adjusted, do not change! for other inventories, change to "resource_name"
 Config.CustomInventory = false
 
 Config.Accounts = {


### PR DESCRIPTION
This PR brings ox inventory detection back, because it seems users are unable to read a very simple message