### PR TITLE
fix(es_extended/client/modules/death): fix death thread on first spawn

### DIFF
--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -62,6 +62,8 @@ end
 
 AddEventHandler("esx:onPlayerSpawn", function()
     Citizen.CreateThreadNow(function()
+        while not ESX.PlayerLoaded do Wait(0) end
+
         while ESX.PlayerLoaded and not ESX.PlayerData.dead do
             if DoesEntityExist(ESX.PlayerData.ped) and (IsPedDeadOrDying(ESX.PlayerData.ped, true) or IsPedFatallyInjured(ESX.PlayerData.ped)) then
                 Death:Died()


### PR DESCRIPTION
### Description
This PR aims to address an [issue ](https://github.com/esx-framework/esx_ambulancejob/issues/68) where the death thread would not start on first spawn when using certain third-party multichar systems. This is not directly an issue with ESX, but more the result of those multichar systems triggering esx events in the wrong order.


### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
