### PR TITLE
feat(es_extended/imports): add require

### DIFF
--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -71,7 +71,7 @@ end
 ---@param modulePath string
 ---@return any
 function require(modulePath)
-    assert(type(modulePath) == "string", "Module name must be a string")
+    assert(type(modulePath) == "string", "Module path must be a string")
 
     if loadingModules[modulePath] then
         error(("Circular dependency detected for module '%s'."):format(modulePath))

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -107,6 +107,4 @@ if not lib?.require then
 
         return result
     end
-else
-    print("LIB LOADED")
 end

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -1,4 +1,5 @@
 ESX = exports["es_extended"]:getSharedObject()
+_resourceName = GetCurrentResourceName()
 
 OnPlayerData = function (key, val, last) end
 
@@ -41,4 +42,67 @@ if not IsDuplicityVersion() then -- Only register this event for the client
             return error(('\n^1Error loading module (%s)'):format(external[i]))
         end
     end
+end
+
+local cachedModules = {} ---@type table<string, any>
+local loadingModules = {} ---@type table<string, true?>
+
+---@param modulePath string
+---@return string
+local function getResourceNameFromModulePath(modulePath)
+    local externalResourceName = modulePath:match("^@(.-)%.")
+    if externalResourceName then
+        return externalResourceName
+    end
+
+    return _resourceName
+end
+
+---@param modulePath string
+---@return string, number
+local function getModuleFilePath(modulePath)
+    if modulePath:sub(1, 1) == "@" then
+        modulePath = modulePath:sub(modulePath:find("%.") + 1)
+    end
+
+    return modulePath:gsub("%.", "/")
+end
+
+---@param modulePath string
+---@return any
+function require(modulePath)
+    assert(type(modulePath) == "string", "Module name must be a string")
+
+    if loadingModules[modulePath] then
+        error(("Circular dependency detected for module '%s'."):format(modulePath))
+    end
+
+    if cachedModules[modulePath] then
+        return cachedModules[modulePath]
+    end
+
+    loadingModules[modulePath] = true
+
+    local resourceName = getResourceNameFromModulePath(modulePath)
+    local moduleFilePath = getModuleFilePath(modulePath)
+    local moduleFileContent = LoadResourceFile(resourceName, moduleFilePath .. ".lua")
+
+    if not moduleFileContent then
+        loadingModules[modulePath] = nil
+        error(("Module '%s' not found in resource '%s'."):format(moduleFilePath, resourceName))
+    end
+
+    local chunk, err = load(moduleFileContent, ("@%s/%s"):format(resourceName, moduleFilePath), "t")
+
+    if not chunk then
+        loadingModules[modulePath] = nil
+        error(("Failed to load module '%s': %s"):format(moduleFilePath, err))
+    end
+
+    local result = chunk()
+
+    cachedModules[modulePath] = result ~= nil and result or true
+    loadingModules[modulePath] = nil
+
+    return result
 end


### PR DESCRIPTION
### Description
This PR introduces a new module loading system for the ESX framework. The require function is now available for importing resources, allowing them to load modules properly and efficiently, including those that define classes with metatables. This function includes caching to avoid redundant loads and circular dependency checks to prevent infinite loops.

---

### Example Usage
```lua
--- resource1/modules/CStudent.lua
local Student = {}
Student.__index = Student

function Student.new(name, age)
	local self = setmetatable({}, Student)
	self.name = name
	self.age = age
	return self
end

function Student:getInfo()
	return ("Name: %s | Age: %d"):format(self.name, self.age)
end

return Student
```

```lua
--- resource2/server/main.lua
local CStudent = require("@resource1.modules.CStudent")

local student = CStudent.new("John Doe", 18)
print(newStudent:getInfo()) -- Output: "Name: John Doe | Age: 18"
```

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
