### PR TITLE
fix(es_extended/server/functions): Core.IsPlayerAdmin returning false

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -610,6 +610,6 @@ function Core.IsPlayerAdmin(playerId)
         return true
     end
 
-    local xPlayer = ESX.Players[playerId]
-    return (xPlayer and Config.AdminGroups[xPlayer.group] and true) or false
+    local xPlayer = ESX.Players[tonumber(playerId)]
+    return xPlayer and Config.AdminGroups[xPlayer.group] or false
 end


### PR DESCRIPTION
For some strange reason, the original code `local xPlayer = ESX.Players[playerId]` always returned `null`. However, when changed to `local xPlayer = ESX.Players[tonumber(playerId)]`, it correctly returned the data. Not sure if this is an issue just for me.