### PR TITLE
refactor(es_extended/client/modules/scaleform): Make scaleforms show duration framerate independent

### DIFF
--- a/[core]/es_extended/client/modules/scaleform.lua
+++ b/[core]/es_extended/client/modules/scaleform.lua
@@ -3,11 +3,10 @@ ESX.Scaleform.Utils = {}
 
 function ESX.Scaleform.ShowFreemodeMessage(title, msg, sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("MP_BIG_MESSAGE_FREEMODE", "SHOW_SHARD_WASTED_MP_MESSAGE", false, title, msg)
-
-    while sec > 0 do
+    
+    local startTimer = GetGameTimer()
+    while GetGameTimer() - startTimer < sec * 1000 do
         Wait(0)
-        sec = sec - 0.01
-
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
 
@@ -19,10 +18,9 @@ function ESX.Scaleform.ShowBreakingNews(title, msg, bottom, sec)
     ESX.Scaleform.Utils.RunMethod(scaleform, "SET_SCROLL_TEXT", false, 0, 0, title)
     ESX.Scaleform.Utils.RunMethod(scaleform, "DISPLAY_SCROLL_TEXT", false, 0, 0)
 
-    while sec > 0 do
+    local startTimer = GetGameTimer()
+    while GetGameTimer() - startTimer < sec * 1000 do
         Wait(0)
-        sec = sec - 0.01
-
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
 
@@ -32,10 +30,9 @@ end
 function ESX.Scaleform.ShowPopupWarning(title, msg, bottom, sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("POPUP_WARNING", "SHOW_POPUP_WARNING", false, 500.0, title, msg, bottom, true)
 
-    while sec > 0 do
+    local startTimer = GetGameTimer()
+    while GetGameTimer() - startTimer < sec * 1000 do
         Wait(0)
-        sec = sec - 0.01
-
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
 
@@ -45,10 +42,9 @@ end
 function ESX.Scaleform.ShowTrafficMovie(sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("TRAFFIC_CAM", "PLAY_CAM_MOVIE", false)
 
-    while sec > 0 do
+    local startTimer = GetGameTimer()
+    while GetGameTimer() - startTimer < sec * 1000 do
         Wait(0)
-        sec = sec - 0.01
-
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
 

--- a/[core]/es_extended/client/modules/scaleform.lua
+++ b/[core]/es_extended/client/modules/scaleform.lua
@@ -4,8 +4,8 @@ ESX.Scaleform.Utils = {}
 function ESX.Scaleform.ShowFreemodeMessage(title, msg, sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("MP_BIG_MESSAGE_FREEMODE", "SHOW_SHARD_WASTED_MP_MESSAGE", false, title, msg)
     
-    local startTimer = GetGameTimer()
-    while GetGameTimer() - startTimer < sec * 1000 do
+    local endTime = GetGameTimer() + (sec * 1000)
+    while GetGameTimer() < endTime do
         Wait(0)
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
@@ -18,8 +18,8 @@ function ESX.Scaleform.ShowBreakingNews(title, msg, bottom, sec)
     ESX.Scaleform.Utils.RunMethod(scaleform, "SET_SCROLL_TEXT", false, 0, 0, title)
     ESX.Scaleform.Utils.RunMethod(scaleform, "DISPLAY_SCROLL_TEXT", false, 0, 0)
 
-    local startTimer = GetGameTimer()
-    while GetGameTimer() - startTimer < sec * 1000 do
+    local endTime = GetGameTimer() + (sec * 1000)
+    while GetGameTimer() < endTime do
         Wait(0)
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
@@ -30,8 +30,8 @@ end
 function ESX.Scaleform.ShowPopupWarning(title, msg, bottom, sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("POPUP_WARNING", "SHOW_POPUP_WARNING", false, 500.0, title, msg, bottom, true)
 
-    local startTimer = GetGameTimer()
-    while GetGameTimer() - startTimer < sec * 1000 do
+    local endTime = GetGameTimer() + (sec * 1000)
+    while GetGameTimer() < endTime do
         Wait(0)
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
@@ -42,8 +42,8 @@ end
 function ESX.Scaleform.ShowTrafficMovie(sec)
     local scaleform = ESX.Scaleform.Utils.RunMethod("TRAFFIC_CAM", "PLAY_CAM_MOVIE", false)
 
-    local startTimer = GetGameTimer()
-    while GetGameTimer() - startTimer < sec * 1000 do
+    local endTime = GetGameTimer() + (sec * 1000)
+    while GetGameTimer() < endTime do
         Wait(0)
         DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
- This PR updates the scaleform display logic to ensure that the duration of messages is no longer dependent on the frame rate. The new implementation uses ```GetGameTimer()``` to calculate when the scaleform should stop showing.
---
### Motivation
<!-- Explain why you are making this PR -->
- The previous implementation of the scaleform showing duration relied on frame-dependent timing, which caused inconsistent behavior on different machines or just different FPS. A 5 second scaleform would hide after ~5 seconds on 100FPS but after ~10 seconds on 50FPS. This change ensures that the showing duration is accurate and not dependent of client framerate.
---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
- Replaced the frame-dependent loop ```(sec = sec - 0.01)``` with a time-based calculation using ```GetGameTimer()```.
- The loop now checks the elapsed time in milliseconds instead of decrementing a counter every frame.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
