### PR TITLE
fix(es_extended/client/imports/point) Modify Point:delete()

### DIFF
--- a/[core]/es_extended/client/imports/point.lua
+++ b/[core]/es_extended/client/imports/point.lua
@@ -39,8 +39,22 @@ function Point:constructor(properties)
 end
 
 function Point:delete()
-	ESX.RemovePointInternal(self.handle)
+    if not nearby[self.handle] then
+        return
+    end
+    nearby[self.handle] = nil
+
+    if self.leave then
+        self:leave()
+    end
+
+    if next(nearby) == nil then
+        loop = false
+    end
+
+    ESX.RemovePointInternal(self.handle)
 end
+
 
 function Point:toggle(hidden)
 	if hidden == nil then


### PR DESCRIPTION
### Description
Currently, you are unable to delete the point from within the point without the points being broken. This fix was created by Kasey and I slightly refactored it.

### PR Checklist
- [✓]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [✓]  My changes have been tested locally and function as expected.
- [✓]  My PR does not introduce any breaking changes.
- [✓]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
