### PR TITLE
feat(es_extended/locale): add support for lazy loading locales

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -7,7 +7,6 @@ version '1.12.2'
 
 shared_scripts {
 	'locale.lua',
-	'locales/*.lua',
 
 	'shared/config/main.lua',
     'shared/config/weapons.lua',
@@ -63,6 +62,7 @@ ui_page {
 
 files {
 	'imports.lua',
+	'locales/*.lua',
 	'locale.js',
 	'html/ui.html',
 

--- a/[core]/es_extended/locale.lua
+++ b/[core]/es_extended/locale.lua
@@ -3,21 +3,23 @@ Locales = {}
 function Translate(str, ...) -- Translate string
     if not str then
         error(("Resource ^5%s^1 You did not specify a parameter for the Translate function or the value is nil!"):format(GetInvokingResource() or GetCurrentResourceName()))
-        return "Given translate function parameter is nil!"
     end
-    if Locales[Config.Locale] then
-        if Locales[Config.Locale][str] then
-            return string.format(Locales[Config.Locale][str], ...)
-        elseif Config.Locale ~= "en" and Locales["en"] and Locales["en"][str] then
-            return string.format(Locales["en"][str], ...)
-        else
-            return "Translation [" .. Config.Locale .. "][" .. str .. "] does not exist"
+
+    local translations = Locales[Config.Locale]
+    if not translations then
+        -- Fall back to English translation if the current locale is not found
+        if Locales.en and Locales.en[str] then
+            return Locales.en[str]:format(...)
         end
-    elseif Config.Locale ~= "en" and Locales["en"] and Locales["en"][str] then
-        return string.format(Locales["en"][str], ...)
-    else
-        return "Locale [" .. Config.Locale .. "] does not exist"
+
+        return ("Locale [%s] does not exist"):format(Config.Locale)
     end
+
+    if translations[str] then
+        return translations[str]:format(...)
+    end
+
+    return ("Translation [%s][%s] does not exist"):format(Config.Locale, str)
 end
 
 function TranslateCap(str, ...) -- Translate string first char uppercase

--- a/[core]/es_extended/locale.lua
+++ b/[core]/es_extended/locale.lua
@@ -5,14 +5,24 @@ function Translate(str, ...) -- Translate string
         error(("Resource ^5%s^1 You did not specify a parameter for the Translate function or the value is nil!"):format(GetInvokingResource() or GetCurrentResourceName()))
     end
 
+    --- Load the locale file if it hasn't been loaded yet
+    if Locales[Config.Locale] == nil then
+        local success, result = pcall(function()
+            return assert(load(LoadResourceFile(GetCurrentResourceName(), ("locales/%s.lua"):format(Config.Locale))))()
+        end)
+
+        Locales[Config.Locale] = success and result or false
+    end
+
     local translations = Locales[Config.Locale]
     if not translations then
-        -- Fall back to English translation if the current locale is not found
-        if Locales.en and Locales.en[str] then
-            return Locales.en[str]:format(...)
+        if Config.Locale == "en" then
+            return "Locale [en] does not exist"
         end
 
-        return ("Locale [%s] does not exist"):format(Config.Locale)
+        -- Fall back to English translation if the current locale is not found
+        Config.Locale = "en"
+        return Translate(str, ...)
     end
 
     if translations[str] then

--- a/[core]/es_extended/locales/cs.lua
+++ b/[core]/es_extended/locales/cs.lua
@@ -1,4 +1,4 @@
-Locales["cs"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventář ( Váha %s / %s )",
     ["use"] = "Použít",
@@ -223,10 +223,10 @@ Locales["cs"] = {
     ["weapon_tactilerifle"] = "Service Carbine",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Thrown
     ["weapon_ball"] = "Míček",

--- a/[core]/es_extended/locales/de.lua
+++ b/[core]/es_extended/locales/de.lua
@@ -1,4 +1,4 @@
-Locales["de"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventar ( Gewicht %s / %s )",
     ["use"] = "Benutzen",

--- a/[core]/es_extended/locales/el.lua
+++ b/[core]/es_extended/locales/el.lua
@@ -1,4 +1,4 @@
-Locales["el"] = {
+return {
     -- Inventory
     ["inventory"] = "Αποθήκη ( Βάρος %s / %s )",
     ["use"] = "Χρήση",

--- a/[core]/es_extended/locales/en.lua
+++ b/[core]/es_extended/locales/en.lua
@@ -1,4 +1,4 @@
-Locales["en"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventory ( Weight %s / %s )",
     ["use"] = "Use",

--- a/[core]/es_extended/locales/es.lua
+++ b/[core]/es_extended/locales/es.lua
@@ -1,4 +1,4 @@
-Locales["es"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventario %s / %s",
     ["use"] = "Usar",

--- a/[core]/es_extended/locales/fi.lua
+++ b/[core]/es_extended/locales/fi.lua
@@ -1,4 +1,4 @@
-Locales["fi"] = {
+return {
     -- Inventory
     ["inventory"] = "Reppu %s / %s",
     ["use"] = "Käytä",

--- a/[core]/es_extended/locales/fr.lua
+++ b/[core]/es_extended/locales/fr.lua
@@ -1,4 +1,4 @@
-Locales["fr"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventaire ( Poids %s / %s )",
     ["use"] = "Utiliser",

--- a/[core]/es_extended/locales/he.lua
+++ b/[core]/es_extended/locales/he.lua
@@ -1,4 +1,4 @@
-Locales["he"] = {
+return {
     -- Inventory
     ["inventory"] = "מלאי ( משקל %s / %s )",
     ["use"] = "השתמש",

--- a/[core]/es_extended/locales/hu.lua
+++ b/[core]/es_extended/locales/hu.lua
@@ -1,4 +1,4 @@
-Locales["hu"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventory ( Súly %s / %s )",
     ["use"] = "Használ",
@@ -229,10 +229,10 @@ Locales["hu"] = {
     ["weapon_tactilerifle"] = "Service Carbine",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Thrown
     ["weapon_ball"] = "Baseball",

--- a/[core]/es_extended/locales/id.lua
+++ b/[core]/es_extended/locales/id.lua
@@ -1,4 +1,4 @@
-Locales["id"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventaris ( Berat %s / %s )",
     ["use"] = "Gunakan",

--- a/[core]/es_extended/locales/it.lua
+++ b/[core]/es_extended/locales/it.lua
@@ -1,4 +1,4 @@
-Locales["it"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventario ( Peso %s / %s )",
     ["use"] = "Usa",

--- a/[core]/es_extended/locales/nl.lua
+++ b/[core]/es_extended/locales/nl.lua
@@ -1,4 +1,4 @@
-Locales["nl"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventaris ( Gewicht %s / %s )",
     ["use"] = "Gebruik",

--- a/[core]/es_extended/locales/pl.lua
+++ b/[core]/es_extended/locales/pl.lua
@@ -1,4 +1,4 @@
-Locales["pl"] = {
+return {
     -- Inventory
     ["inventory"] = "ekwipunek %s / %s",
     ["use"] = "użyj",
@@ -202,10 +202,10 @@ Locales["pl"] = {
     ["component_luxary_finish"] = "luksusowe wykończenie broni",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Weapon Ammo
     ["ammo_rounds"] = "nabój/oi",

--- a/[core]/es_extended/locales/sl.lua
+++ b/[core]/es_extended/locales/sl.lua
@@ -1,4 +1,4 @@
-Locales["sl"] = {
+return {
     -- Inventory
     ["inventory"] = "Shramba ( Teza %s / %s )",
     ["use"] = "Uporabi",
@@ -229,10 +229,10 @@ Locales["sl"] = {
     ["weapon_tactilerifle"] = "Service Carbine",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Thrown
     ["weapon_ball"] = "Baseball",

--- a/[core]/es_extended/locales/sr.lua
+++ b/[core]/es_extended/locales/sr.lua
@@ -1,4 +1,4 @@
-Locales["sr"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventar ( Težina %s / %s )",
     ["use"] = "Koristi",
@@ -229,10 +229,10 @@ Locales["sr"] = {
     ["weapon_tactilerifle"] = "Service Carbine",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Thrown
     ["weapon_ball"] = "Baseball",

--- a/[core]/es_extended/locales/sv.lua
+++ b/[core]/es_extended/locales/sv.lua
@@ -1,4 +1,4 @@
-Locales["sv"] = {
+return {
     -- Inventory
     ["inventory"] = "Inventory ( Vikt %s / %s )",
     ["use"] = "Använd",

--- a/[core]/es_extended/locales/tr.lua
+++ b/[core]/es_extended/locales/tr.lua
@@ -1,4 +1,4 @@
-Locales["tr"] = {
+return {
     -- Inventory
     ["inventory"] = "Envanter ( Ağırlık %s / %s )",
     ["use"] = "Kullan",
@@ -36,10 +36,10 @@ Locales["tr"] = {
     ["threw_weapon_already"] = "Bu Silaha Zaten Sahipsiniz",
     ["threw_cannot_pickup"] = "Envanter Dolu, Alınamaz!",
     ["threw_pickup_prompt"] = "Almak İçin E'ye Basın",
-    
+
     -- Key mapping
     ["keymap_showinventory"] = "Envanteri Göster",
-    
+
     -- Salary related
     ["received_salary"] = "Maaşınız Ödendi: $%s",
     ["received_help"] = "Yardım Çekiniz Ödendi: $%s",
@@ -49,11 +49,11 @@ Locales["tr"] = {
     ["account_bank"] = "Banka",
     ["account_black_money"] = "Kirli Para",
     ["account_money"] = "Nakit",
-    
+
     ["act_imp"] = "İşlem Yapılamaz",
     ["in_vehicle"] = "İşlem Yapılamaz, Oyuncu Araçta",
     ["not_in_vehicle"] = "İşlem Yapılamaz, Oyuncu Araçta Değil",
-    
+
     -- Commands
     ["command_bring"] = "Oyuncuyu Yanınıza Getir",
     ["command_car"] = "Araç Spawn Et",
@@ -119,14 +119,14 @@ Locales["tr"] = {
     ["command_giveammo_ammo"] = "Mermi Miktarı",
     ["tpm_nowaypoint"] = "Hiçbir Yol İşareti Ayarlanmadı.",
     ["tpm_success"] = "Başarıyla Teleport Edildi",
-    
+
     ["noclip_message"] = "Noclip %s Yapıldı",
     ["enabled"] = "~g~Aktif Edildi~s~",
     ["disabled"] = "~r~Pasif Edildi~s~",
-    
+
     -- Locale settings
     ["locale_digit_grouping_symbol"] = ",",
-    ["locale_currency"] = "£%s",    
+    ["locale_currency"] = "£%s",
 
     -- Silahlar
 

--- a/[core]/es_extended/locales/zh-cn.lua
+++ b/[core]/es_extended/locales/zh-cn.lua
@@ -1,4 +1,4 @@
-Locales["zh-cn"] = {
+return {
     -- Inventory
     ["inventory"] = "背包 %s / %s",
     ["use"] = "使用",
@@ -229,10 +229,10 @@ Locales["zh-cn"] = {
     ["weapon_tactilerifle"] = "制式卡宾步枪",
 
     -- Drug Wars DLC
-    ["weapon_candycane"] = "Candy Cane", -- not translated
+    ["weapon_candycane"] = "Candy Cane",     -- not translated
     ["weapon_acidpackage"] = "Acid Package", -- not translated
-    ["weapon_pistolxm3"] = "WM 29 Pistol", -- not translated
-    ["weapon_railgunxm3"] = "Railgun", -- not translated
+    ["weapon_pistolxm3"] = "WM 29 Pistol",   -- not translated
+    ["weapon_railgunxm3"] = "Railgun",       -- not translated
 
     -- Thrown
     ["weapon_ball"] = "棒球",

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -1,5 +1,9 @@
 Config = {}
 
+local txAdminLocale = GetConvar("txAdmin-locale", "en")
+local esxLocale = GetConvar("esx:locale", "invalid")
+Config.Locale = (esxLocale ~= "invalid") and esxLocale or (txAdminLocale ~= "custom" and txAdminLocale) or "en"
+
 -- for ox inventory, this will automatically be adjusted, do not change! for other inventories, change to "resource_name"
 Config.CustomInventory = false
 
@@ -60,8 +64,3 @@ if GetResourceState("ox_inventory") ~= "missing" then
 end
 
 Config.EnableDefaultInventory = Config.CustomInventory == false -- Display the default Inventory ( F2 )
-
-local txAdminLocale = GetConvar("txAdmin-locale", "en")
-local esxLocale = GetConvar("esx:locale", "invalid")
-
-Config.Locale = (esxLocale ~= "invalid") and esxLocale or (txAdminLocale ~= "custom" and txAdminLocale) or "en"

--- a/[core]/esx_identity/locales/cs.lua
+++ b/[core]/esx_identity/locales/cs.lua
@@ -1,4 +1,4 @@
-Locales["cs"] = {
+return {
     ["show_registration"] = "zobrazit registracni menu",
     ["show_active_character"] = "zobrazit aktivni postavy",
     ["delete_character"] = "smazat svou stavajici postavu a vytvorit novou",

--- a/[core]/esx_identity/locales/da.lua
+++ b/[core]/esx_identity/locales/da.lua
@@ -1,4 +1,4 @@
-Locales["da"] = {
+return {
     ["show_active_character"] = "Vis aktiv karakter",
     ["active_character"] = "Aktiv karakter: %s",
     ["error_active_character"] = "Der opstod en fejl under indhentning af dine data.",

--- a/[core]/esx_identity/locales/de.lua
+++ b/[core]/esx_identity/locales/de.lua
@@ -1,4 +1,4 @@
-Locales["de"] = {
+return {
   ["show_active_character"] = "Aktiven Charakter anzeigen",
   ["active_character"] = "Aktiver Charakter: %s",
   ["error_active_character"] = "Beim Abrufen deiner Daten ist ein Fehler aufgetreten",

--- a/[core]/esx_identity/locales/en.lua
+++ b/[core]/esx_identity/locales/en.lua
@@ -1,4 +1,4 @@
-Locales["en"] = {
+return {
     ["show_active_character"] = "Show Active Character",
     ["active_character"] = "Active Character: %s",
     ["error_active_character"] = "There was an error obtaining your data.",

--- a/[core]/esx_identity/locales/es.lua
+++ b/[core]/esx_identity/locales/es.lua
@@ -1,4 +1,4 @@
-Locales["es"] = {
+return {
     ["show_active_character"] = "Mostrar personaje actual",
     ["active_character"] = "Personaje actual: %s",
     ["error_active_character"] = "Se produjo un error al recuperar tu nombre. Por favor contacta con un administrador",

--- a/[core]/esx_identity/locales/fi.lua
+++ b/[core]/esx_identity/locales/fi.lua
@@ -1,4 +1,4 @@
-Locales["fi"] = {
+return {
     ["show_active_character"] = "Näytä nykyinen hahmosi",
     ["active_character"] = "Nykyinen hahmosi: %s",
     ["error_active_character"] = "Hahmosi hakemisessa ilmeni ongelma. Ota yhteyttä ylläpitoon.",

--- a/[core]/esx_identity/locales/fr.lua
+++ b/[core]/esx_identity/locales/fr.lua
@@ -1,4 +1,4 @@
-Locales["fr"] = {
+return {
     ["show_active_character"] = "Afficher le personnage actif",
     ["active_character"] = "Personnage actif: %s",
     ["error_active_character"] = "Une erreur s'est produite lors de l'obtention de vos données.",

--- a/[core]/esx_identity/locales/he.lua
+++ b/[core]/esx_identity/locales/he.lua
@@ -1,4 +1,4 @@
-Locales["he"] = {
+return {
     ["show_active_character"] = "הצג דמות פעילה",
     ["active_character"] = "דמות פעילה: %s",
     ["error_active_character"] = "אירעה שגיאה בקבלת הנתונים שלך.",

--- a/[core]/esx_identity/locales/hu.lua
+++ b/[core]/esx_identity/locales/hu.lua
@@ -1,4 +1,4 @@
-Locales["hu"] = {
+return {
     ["show_active_character"] = "Aktív karakterek mutatása",
     ["active_character"] = "Aktív karakter: %s",
     ["error_active_character"] = "A név nem megfelelő",

--- a/[core]/esx_identity/locales/it.lua
+++ b/[core]/esx_identity/locales/it.lua
@@ -1,4 +1,4 @@
-Locales["it"] = {
+return {
     ["show_active_character"] = "Mostra Personaggio Attivo",
     ["active_character"] = "Personaggio Attivo: %s",
     ["error_active_character"] = "Errore nel recuperare i tuoi dati.",

--- a/[core]/esx_identity/locales/nl.lua
+++ b/[core]/esx_identity/locales/nl.lua
@@ -1,4 +1,4 @@
-Locales["nl"] = {
+return {
     ["show_active_character"] = "Actieve karakter laten zien",
     ["active_character"] = "Actief karakter: %s",
     ["error_active_character"] = "Er is een probleem opgetreden tijdens het verzamelen van uw data.",

--- a/[core]/esx_identity/locales/pl.lua
+++ b/[core]/esx_identity/locales/pl.lua
@@ -1,4 +1,4 @@
-Locales["pl"] = {
+return {
     ["show_active_character"] = "Pokaż aktywną postać",
     ["active_character"] = "Aktywna postać: %s",
     ["error_active_character"] = "Podczas pobierania Twojego imienia wystąpił błąd. Proszę skontaktować się z administratorem.",

--- a/[core]/esx_identity/locales/pt.lua
+++ b/[core]/esx_identity/locales/pt.lua
@@ -1,4 +1,4 @@
-Locales["pt"] = {
+return {
     ["show_active_character"] = "Mostrar personagem ativa",
     ["active_character"] = "Personagem ativa: %s",
     ["error_active_character"] = "Houve um erro a obter os teus dados.",

--- a/[core]/esx_identity/locales/sl.lua
+++ b/[core]/esx_identity/locales/sl.lua
@@ -1,4 +1,4 @@
-Locales["sl"] = {
+return {
     ["show_active_character"] = "Prikaži aktivnega lika",
     ["active_character"] = "Aktivni lik: %s",
     ["error_active_character"] = "Prišlo je do napake pri pridobivanju podatkov.",

--- a/[core]/esx_identity/locales/sr.lua
+++ b/[core]/esx_identity/locales/sr.lua
@@ -1,4 +1,4 @@
-Locales["sr"] = {
+return {
     ["show_active_character"] = "Prikazi karaktere",
     ["active_character"] = "Karakteri: %s",
     ["error_active_character"] = "Imamo problem sa ucitavanjem karaktera.",

--- a/[core]/esx_identity/locales/sv.lua
+++ b/[core]/esx_identity/locales/sv.lua
@@ -1,4 +1,4 @@
-Locales["sv"] = {
+return {
     ["show_active_character"] = "Visa aktiv karaktär",
     ["active_character"] = "Aktiv karaktär: %s",
     ["error_active_character"] = "Det blev ett fel med att ta din data.",

--- a/[core]/esx_skin/locales/da.lua
+++ b/[core]/esx_skin/locales/da.lua
@@ -1,4 +1,4 @@
-Locales["da"] = {
+return {
     ["skin_menu"] = "Udseende Menu",
     ["use_rotate_view"] = "brug Q og E for at dreje kameraet.",
     ["skin"] = "skift udseende",

--- a/[core]/esx_skin/locales/de.lua
+++ b/[core]/esx_skin/locales/de.lua
@@ -1,6 +1,6 @@
-Locales["de"] = {
-    ["skin_menu"] = "Skin Menü",
-    ["use_rotate_view"] = "Drücke Q oder E um deine Ansicht zu ändern.",
-    ["skin"] = "Aussehen ändern",
-    ["saveskin"] = "Aussehen abspeichern",
-  }
+return {
+  ["skin_menu"] = "Skin Menü",
+  ["use_rotate_view"] = "Drücke Q oder E um deine Ansicht zu ändern.",
+  ["skin"] = "Aussehen ändern",
+  ["saveskin"] = "Aussehen abspeichern",
+}

--- a/[core]/esx_skin/locales/en.lua
+++ b/[core]/esx_skin/locales/en.lua
@@ -1,4 +1,4 @@
-Locales["en"] = {
+return {
     ["skin_menu"] = "Skin Menu",
     ["use_rotate_view"] = "use Q and E to rotate the view.",
     ["skin"] = "change skin",

--- a/[core]/esx_skin/locales/es.lua
+++ b/[core]/esx_skin/locales/es.lua
@@ -1,4 +1,4 @@
-Locales["es"] = {
+return {
     ["skin_menu"] = "Menú de apariencia",
     ["use_rotate_view"] = "Utiliza Q y E para rotar la vista.",
     ["skin"] = "Cambiar aspecto",

--- a/[core]/esx_skin/locales/fi.lua
+++ b/[core]/esx_skin/locales/fi.lua
@@ -1,4 +1,4 @@
-Locales["fi"] = {
+return {
     ["skin_menu"] = "Ulkonäkö",
     ["use_rotate_view"] = "Paina Q tai E liikutaaksesi kameraa.",
     ["skin"] = "Muokkaa ulkonäköä",

--- a/[core]/esx_skin/locales/fr.lua
+++ b/[core]/esx_skin/locales/fr.lua
@@ -1,4 +1,4 @@
-Locales["fr"] = {
+return {
     ["skin_menu"] = "menu de Skin",
     ["use_rotate_view"] = "utilisez Q et E pour tourner la vue.",
     ["skin"] = "changer de skin",

--- a/[core]/esx_skin/locales/he.lua
+++ b/[core]/esx_skin/locales/he.lua
@@ -1,4 +1,4 @@
-Locales["he"] = {
+return {
     ["skin_menu"] = "תפריט עור",
     ["use_rotate_view"] = "השתמש Q ו E כדי לסובב את התצוגה.",
     ["skin"] = "שנה עור",

--- a/[core]/esx_skin/locales/hu.lua
+++ b/[core]/esx_skin/locales/hu.lua
@@ -1,4 +1,4 @@
-Locales["hu"] = {
+return {
     ["skin_menu"] = "Kinézet Menü",
     ["use_rotate_view"] = "Használd Q vagy E gombokat a forgatáshoz",
     ["skin"] = "kinézet változtatása",

--- a/[core]/esx_skin/locales/it.lua
+++ b/[core]/esx_skin/locales/it.lua
@@ -1,4 +1,4 @@
-Locales["it"] = {
+return {
     ["skin_menu"] = "Menu Skin",
     ["use_rotate_view"] = "usa Q e E per ruotare la visuale.",
     ["skin"] = "cambia skin",

--- a/[core]/esx_skin/locales/nl.lua
+++ b/[core]/esx_skin/locales/nl.lua
@@ -1,4 +1,4 @@
-Locales["nl"] = {
+return {
     ["skin_menu"] = "Kleding Menu",
     ["use_rotate_view"] = "gebruik Q en E om de camera te draaien.",
     ["skin"] = "verander outfit",

--- a/[core]/esx_skin/locales/pl.lua
+++ b/[core]/esx_skin/locales/pl.lua
@@ -1,4 +1,4 @@
-Locales["pl"] = {
+return {
     ["skin_menu"] = "menu wyglądu",
     ["use_rotate_view"] = "użyj Q i E aby obrócić ekran.",
     ["skin"] = "zmień wygląd",

--- a/[core]/esx_skin/locales/pt.lua
+++ b/[core]/esx_skin/locales/pt.lua
@@ -1,4 +1,4 @@
-Locales["pt"] = {
+return {
     ["skin_menu"] = "Menu de Skin",
     ["use_rotate_view"] = "Usa Q e E para rodar a câmara.",
     ["skin"] = "alterar skin",

--- a/[core]/esx_skin/locales/sl.lua
+++ b/[core]/esx_skin/locales/sl.lua
@@ -1,4 +1,4 @@
-Locales["sl"] = {
+return {
     ["skin_menu"] = "Oblacilni menu.",
     ["use_rotate_view"] = "Pritisni Q in E da se obracas s pogledom.",
     ["skin"] = "Zamenjaj Skin.",

--- a/[core]/esx_skin/locales/sr.lua
+++ b/[core]/esx_skin/locales/sr.lua
@@ -1,4 +1,4 @@
-Locales["sr"] = {
+return {
     ["skin_menu"] = "Skin Meni",
     ["use_rotate_view"] = "koristi Q i E da rotiras kameru.",
     ["skin"] = "promeni skin",

--- a/[core]/esx_skin/locales/sv.lua
+++ b/[core]/esx_skin/locales/sv.lua
@@ -1,4 +1,4 @@
-Locales["sv"] = {
+return {
     ["skin_menu"] = "Skin Meny",
     ["use_rotate_view"] = "Använd Q och E för att rotera.",
     ["skin"] = "Ända utseende",

--- a/[core]/esx_skin/locales/zh-cn.lua
+++ b/[core]/esx_skin/locales/zh-cn.lua
@@ -1,4 +1,4 @@
-Locales["zh-cn"] = {
+return {
     ["skin_menu"] = "皮肤选单",
     ["use_rotate_view"] = "使用 Q 和 E 旋转镜头视角.",
     ["skin"] = "更换皮肤数据",


### PR DESCRIPTION
### Description
This PR updates the existing localization system by introducing lazy loading for locale files. Instead of loading all locales into memory at startup, we now load locale files dynamically during runtime when needed.

---
### Motivation
This change reduces the memory footprint of the core by roughly 50%.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
