### PR TITLE
fix(es_extended/client/modules/adjustments): `SetHudComponentPosition` expects float

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -4,7 +4,7 @@ function Adjustments:RemoveHudComponents()
     for i = 1, #Config.RemoveHudComponents do
         if Config.RemoveHudComponents[i] then
             SetHudComponentSize(i, 0.0, 0.0)
-            SetHudComponentPosition(i, 900, 900)
+            SetHudComponentPosition(i, 900.0, 900.0)
         end
     end
 end


### PR DESCRIPTION

### Description
`SetHudComponentPosition` expects floats while we were passing integers.

---
### Motivation
Hud components were not properly being hidden for some people.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
