### PR TITLE
feat(es_extended/server/classes/vehicle): add vehicle class

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -25,6 +25,7 @@ server_scripts {
 	'server/common.lua',
 	'server/modules/callback.lua',
 	'server/classes/player.lua',
+	'server/classes/vehicle.lua',
 	'server/classes/overrides/*.lua',
 	'server/functions.lua',
 	'server/modules/onesync.lua',

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -53,6 +53,7 @@ Core.vehicleClass = {
 		Entity(entity).state:set("owner", owner, false)
 		Entity(entity).state:set("plate", plate, false)
 
+		---@type CVehicleData
 		local vehicleData = {
 			plate = plate,
 			entity = entity,

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -63,7 +63,7 @@ Core.vehicleClass = {
 		}
 		Core.vehicles[plate] = vehicleData
 
-		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 0 WHERE `owner` = ? AND `plate` = ?", { owner, plate })
+		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = false WHERE `owner` = ? AND `plate` = ?", { owner, plate })
 
 		local obj = table.clone(Core.vehicleClass)
 		obj.plate = plate

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -38,10 +38,10 @@ Core.vehicleClass = {
 		vehicleProps = json.decode(vehicleProps)
 
 		if type(vehicleProps.model) ~= "number" then
-			model = joaat(model)
+			vehicleProps.model = joaat(vehicleProps.model)
 		end
 
-		local netId = ESX.OneSync.SpawnVehicle(model, coords.xyz, coords.w, vehicleProps)
+		local netId = ESX.OneSync.SpawnVehicle(vehicleProps.model, coords.xyz, coords.w, vehicleProps)
 		if not netId then
 			return
 		end
@@ -56,7 +56,7 @@ Core.vehicleClass = {
 			plate = plate,
 			entity = entity,
 			netId = netId,
-			modelHash = model,
+			modelHash = vehicleProps.model,
 			owner = owner,
 		}
 		Core.vehicles[plate] = vehicle

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -1,24 +1,24 @@
----@class VehicleData
+---@class CVehicleData
 ---@field plate string
 ---@field netId number
 ---@field entity number
 ---@field modelHash number
 ---@field owner string
 
----@class VehicleClass
+---@class CExtendedVehicle
 ---@field plate string
----@field isValid fun(self:VehicleClass):boolean
----@field new fun(owner:string, plate:string, coords:vector4): VehicleClass?
----@field getFromPlate fun(plate:string):VehicleClass?
----@field getPlate fun(self:VehicleClass):string?
----@field getNetId fun(self:VehicleClass):number?
----@field getEntity fun(self:VehicleClass):number?
----@field getModelHash fun(self:VehicleClass):number?
----@field getOwner fun(self:VehicleClass):string?
----@field setPlate fun(self:VehicleClass, newPlate:string):boolean
----@field setProps fun(self:VehicleClass, props:table):boolean
----@field setOwner fun(self:VehicleClass, newOwner:string):boolean
----@field delete fun(self:VehicleClass, garageName:string?, isImpound:boolean?):nil
+---@field isValid fun(self:CExtendedVehicle):boolean
+---@field new fun(owner:string, plate:string, coords:vector4): CExtendedVehicle?
+---@field getFromPlate fun(plate:string):CExtendedVehicle?
+---@field getPlate fun(self:CExtendedVehicle):string?
+---@field getNetId fun(self:CExtendedVehicle):number?
+---@field getEntity fun(self:CExtendedVehicle):number?
+---@field getModelHash fun(self:CExtendedVehicle):number?
+---@field getOwner fun(self:CExtendedVehicle):string?
+---@field setPlate fun(self:CExtendedVehicle, newPlate:string):boolean
+---@field setProps fun(self:CExtendedVehicle, newProps:table):boolean
+---@field setOwner fun(self:CExtendedVehicle, newOwner:string):boolean
+---@field delete fun(self:CExtendedVehicle, garageName:string?, isImpound:boolean?):nil
 Core.vehicleClass = {
 	plate = "",
 	new = function(owner, plate, coords)
@@ -159,20 +159,20 @@ Core.vehicleClass = {
 
 		return true
 	end,
-	setProps = function(self, props)
+	setProps = function(self, newProps)
 		if not self:isValid() then
 			return false
 		end
-		assert(type(props) == "table", "Expected 'props' to be a table")
+		assert(type(newProps) == "table", "Expected 'props' to be a table")
 
 		local xVehicle = Core.vehicles[self.plate]
-		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(props), xVehicle.plate, xVehicle.owner)
+		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(newProps), xVehicle.plate, xVehicle.owner)
 		if affectedRows <= 0 then
 			self:delete()
 			return false
 		end
 
-		Entity(xVehicle.entity).state:set("VehicleProperties", props, true)
+		Entity(xVehicle.entity).state:set("VehicleProperties", newProps, true)
 
 		return true
 	end,

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -51,6 +51,7 @@ Core.vehicleClass = {
 			return
 		end
 		Entity(entity).state:set("owner", owner, false)
+		Entity(entity).state:set("plate", plate, false)
 
 		local vehicle = {
 			plate = plate,
@@ -86,13 +87,7 @@ Core.vehicleClass = {
 		end
 
 		local entity = NetworkGetEntityFromNetworkId(xVehicle.netId)
-		if entity <= 0 or Entity(entity).state.owner ~= xVehicle.owner then
-			self:delete()
-			return false
-		end
-
-		local plate = ESX.Math.Trim(GetVehicleNumberPlateText(entity))
-		if plate ~= xVehicle.plate then
+		if entity <= 0 or Entity(entity).state.owner ~= xVehicle.owner or Entity(entity).state.plate ~= xVehicle.plate then
 			self:delete()
 			return false
 		end
@@ -143,6 +138,7 @@ Core.vehicleClass = {
 		assert(type(plate) == "string", "Expected 'plate' to be a string")
 
 		local xVehicle = Core.vehicles[self.plate]
+		Entity(xVehicle.entity).state:set("plate", plate, false)
 		SetVehicleNumberPlateText(xVehicle.entity, plate)
 		xVehicle.plate = plate
 		MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -147,7 +147,14 @@ Core.vehicleClass = {
 
 		Entity(xVehicle.entity).state:set("plate", plate, false)
 		SetVehicleNumberPlateText(xVehicle.entity, plate)
+
+		local oldPlate = xVehicle.plate
 		xVehicle.plate = plate
+		Core.vehicles[plate] = table.clone(xVehicle)
+		Core.vehicles[self.plate] = nil
+
+		TriggerEvent("esx:changedExtendedVehiclePlate", xVehicle.plate, oldPlate)
+		Wait(0)
 
 		return true
 	end,

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -14,7 +14,6 @@
 ---@field getNetId fun(self:VehicleClass):number?
 ---@field getEntity fun(self:VehicleClass):number?
 ---@field getModelHash fun(self:VehicleClass):number?
----@field getProps fun(self:VehicleClass):table?
 ---@field getOwner fun(self:VehicleClass):string?
 ---@field setPlate fun(self:VehicleClass, plate:string):boolean
 ---@field setProps fun(self:VehicleClass, props:table):boolean
@@ -51,7 +50,6 @@ Core.vehicleClass = {
 		if entity <= 0 then
 			return
 		end
-
 		Entity(entity).state:set("owner", owner, false)
 
 		local vehicle = {
@@ -130,13 +128,6 @@ Core.vehicleClass = {
 		end
 
 		return Core.vehicles[self.plate].modelHash
-	end,
-	getProps = function(self)
-		if not self:isValid() then
-			return
-		end
-
-		return Core.vehicles[self.plate].props
 	end,
 	getOwner = function(self)
 		if not self:isValid() then

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -1,13 +1,3 @@
----@class DbVehicle
----@field owner string
----@field plate string
----@field vehicle string
----@field type string
----@field job? string
----@field stored boolean
----@field parking? string
----@field pound? string
-
 ---@class VehicleData
 ---@field plate string
 ---@field netId number
@@ -42,12 +32,12 @@ Core.vehicleClass = {
 			return xVehicle
 		end
 
-		local dbVehicle = MySQL.single.await("SELECT * FROM `owned_vehicles` WHERE `stored` = true AND `owner` = ? AND `plate` = ?", { owner, plate }) --[[@as DbVehicle]]
-		if not dbVehicle then
+		local vehicleProps = MySQL.scalar.await("SELECT `vehicle` FROM `owned_vehicles` WHERE `stored` = true AND `owner` = ? AND `plate` = ? LIMIT 1", { owner, plate })
+		if not vehicleProps then
 			return
 		end
+		vehicleProps = json.decode(vehicleProps.vehicle)
 
-		local vehicleProps = json.decode(dbVehicle.vehicle)
 		if type(vehicleProps.model) ~= "number" then
 			model = joaat(model)
 		end

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -142,6 +142,7 @@ Core.vehicleClass = {
 		local xVehicle = Core.vehicles[self.plate]
 		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })
 		if affectedRows <= 0 then
+			self:delete()
 			return false
 		end
 
@@ -167,6 +168,7 @@ Core.vehicleClass = {
 		local xVehicle = Core.vehicles[self.plate]
 		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(props), xVehicle.plate, xVehicle.owner)
 		if affectedRows <= 0 then
+			self:delete()
 			return false
 		end
 
@@ -187,6 +189,7 @@ Core.vehicleClass = {
 
 		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `owner` = ? WHERE owner = ? AND `plate` = ?", { owner, xVehicle.owner, xVehicle.plate })
 		if affectedRows <= 0 then
+			self:delete()
 			return false
 		end
 

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -53,14 +53,14 @@ Core.vehicleClass = {
 		Entity(entity).state:set("owner", owner, false)
 		Entity(entity).state:set("plate", plate, false)
 
-		local vehicle = {
+		local vehicleData = {
 			plate = plate,
 			entity = entity,
 			netId = netId,
 			modelHash = vehicleProps.model,
 			owner = owner,
 		}
-		Core.vehicles[plate] = vehicle
+		Core.vehicles[plate] = vehicleData
 
 		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 0 WHERE `owner` = ? AND `plate` = ?", { owner, plate })
 
@@ -142,6 +142,7 @@ Core.vehicleClass = {
 		if affectedRows <= 0 then
 			return false
 		end
+
 		Entity(xVehicle.entity).state:set("plate", plate, false)
 		SetVehicleNumberPlateText(xVehicle.entity, plate)
 		xVehicle.plate = plate
@@ -159,6 +160,7 @@ Core.vehicleClass = {
 		if affectedRows <= 0 then
 			return false
 		end
+
 		Entity(xVehicle.entity).state:set("VehicleProperties", props, true)
 
 		return true
@@ -178,6 +180,7 @@ Core.vehicleClass = {
 		if affectedRows <= 0 then
 			return false
 		end
+
 		Entity(xVehicle.entity).state:set("owner", owner, false)
 		xVehicle.owner = owner
 

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -1,0 +1,209 @@
+---@class DbVehicle
+---@field owner string
+---@field plate string
+---@field vehicle string
+---@field type string
+---@field job? string
+---@field stored boolean
+---@field parking? string
+---@field pound? string
+
+---@class VehicleData
+---@field plate string
+---@field netId number
+---@field entity number
+---@field modelHash number
+---@field owner string
+
+---@class VehicleClass
+---@field plate string
+---@field isValid fun(self:VehicleClass):boolean
+---@field new fun(owner:string, plate:string, coords:vector4): VehicleClass?
+---@field getPlate fun(self:VehicleClass):string?
+---@field getNetId fun(self:VehicleClass):number?
+---@field getEntity fun(self:VehicleClass):number?
+---@field getModelHash fun(self:VehicleClass):number?
+---@field getProps fun(self:VehicleClass):table?
+---@field getOwner fun(self:VehicleClass):string?
+---@field setPlate fun(self:VehicleClass, plate:string):boolean
+---@field setProps fun(self:VehicleClass, props:table):boolean
+---@field setOwner fun(self:VehicleClass, owner:string):boolean
+---@field delete fun(self:VehicleClass):nil
+Core.vehicleClass = {
+	plate = "",
+	new = function(owner, plate, coords)
+		assert(type(owner) == "string", "Expected 'owner' to be a string")
+		assert(type(plate) == "string", "Expected 'plate' to be a string")
+		assert(type(coords) == "vector4", "Expected 'coords' to be a vector4")
+
+		if Core.vehicles[plate] then
+			local obj = table.clone(Core.vehicleClass)
+			obj.plate = plate
+
+			if obj:isValid() then
+				return obj
+			end
+		end
+
+		local dbVehicle = MySQL.single.await("SELECT * FROM `owned_vehicles` WHERE `stored` = true AND `owner` = ? AND `plate` = ?", { owner, plate }) --[[@as DbVehicle]]
+		if not dbVehicle then
+			return
+		end
+
+		local vehicleProps = json.decode(dbVehicle.vehicle)
+		if type(vehicleProps.model) ~= "number" then
+			model = joaat(model)
+		end
+
+		local netId = ESX.OneSync.SpawnVehicle(model, coords.xyz, coords.w, vehicleProps)
+		if not netId then
+			return
+		end
+
+		local entity = NetworkGetEntityFromNetworkId(netId)
+		if entity <= 0 then
+			return
+		end
+
+		Entity(entity).state:set("owner", owner, false)
+
+		local vehicle = {
+			plate = plate,
+			entity = entity,
+			netId = netId,
+			modelHash = model,
+			owner = owner,
+		}
+		Core.vehicles[plate] = vehicle
+
+		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 0 WHERE `owner` = ? AND `plate` = ?", { owner, plate })
+
+		local obj = table.clone(Core.vehicleClass)
+		obj.plate = plate
+		TriggerEvent("esx:createdExtendedVehicle", obj)
+
+		return obj
+	end,
+	isValid = function(self)
+		local xVehicle = Core.vehicles[self.plate]
+		if not xVehicle then
+			return false
+		end
+
+		local entity = NetworkGetEntityFromNetworkId(xVehicle.netId)
+		if entity <= 0 or Entity(entity).state.owner ~= xVehicle.owner then
+			self:delete()
+			return false
+		end
+
+		local plate = ESX.Math.Trim(GetVehicleNumberPlateText(entity))
+		if plate ~= xVehicle.plate then
+			self:delete()
+			return false
+		end
+
+		xVehicle.entity = entity
+
+		return true
+	end,
+	getNetId = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].netId
+	end,
+	getEntity = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].entity
+	end,
+	getPlate = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].plate
+	end,
+	getModelHash = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].modelHash
+	end,
+	getProps = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].props
+	end,
+	getOwner = function(self)
+		if not self:isValid() then
+			return
+		end
+
+		return Core.vehicles[self.plate].owner
+	end,
+	setPlate = function(self, plate)
+		if not self:isValid() then
+			return false
+		end
+		assert(type(plate) == "string", "Expected 'plate' to be a string")
+
+		local xVehicle = Core.vehicles[self.plate]
+		SetVehicleNumberPlateText(xVehicle.entity, plate)
+		xVehicle.plate = plate
+		MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })
+
+		return true
+	end,
+	setProps = function(self, props)
+		if not self:isValid() then
+			return false
+		end
+		assert(type(props) == "table", "Expected 'props' to be a table")
+
+		local xVehicle = Core.vehicles[self.plate]
+		Entity(xVehicle.entity).state:set("VehicleProperties", props, true)
+		MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(props), xVehicle.plate, xVehicle.owner)
+
+		return true
+	end,
+	setOwner = function(self, owner)
+		if not self:isValid() then
+			return false
+		end
+		assert(type(owner) == "string", "Expected 'owner' to be a string")
+
+		local xVehicle = Core.vehicles[self.plate]
+		if xVehicle.owner == owner then
+			return true
+		end
+
+		Entity(xVehicle.entity).state:set("owner", owner, false)
+		xVehicle.owner = owner
+		MySQL.update.await("UPDATE `owned_vehicles` SET `owner` = ? WHERE `plate` = ?", { owner, xVehicle.plate })
+
+		return true
+	end,
+	delete = function(self)
+		local xVehicle = Core.vehicles[self.plate]
+		if not xVehicle then
+			return
+		end
+
+		local entity = NetworkGetEntityFromNetworkId(xVehicle.netId)
+		if entity >= 0 and Entity(entity).state.owner == xVehicle.owner then
+			DeleteEntity(xVehicle.entity)
+		end
+
+		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 1 WHERE `plate` = ?", { xVehicle.plate })
+		TriggerEvent("esx:deletedExtendedVehicle", self)
+
+		Core.vehicles[self.plate] = nil
+	end,
+}

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -19,6 +19,7 @@
 ---@field plate string
 ---@field isValid fun(self:VehicleClass):boolean
 ---@field new fun(owner:string, plate:string, coords:vector4): VehicleClass?
+---@field getFromPlate fun(plate:string):VehicleClass?
 ---@field getPlate fun(self:VehicleClass):string?
 ---@field getNetId fun(self:VehicleClass):number?
 ---@field getEntity fun(self:VehicleClass):number?
@@ -36,13 +37,9 @@ Core.vehicleClass = {
 		assert(type(plate) == "string", "Expected 'plate' to be a string")
 		assert(type(coords) == "vector4", "Expected 'coords' to be a vector4")
 
-		if Core.vehicles[plate] then
-			local obj = table.clone(Core.vehicleClass)
-			obj.plate = plate
-
-			if obj:isValid() then
-				return obj
-			end
+		local xVehicle = Core.vehicleClass.getFromPlate(plate)
+		if xVehicle then
+			return xVehicle
 		end
 
 		local dbVehicle = MySQL.single.await("SELECT * FROM `owned_vehicles` WHERE `stored` = true AND `owner` = ? AND `plate` = ?", { owner, plate }) --[[@as DbVehicle]]
@@ -83,6 +80,16 @@ Core.vehicleClass = {
 		TriggerEvent("esx:createdExtendedVehicle", obj)
 
 		return obj
+	end,
+	getFromPlate = function(plate)
+		if Core.vehicles[plate] then
+			local obj = table.clone(Core.vehicleClass)
+			obj.plate = plate
+
+			if obj:isValid() then
+				return obj
+			end
+		end
 	end,
 	isValid = function(self)
 		local xVehicle = Core.vehicles[self.plate]

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -71,6 +71,8 @@ Core.vehicleClass = {
 		return obj
 	end,
 	getFromPlate = function(plate)
+		assert(type(plate) == "string", "Expected 'plate' to be a string")
+
 		if Core.vehicles[plate] then
 			local obj = table.clone(Core.vehicleClass)
 			obj.plate = plate

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -140,8 +140,8 @@ Core.vehicleClass = {
 		local xVehicle = Core.vehicles[self.plate]
 		Entity(xVehicle.entity).state:set("plate", plate, false)
 		SetVehicleNumberPlateText(xVehicle.entity, plate)
-		xVehicle.plate = plate
 		MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })
+		xVehicle.plate = plate
 
 		return true
 	end,

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -138,9 +138,12 @@ Core.vehicleClass = {
 		assert(type(plate) == "string", "Expected 'plate' to be a string")
 
 		local xVehicle = Core.vehicles[self.plate]
+		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })
+		if affectedRows <= 0 then
+			return false
+		end
 		Entity(xVehicle.entity).state:set("plate", plate, false)
 		SetVehicleNumberPlateText(xVehicle.entity, plate)
-		MySQL.update.await("UPDATE `owned_vehicles` SET `plate` = ? WHERE `plate` = ? AND `owner` = ?", { plate, xVehicle.plate, xVehicle.owner })
 		xVehicle.plate = plate
 
 		return true
@@ -152,8 +155,11 @@ Core.vehicleClass = {
 		assert(type(props) == "table", "Expected 'props' to be a table")
 
 		local xVehicle = Core.vehicles[self.plate]
+		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(props), xVehicle.plate, xVehicle.owner)
+		if affectedRows <= 0 then
+			return false
+		end
 		Entity(xVehicle.entity).state:set("VehicleProperties", props, true)
-		MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(props), xVehicle.plate, xVehicle.owner)
 
 		return true
 	end,
@@ -168,9 +174,12 @@ Core.vehicleClass = {
 			return true
 		end
 
+		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `owner` = ? WHERE owner = ? AND `plate` = ?", { owner, xVehicle.owner, xVehicle.plate })
+		if affectedRows <= 0 then
+			return false
+		end
 		Entity(xVehicle.entity).state:set("owner", owner, false)
 		xVehicle.owner = owner
-		MySQL.update.await("UPDATE `owned_vehicles` SET `owner` = ? WHERE `plate` = ?", { owner, xVehicle.plate })
 
 		return true
 	end,

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -209,7 +209,7 @@ Core.vehicleClass = {
 			DeleteEntity(xVehicle.entity)
 		end
 
-		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 1 WHERE `plate` = ?", { xVehicle.plate })
+		MySQL.update.await("UPDATE `owned_vehicles` SET `stored` = 1 WHERE `plate` = ? AND `owner` = ?", { xVehicle.plate, xVehicle.owner })
 		TriggerEvent("esx:deletedExtendedVehicle", self)
 
 		Core.vehicles[self.plate] = nil

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -35,7 +35,7 @@ Core.vehicleClass = {
 		if not vehicleProps then
 			return
 		end
-		vehicleProps = json.decode(vehicleProps.vehicle)
+		vehicleProps = json.decode(vehicleProps)
 
 		if type(vehicleProps.model) ~= "number" then
 			model = joaat(model)

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -11,6 +11,8 @@ Core.PlayerFunctionOverrides = {}
 Core.DatabaseConnected = false
 Core.playersByIdentifier = {}
 
+---@type table<string, VehicleData>
+Core.vehicles = {}
 Core.vehicleTypesByModel = {}
 
 RegisterNetEvent("esx:onPlayerSpawn", function()

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -11,7 +11,7 @@ Core.PlayerFunctionOverrides = {}
 Core.DatabaseConnected = false
 Core.playersByIdentifier = {}
 
----@type table<string, VehicleData>
+---@type table<string, CVehicleData>
 Core.vehicles = {}
 Core.vehicleTypesByModel = {}
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -629,9 +629,5 @@ end
 function ESX.GetExtendedVehicleFromPlate(plate)
     assert(type(plate) == "string", "Expected 'plate' to be a string")
 
-    if Core.vehicles[plate] then
-        local obj = table.clone(Core.vehicleClass)
-        obj.plate = plate
-        return obj
-    end
+   return Core.vehicleClass.getFromPlate(plate)
 end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -619,13 +619,13 @@ end
 ---@param owner string
 ---@param plate string
 ---@param coords vector4
----@return VehicleClass?
+---@return CExtendedVehicle?
 function ESX.CreateExtendedVehicle(owner, plate, coords)
     return Core.vehicleClass.new(owner, plate, coords)
 end
 
 ---@param plate string
----@return VehicleClass?
+---@return CExtendedVehicle?
 function ESX.GetExtendedVehicleFromPlate(plate)
    return Core.vehicleClass.getFromPlate(plate)
 end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -615,3 +615,23 @@ function Core.IsPlayerAdmin(playerId)
     local xPlayer = ESX.Players[playerId]
     return (xPlayer and Config.AdminGroups[xPlayer.group] and true) or false
 end
+
+---@param owner string
+---@param plate string
+---@param coords vector4
+---@return VehicleClass?
+function ESX.CreateExtendedVehicle(owner, plate, coords)
+    return Core.vehicleClass.new(owner, plate, coords)
+end
+
+---@param plate string
+---@return VehicleClass?
+function ESX.GetExtendedVehicleFromPlate(plate)
+    assert(type(plate) == "string", "Expected 'plate' to be a string")
+
+    if Core.vehicles[plate] then
+        local obj = table.clone(Core.vehicleClass)
+        obj.plate = plate
+        return obj
+    end
+end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -627,7 +627,5 @@ end
 ---@param plate string
 ---@return VehicleClass?
 function ESX.GetExtendedVehicleFromPlate(plate)
-    assert(type(plate) == "string", "Expected 'plate' to be a string")
-
    return Core.vehicleClass.getFromPlate(plate)
 end

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -107,10 +107,10 @@ function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
             local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
             local tries = 0
 
-            while not createdVehicle or createdVehicle == 0 or not GetEntityCoords(createdVehicle) do
+            while not createdVehicle or createdVehicle == 0 or NetworkGetEntityOwner(createdVehicle) == -1 do
                 Wait(200)
                 tries = tries + 1
-                if tries > 20 then
+                if tries > 40 then
                     if promise then
                         return promise:reject(("Could not spawn vehicle - ^5%s^7!"):format(model))
                     end
@@ -122,6 +122,7 @@ function ESX.OneSync.SpawnVehicle(model, coords, heading, properties, cb)
             SetEntityOrphanMode(createdVehicle, 2)
             local networkId = NetworkGetNetworkIdFromEntity(createdVehicle)
             Entity(createdVehicle).state:set("VehicleProperties", vehicleProperties, true)
+
             if promise then
                 promise:resolve(networkId)
             elseif cb then


### PR DESCRIPTION
### Description

This PR introduces a robust vehicle class to the ESX framework, offering developers a standardized way to manage owned vehicle entities in FiveM.

---
### Motivation

The primary motivation for this addition is to address the challenges of managing owned vehicles reliably in a multiplayer environment. Specifically, this class enables developers to:

- **Determine if an owned vehicle is spawned or not:** With this class, it's straightforward to check whether a specific vehicle is currently active in the world or has been despawned.

- **Ensure vehicle validity:** By leveraging entity statebags, the system ensures that each tracked vehicle is indeed the one that was created, avoiding issues caused by network ID reassignment (a common occurrence when entities are deleted and new ones are created).
---

### **Implementation Details**

1. **Entity Statebags**  
   Each vehicle is assigned the owner's identifier **and plate** in its statebag at the time of creation. This ensures that, regardless of entity lifecycle events, the vehicle can still be uniquely and reliably identified. The plate stored in the statebag acts as an additional tool for validation, as it is a crucial identifier for vehicles. Using the statebag for the plate, instead of relying on fetching the vehicle plate through natives, avoids potential **race conditions.** Native RPCs take time to propagate changes to the entity, so if a script were to perform an operation on a vehicle class object immediately after creation, there could be a mismatch between the plate the class expects and the plate set on the entity in the game. This mismatch could cause the class to invalidate the entity incorrectly. Storing the plate in the statebag ensures consistency and immediate access to the correct data.

2. **Automatic Validation**  
   The `isValid` function plays a critical role in maintaining the integrity of the vehicle object. It checks the existence and validity of the associated entity in the world. The class automatically invokes `isValid` on every action (e.g., getting the netId, setting the vehicle properties, or getting the entity handle). This guarantees that actions are always performed on up-to-date and valid entities.

---

### Usage Example
```lua
AddEventHandler("esx:createdExtendedVehicle", function(xVehicle)
    print("[esx:createdExtendedVehicle] VEHICLE NET ID", xVehicle:getNetId())         -- Output: <netId>
    print("[esx:createdExtendedVehicle] VEHICLE ENTITY", xVehicle:getEntity())        -- Output: <entityHandle>
    print("[esx:createdExtendedVehicle] VEHICLE PLATE", xVehicle:getPlate())          -- Output: "ESX"
    print("[esx:createdExtendedVehicle] VEHICLE MODEL HASH", xVehicle:getModelHash()) -- Output: <modelHash>
    print("[esx:createdExtendedVehicle] VEHICLE OWNER", xVehicle:getOwner())
end)

AddEventHandler("esx:deletedExtendedVehicle", function(xVehicle)
    print("[esx:deletedExtendedVehicle] VEHICLE NET ID", xVehicle:getNetId())         -- Output: <netId>
    print("[esx:deletedExtendedVehicle] VEHICLE ENTITY", xVehicle:getEntity())        -- Output: <entityHandle>
    print("[esx:deletedExtendedVehicle] VEHICLE PLATE", xVehicle:getPlate())          -- Output: "NEWPLATE"
    print("[esx:deletedExtendedVehicle] VEHICLE MODEL HASH", xVehicle:getModelHash()) -- Output: <modelHash>
    print("[esx:deletedExtendedVehicle] VEHICLE OWNER", xVehicle:getOwner())          -- Output: "char1:12754a0705e35cda21ced87c7daf329730135087"
end)

AddEventHandler("esx:changedExtendedVehiclePlate", function(newPlate, oldPlate)
    if xVehicle.plate == oldPlate then
        xVehicle.plate = newPlate
    end
end)

xVehicle = ESX.CreateExtendedVehicle("char1:12754a0705e35cda21ced87c7daf329730135087", "ESX", vector4(-204.5230, -1703.2838, 33.4497, 91.1210))
if not xVehicle then
    return
end

print("VEHICLE NET ID", xVehicle:getNetId())         -- Output: <netId>
print("VEHICLE ENTITY", xVehicle:getEntity())        -- Output: <entityHandle>
print("VEHICLE PLATE", xVehicle:getPlate())          -- Output: "ESX"
print("VEHICLE MODEL HASH", xVehicle:getModelHash()) -- Output: <modelHash>
print("VEHICLE OWNER", xVehicle:getOwner())          -- Output: "char1:12754a0705e35cda21ced87c7daf329730135087"

local success = xVehicle:setPlate("NEWPLATE")
if not success then
    print("Vehicle has been invalidated")
    return
end
print("VEHICLE PLATE", xVehicle:getPlate()) -- Output: "NEWPLATE"

local xVehicle2 = ESX.GetExtendedVehicleFromPlate("NEWPLATE")
if not xVehicle2 then
    print("Vehicle not found")
    return
end
print("SECOND VEHICLE PLATE", xVehicle2:getPlate()) -- Output: "NEWPLATE"

local xVehicle3 = ESX.CreateExtendedVehicle("char1:12754a0705e35cda21ced87c7daf329730135087", "NEWPLATE", vector4(-204.5230, -1703.2838, 33.4497, 91.1210))
if not xVehicle3 then
    return
end
print("THIRD VEHICLE PLATE", xVehicle3:getPlate()) -- Output: "NEWPLATE"

xVehicle:delete()
print("[AFTER DELETION] VEHICLE NET ID", xVehicle:getNetId() or "nil")  -- Output: "nil"
print("[AFTER DELETION] SECOND VEHICLE NET ID", xVehicle2:getNetId() or "nil") -- Output: "nil" (points to the same entity as xVehicle)
print("[AFTER DELETION] THIRD VEHICLE NET ID", xVehicle3:getNetId() or "nil") -- Output: "nil" (points to the same entity as xVehicle)
```
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
