### PR TITLE
fix(es_extended/server/functions): improve `Core.SavePlayers` & `Core.SavePlayer`

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -12,6 +12,7 @@ shared_scripts {
 	'shared/config/main.lua',
     'shared/config/weapons.lua',
     'shared/config/adjustments.lua',
+    'shared/config/compat.lua',
 
     'shared/main.lua',
     'shared/functions.lua',

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -243,12 +243,15 @@ function Core.SavePlayers(cb)
         xPlayer.metadata.health = GetEntityHealth(playerPed)
         xPlayer.metadata.armor = GetPedArmour(playerPed)
 
+        local playerCoords = GetEntityCoords(playerPed)
+        local playerHeading = GetEntityHeading(playerPed)
+
         parameters[#parameters + 1] = {
             json.encode(xPlayer.getAccounts(true)),
             xPlayer.job.name,
             xPlayer.job.grade,
             xPlayer.group,
-            json.encode(xPlayer.getCoords(false, true)),
+            json.encode({x = playerCoords.x, y = playerCoords.y, z = playerCoords.z, heading = playerHeading}),
             json.encode(xPlayer.getInventory(true)),
             json.encode(xPlayer.getLoadout(true)),
             json.encode(xPlayer.getMeta()),

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -192,7 +192,6 @@ local function updateHealthAndArmorInMetadata(xPlayer)
     local ped = GetPlayerPed(xPlayer.source)
     xPlayer.setMeta("health", GetEntityHealth(ped))
     xPlayer.setMeta("armor", GetPedArmour(ped))
-    xPlayer.setMeta("lastPlaytime", xPlayer.getPlayTime())
 end
 
 ---@param xPlayer table

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -230,53 +230,96 @@ function Core.SavePlayer(xPlayer, cb)
     )
 end
 
----@param cb? function
----@return nil
-function Core.SavePlayers(cb)
-    local xPlayers <const> = ESX.Players
-    if not next(xPlayers) then
-        return
-    end
-
-    local startTime <const> = os.time()
-    local parameters = {}
-
-    for _, xPlayer in pairs(ESX.Players) do
-        local playerPed = GetPlayerPed(xPlayer.source)
-        xPlayer.metadata.health = GetEntityHealth(playerPed)
-        xPlayer.metadata.armor = GetPedArmour(playerPed)
-
-        local playerCoords = GetEntityCoords(playerPed)
-        local playerHeading = GetEntityHeading(playerPed)
-
-        parameters[#parameters + 1] = {
-            json.encode(xPlayer.getAccounts(true)),
-            xPlayer.job.name,
-            xPlayer.job.grade,
-            xPlayer.group,
-            json.encode({x = playerCoords.x, y = playerCoords.y, z = playerCoords.z, heading = playerHeading}),
-            json.encode(xPlayer.getInventory(true)),
-            json.encode(xPlayer.getLoadout(true)),
-            json.encode(xPlayer.metadata),
-            xPlayer.identifier,
-        }
-    end
-
-    MySQL.prepare(
-        "UPDATE `users` SET `accounts` = ?, `job` = ?, `job_grade` = ?, `group` = ?, `position` = ?, `inventory` = ?, `loadout` = ?, `metadata` = ? WHERE `identifier` = ?",
-        parameters,
-        function(results)
-            if not results then
-                return
-            end
-
-            if type(cb) == "function" then
-                return cb()
-            end
-
-            print(("[^2INFO^7] Saved ^5%s^7 %s over ^5%s^7 ms"):format(#parameters, #parameters > 1 and "players" or "player", ESX.Math.Round((os.time() - startTime) / 1000000, 2)))
+if Config.Compat.useV12SavePlayers then
+    ---@param cb? function
+    ---@return nil
+    function Core.SavePlayers(cb)
+        local xPlayers <const> = ESX.Players
+        if not next(xPlayers) then
+            return
         end
-    )
+
+        local startTime <const> = os.time()
+        local parameters = {}
+
+        for _, xPlayer in pairs(ESX.Players) do
+            local playerPed = GetPlayerPed(xPlayer.source)
+            xPlayer.metadata.health = GetEntityHealth(playerPed)
+            xPlayer.metadata.armor = GetPedArmour(playerPed)
+
+            local playerCoords = GetEntityCoords(playerPed)
+            local playerHeading = GetEntityHeading(playerPed)
+
+            parameters[#parameters + 1] = {
+                json.encode(xPlayer.getAccounts(true)),
+                xPlayer.job.name,
+                xPlayer.job.grade,
+                xPlayer.group,
+                json.encode({ x = playerCoords.x, y = playerCoords.y, z = playerCoords.z, heading = playerHeading }),
+                json.encode(xPlayer.getInventory(true)),
+                json.encode(xPlayer.getLoadout(true)),
+                json.encode(xPlayer.metadata),
+                xPlayer.identifier,
+            }
+        end
+
+        MySQL.prepare(
+            "UPDATE `users` SET `accounts` = ?, `job` = ?, `job_grade` = ?, `group` = ?, `position` = ?, `inventory` = ?, `loadout` = ?, `metadata` = ? WHERE `identifier` = ?",
+            parameters,
+            function(results)
+                if not results then
+                    return
+                end
+
+                if type(cb) == "function" then
+                    return cb()
+                end
+
+                print(("[^2INFO^7] Saved ^5%s^7 %s over ^5%s^7 ms"):format(#parameters, #parameters > 1 and "players" or "player", ESX.Math.Round((os.time() - startTime) / 1000000, 2)))
+            end
+        )
+    end
+else
+    ---@param cb? function
+    ---@return nil
+    function Core.SavePlayers(cb)
+        local xPlayers <const> = ESX.Players
+        if not next(xPlayers) then
+            return
+        end
+
+        local startTime <const> = os.time()
+        local parameters = {}
+
+        for _, xPlayer in pairs(ESX.Players) do
+            parameters[#parameters + 1] = {
+                json.encode(xPlayer.getAccounts(true)),
+                xPlayer.job.name,
+                xPlayer.job.grade,
+                xPlayer.group,
+                json.encode(xPlayer.getInventory(true)),
+                json.encode(xPlayer.getLoadout(true)),
+                json.encode(xPlayer.metadata),
+                xPlayer.identifier,
+            }
+        end
+
+        MySQL.prepare(
+            "UPDATE `users` SET `accounts` = ?, `job` = ?, `job_grade` = ?, `group` = ?, `inventory` = ?, `loadout` = ?, `metadata` = ? WHERE `identifier` = ?",
+            parameters,
+            function(results)
+                if not results then
+                    return
+                end
+
+                if type(cb) == "function" then
+                    return cb()
+                end
+
+                print(("[^2INFO^7] Saved ^5%s^7 %s over ^5%s^7 ms"):format(#parameters, #parameters > 1 and "players" or "player", ESX.Math.Round((os.time() - startTime) / 1000000, 2)))
+            end
+        )
+    end
 end
 
 ESX.GetPlayers = GetPlayers

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -200,12 +200,15 @@ function Core.SavePlayer(xPlayer, cb)
     xPlayer.metadata.health = GetEntityHealth(playerPed)
     xPlayer.metadata.armor = GetPedArmour(playerPed)
 
+    local playerCoords = GetEntityCoords(playerPed)
+    local playerHeading = GetEntityHeading(playerPed)
+
     local parameters <const> = {
         json.encode(xPlayer.getAccounts(true)),
         xPlayer.job.name,
         xPlayer.job.grade,
         xPlayer.group,
-        json.encode(xPlayer.getCoords(false, true)),
+        json.encode({x = playerCoords.x, y = playerCoords.y, z = playerCoords.z, heading = playerHeading}),
         json.encode(xPlayer.getInventory(true)),
         json.encode(xPlayer.getLoadout(true)),
         json.encode(xPlayer.metadata),

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -188,12 +188,6 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
     end
 end
 
-local function updateHealthAndArmorInMetadata(xPlayer)
-    local ped = GetPlayerPed(xPlayer.source)
-    xPlayer.setMeta("health", GetEntityHealth(ped))
-    xPlayer.setMeta("armor", GetPedArmour(ped))
-end
-
 ---@param xPlayer table
 ---@param cb? function
 ---@return nil
@@ -202,7 +196,10 @@ function Core.SavePlayer(xPlayer, cb)
         return cb and cb()
     end
 
-    updateHealthAndArmorInMetadata(xPlayer)
+    local playerPed = GetPlayerPed(xPlayer.source)
+    xPlayer.metadata.health = GetEntityHealth(playerPed)
+    xPlayer.metadata.armor = GetPedArmour(playerPed)
+
     local parameters <const> = {
         json.encode(xPlayer.getAccounts(true)),
         xPlayer.job.name,
@@ -242,7 +239,10 @@ function Core.SavePlayers(cb)
     local parameters = {}
 
     for _, xPlayer in pairs(ESX.Players) do
-        updateHealthAndArmorInMetadata(xPlayer)
+        local playerPed = GetPlayerPed(xPlayer.source)
+        xPlayer.metadata.health = GetEntityHealth(playerPed)
+        xPlayer.metadata.armor = GetPedArmour(playerPed)
+
         parameters[#parameters + 1] = {
             json.encode(xPlayer.getAccounts(true)),
             xPlayer.job.name,

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -208,7 +208,7 @@ function Core.SavePlayer(xPlayer, cb)
         json.encode(xPlayer.getCoords(false, true)),
         json.encode(xPlayer.getInventory(true)),
         json.encode(xPlayer.getLoadout(true)),
-        json.encode(xPlayer.getMeta()),
+        json.encode(xPlayer.metadata),
         xPlayer.identifier,
     }
 
@@ -254,7 +254,7 @@ function Core.SavePlayers(cb)
             json.encode({x = playerCoords.x, y = playerCoords.y, z = playerCoords.z, heading = playerHeading}),
             json.encode(xPlayer.getInventory(true)),
             json.encode(xPlayer.getLoadout(true)),
-            json.encode(xPlayer.getMeta()),
+            json.encode(xPlayer.metadata),
             xPlayer.identifier,
         }
     end

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -317,6 +317,8 @@ AddEventHandler("playerDropped", function(reason)
 
     if xPlayer then
         TriggerEvent("esx:playerDropped", playerId, reason)
+        xPlayer.setMeta("lastPlaytime", xPlayer.getPlayTime())
+
         local job = xPlayer.getJob().name
         local currentJob = Core.JobsPlayerCount[job]
         Core.JobsPlayerCount[job] = ((currentJob and currentJob > 0) and currentJob or 1) - 1
@@ -355,6 +357,7 @@ AddEventHandler("esx:playerLogout", function(playerId, cb)
     local xPlayer = ESX.GetPlayerFromId(playerId)
     if xPlayer then
         TriggerEvent("esx:playerDropped", playerId)
+        xPlayer.setMeta("lastPlaytime", xPlayer.getPlayTime())
 
         Core.playersByIdentifier[xPlayer.identifier] = nil
         Core.SavePlayer(xPlayer, function()

--- a/[core]/es_extended/shared/config/compat.lua
+++ b/[core]/es_extended/shared/config/compat.lua
@@ -1,0 +1,18 @@
+Config.Compat = {
+	-- Use the <= v1.12 Core.SavePlayers function.
+	-- The new Core.SavePlayers function introduces significant performance improvements by avoiding native calls,
+	-- reducing thread hitches commonly experienced on larger servers during player saves.
+	--
+	-- While this doesn't break compatibility with any user scripts, it may still lead to different behaviour than you would expect.
+	--
+	-- There are trade-offs to consider:
+	-- 1. If a player or the server crashes, their health, armor, and position may not be saved.
+	--    - Client crashes may lead to unsaved data.
+	--    - Server crashes, however, will most definitely result in data loss for affected players.
+	--
+	-- For larger servers, the performance benefits might outweigh these risks,
+	-- especially if frequent thread hitches are an issue.
+	--
+	-- Note: Do not disable this setting unless you fully understand the implications.
+	useV12SavePlayers = true,
+}


### PR DESCRIPTION
### Description
Improves the performance of the `Core.SavePlayers` & `Core.SavePlayer` functions.

---
### Motivation
Larger servers experience regular server thread hitches when ESX saves all of their players. This PR aims to improve that.

---

### **Implementation Details**
- Only save `lastPlayTime` player metadata on player leave.
- Set player metadata directly when saving players. This avoids unnecessary type checks, as well as client events.
- Get player coords directly when saving position. Avoids redundant native calls to get a players ped.
- Added optional new `Core.SavePlayers` function while keeping the old one enabled by default through a new config option. The new one avoids any native calls entirely by sacraficing the players position, health and armour data. This can be saved on player leave, though it may result in data loss when the client or server crashes.
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
