### PR TITLE
fix(es_extended/client/functions): Fixed notification event

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1525,11 +1525,11 @@ function ESX.ShowInventory()
     end)
 end
 
-ESX.SecureNetEvent('esx:showNotification', ESX.ShowNotification)
+RegisterNetEvent('esx:showNotification', ESX.ShowNotification)
 
-ESX.SecureNetEvent('esx:showAdvancedNotification', ESX.ShowAdvancedNotification)
+RegisterNetEvent('esx:showAdvancedNotification', ESX.ShowAdvancedNotification)
 
-ESX.SecureNetEvent('esx:showHelpNotification', ESX.ShowHelpNotification)
+RegisterNetEvent('esx:showHelpNotification', ESX.ShowHelpNotification)
 
 AddEventHandler("onResourceStop", function(resourceName)
     for i = 1, #ESX.UI.Menu.Opened, 1 do


### PR DESCRIPTION
Not sure why this was changed to `ESX.SecureNetEvent` but other resources that call this event themselves doesn't display notifications.