### PR TITLE
fix(es_extended/): fix race conditions & ped change not propogating

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -46,7 +46,6 @@ function Actions:TrackPed()
 
     if playerPed ~= newPed then
         ESX.SetPlayerData("ped", newPed)
-        ESX.PlayerData.ped = newPed
 
         TriggerEvent("esx:playerPedChanged", newPed)
 

--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -45,8 +45,8 @@ function Actions:TrackPed()
     local newPed = PlayerPedId()
 
     if playerPed ~= newPed then
-        ESX.PlayerData.ped = newPed
         ESX.SetPlayerData("ped", newPed)
+        ESX.PlayerData.ped = newPed
 
         TriggerEvent("esx:playerPedChanged", newPed)
 

--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -63,7 +63,7 @@ end
 AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
         while ESX.PlayerLoaded and not ESX.PlayerData.dead do
-            if IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped) then
+            if DoesEntityExist(ESX.PlayerData.ped) and (IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped)) then
                 Death:Died()
                 break
             end

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -14,6 +14,7 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 
     RegisterNetEvent("esx:playerLoaded", function(xPlayer)
         ESX.PlayerData = xPlayer
+        while not ESX.PlayerData.ped or not DoesEntityExist(ESX.PlayerData.ped) do Wait(0) end
         ESX.PlayerLoaded = true
     end)
 


### PR DESCRIPTION
### Summary
- Fixed an issue where relying on `ESX.PlayerLoaded` to be `true` in importing resources did not garuantee that the ped has fully spawned.
- Fixed an issue with ped changes not propogating to importing resources due to execution order.
- Fixed death module relying on a possibly invalid ped which would trigger the death logic.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.