### PR TITLE
feat(es_extended) Dynamic Modules

### DIFF
--- a/[core]/es_extended/client/dynamicModules/blip.lua
+++ b/[core]/es_extended/client/dynamicModules/blip.lua
@@ -1,0 +1,65 @@
+-- inspired by: https://github.com/esx-framework/esx_core/pull/1490
+
+local blips = {}
+
+---@class ESXBlip
+---@field coords vector3 Blip coordinates
+---@field sprite number Blip sprite. See https://docs.fivem.net/docs/game-references/blips/#blips
+---@field label string Blip display name/label
+---@field color? number Blip color. See https://docs.fivem.net/docs/game-references/blips/#blip-colors
+---@field scale? number Blip scale. Defaults to 1.0
+---@field display? number Blip display type. Defaults to 4
+---@field shortRange? boolean Is Blip short range. Defaults to true
+
+--- Used to create static blips on the map. Blips are removed when the resource that created them is stopped.
+---@param blipData ESXBlip
+---@return number: The blip id. The blip can later be removed with DeleteBlip by passing the blip id as the first argument.
+function CreateBlip(blipData)
+    ESX.AssertType(blipData, 'table')
+    ESX.AssertType(blipData.coords, 'vector3')
+    ESX.AssertType(blipData.sprite, 'number')
+    ESX.AssertType(blipData.label, 'string')
+
+    local handle = ESX.Table.SizeOf(blips) + 1
+
+    local blip = AddBlipForCoord(blipData.coords.x, blipData.coords.y, blipData.coords.z)
+
+    SetBlipSprite(blip, blipData.sprite)
+    SetBlipColour(blip, blipData.color or 1)
+    SetBlipScale(blip, blipData.scale or 1.0)
+    SetBlipDisplay(blip, blipData.display or 4)
+    SetBlipAsShortRange(blip, blipData.shortRange or true)
+
+    local textEntry = ("esxBlip:%s"):format(handle)
+
+    AddTextEntry(textEntry, blipData.label)
+
+    BeginTextCommandSetBlipName(textEntry)
+    EndTextCommandSetBlipName(blip)
+
+    blips[handle] = {
+        blipHandle = blip,
+        resource = GetInvokingResource()
+    }
+
+    return handle
+end
+
+---@param blipId number The blip id that is provided when creating the blip with CreateBlip
+function DeleteBlip(blipId)
+    local blip = blips[blipId]
+
+    if blip then
+        RemoveBlip(blip.blipHandle)
+        blips[blipId] = nil
+    end
+end
+
+local function onResourceStop(resourceName)
+    for blipId, blipData in pairs(blips) do
+        if blipData.resource == resourceName then
+            DeleteBlip(blipId)
+        end
+    end
+end
+AddEventHandler('onResourceStop', onResourceStop)

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -73,6 +73,10 @@ files {
 
 	'html/fonts/pdown.ttf',
 	'html/fonts/bankgothic.ttf',
+
+	-- Dynamic Modules
+	'client/dynamicModules/*.lua',
+	'server/dynamicModules/*.lua'
 }
 
 dependencies {

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -22,3 +22,45 @@ if not IsDuplicityVersion() then -- Only register this event for the client
         ESX.PlayerData = {}
     end)
 end
+
+
+local basePath = ('%s/dynamicModules'):format(IsDuplicityVersion() and 'server' or 'client')
+local loadedModules = {}
+
+--- Load a module by its name. Make sure the specified resource has the module loaded via files {} in fxmanifest.lua (e.g files { 'modules/myModule.lua' })
+--- @param moduleName string The name of the module to load
+--- @param path? string Optional. A sub-path relative to the resource's root or nil to use the default basePath
+--- @param resourceName? string Optional. The resource name to load the module from. Default is 'es_extended'
+--- @return unknown | boolean: Returns the result of the module or true if successful
+function ESX.LoadModule(moduleName, path, resourceName)
+    ESX.AssertType(moduleName, 'string', 'moduleName should be a string.')
+    if path then
+        ESX.AssertType(path, 'string', 'path should be a string.')
+    end
+    if resourceName then
+        ESX.AssertType(resourceName, 'string', 'customResource should be a string.')
+    end
+
+    resourceName = resourceName or 'es_extended'
+
+    local moduleKey = ('%s-%s'):format(moduleName, path or '')
+    if loadedModules[moduleKey] then
+        print(('Module %s is already loaded'):format(moduleName))
+        return true
+    end
+
+    local modulePath = path and ('%s/%s.lua'):format(path, moduleName) or ('%s/%s.lua'):format(basePath, moduleName)
+
+    local moduleCode = LoadResourceFile(resourceName, modulePath)
+    assert(moduleCode, 'moduleCode is nil, make sure your module path is correct. Note: Client-side modules can not be loaded from the server-side.')
+
+    local func, err = load(moduleCode, ('@@%s/%s'):format(resourceName, modulePath))
+    assert(func, ('Failed to load module %s: %s'):format(moduleName, err))
+
+    local success, result = pcall(func)
+    assert(success, ('Failed to execute module %s: %s'):format(moduleName, result))
+
+    loadedModules[moduleKey] = true
+
+    return result or true
+end


### PR DESCRIPTION
This PR introduces a dynamic module system to the ESX Framework. The key features and purposes of this system are as follows:

- **Dynamic Module Loading:** Allows loading of modules dynamically from specified paths and resources.
- **Client and Server Support:** Supports both client side and server side module loading with valid handling to prevent cross-loading.
- **Enhanced Flexibility:** Enables developers to load custom modules from different resources, enhancing the flexibility and modularity of the ESX Framework.

# Motivation

The dynamic module system aims to improve the modularity and flexibility of the ESX Framework, allowing developers to extend and customize the framework more efficiently. This system is particularly useful for code that does not need to run within the ESX Core but inside the resource that requires it. For example:

- **Blips:** es_extended does not need to store blips created by other resources.
- **Peds:** Custom peds can be managed by specific resources.
- **KVP database wrapper:** Resource-dependent database wrappers can be loaded dynamically.

**Usage isntructions**

- Define your modules in the specified path and ensure they are included in fxmanifest.lua file using the files directive
- Use the ESX.LoadModule function to load modules dynamically by specifying the module name, optional path and optional resource name.
^ You can either return a table in the module and use it like i provided down below with the "db" module, or you can use it like in the blip module, just creating glboal functions.

**Example**

Although you can find an example in client/dynamicModules/blip.lua, i will provide another one:

_Expandable code, just showing what it could be used for_

```lua
local module = {}

module.saveToDb = function(key, value)
    SetResourceKvp(key, value) 
end

module.getFromDb = function(key)
    return GetResourceKvpString(key)
end

return module
```

```lua
-- Loading the module assuming the module is inside es_extended/server/dynamicModules/kvp.lua
local db = ESX.LoadModule('kvp')
db.saveToDb('exampleKey, 'exampleValue')

local exampleValue = db.getFromDb('exampleKey')
```

**Loading a module that is in a different resource**
```lua
-- this module would have to be in esx_testing/modules/testModule.lua
ESX.LoadModule('testModule', 'modules', 'esx_testing')
```
 
```