### PR TITLE
fix(es_extended/imports): remove lua 5.4 dependency for importing resources

### DIFF
--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -44,7 +44,7 @@ if not IsDuplicityVersion() then -- Only register this event for the client
     end
 end
 
-if not lib?.require then
+if not lib or not lib.require then
     local cachedModules = {} ---@type table<string, any>
     local loadingModules = {} ---@type table<string, true?>
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -563,7 +563,7 @@ end
 
 ---@return table
 function ESX.GetItems()
-    return Core.Items
+    return ESX.Items
 end
 
 ---@return table


### PR DESCRIPTION
### Summary
- Removed usage of optional chaining (a 5.4 feature) in the imports.lua. 
- Fixed return value of `ESX.GetItems`. Returned nil because of [this revert](https://github.com/esx-framework/esx_core/pull/1572)

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.