### PR TITLE
feat(es_extended): add static player methods

### DIFF
--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -47,7 +47,9 @@ else
         __call = function(_, src)
             if type(src) ~= "number" then
                 src = ESX.GetPlayerIdFromIdentifier(src)
-                if not src then return end
+                if not src then
+                    return
+                end
             elseif not ESX.IsPlayerLoaded(src) then
                 return
             end

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -45,7 +45,13 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 else
     ESX.Player = setmetatable({}, {
         __call = function(_, src)
-            if not ESX.IsPlayerLoaded(src) then return end
+            if type(src) ~= "number" then
+                src = ESX.GetPlayerIdFromIdentifier(src)
+                if not src then return end
+            elseif not ESX.IsPlayerLoaded(src) then
+                return
+            end
+
             return setmetatable({src = src}, {
                 __index = function(self, method)
                     return function(...)

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -42,6 +42,19 @@ if not IsDuplicityVersion() then -- Only register this event for the client
             return error(('\n^1Error loading module (%s)'):format(external[i]))
         end
     end
+else
+    ESX.Player = setmetatable({}, {
+        __call = function(_, src)
+            if not ESX.IsPlayerLoaded(src) then return end
+            return setmetatable({src = src}, {
+                __index = function(self, method)
+                    return function(...)
+                        return exports.es_extended:RunStaticPlayerMethod(self.src, method, ...)
+                    end
+                end
+            })
+        end
+    })
 end
 
 if GetResourceState("ox_lib") == "missing" then

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -951,6 +951,10 @@ local function runStaticPlayerMethod(src, method, ...)
         return
     end
 
+    if not ESX.IsFunctionReference(xPlayer[method]) then
+        error(("Attempted to call invalid method on playerId %s: %s"):format(src, method))
+    end
+
     return xPlayer[method](...)
 end
 exports("RunStaticPlayerMethod", runStaticPlayerMethod)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -456,6 +456,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     end
 
     ---@return number
+    function self.getSource()
+        return self.source
+    end
+
+    ---@return number
     function self.getMaxWeight()
         return self.maxWeight
     end

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -91,6 +91,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
         return self.paycheckEnabled
     end
 
+    ---@return boolean
+    function self.isAdmin()
+        return Core.IsPlayerAdmin(self.source)
+    end
+
     ---@param coordinates vector4 | vector3 | table
     ---@return nil
     function self.setCoords(coordinates)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -944,3 +944,13 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
     return self
 end
+
+local function runStaticPlayerMethod(src, method, ...)
+    local xPlayer = ESX.Players[src]
+    if not xPlayer then
+        return
+    end
+
+    return xPlayer[method](...)
+end
+exports("RunStaticPlayerMethod", runStaticPlayerMethod)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -464,6 +464,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     function self.getSource()
         return self.source
     end
+    self.getPlayerId = self.getSource
 
     ---@return number
     function self.getMaxWeight()

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -358,6 +358,12 @@ function ESX.GetPlayerFromIdentifier(identifier)
     return Core.playersByIdentifier[identifier]
 end
 
+---@param source number
+---@return boolean
+function ESX.IsPlayerLoaded(source)
+    return ESX.Players[source] ~= nil
+end
+
 ---@param playerId number | string
 ---@return string
 function ESX.GetIdentifier(playerId)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -358,6 +358,12 @@ function ESX.GetPlayerFromIdentifier(identifier)
     return Core.playersByIdentifier[identifier]
 end
 
+---@param identifier string
+---@return number playerId
+function ESX.GetPlayerIdFromIdentifier(identifier)
+    return Core.playersByIdentifier[identifier]?.source
+end
+
 ---@param source number
 ---@return boolean
 function ESX.IsPlayerLoaded(source)


### PR DESCRIPTION
### Description  
Introducing **static ESX Player methods** to streamline player handling. Instead of dealing with a bloated `xPlayer` object that can impact performance as player counts grow, this implementation provides a lightweight alternative by dynamically calling only the required functionality through exports.

---

### Motivation  
The current `xPlayer` object is overly bloated, storing unnecessary data that scales poorly with larger player bases. This approach addresses these performance concerns while maintaining a syntax familiar to ESX developers.

---

### Implementation Details  
The `ESX.Player` object uses a metamethod to return a lightweight table containing only the player's server ID when called. If the requested player is offline, it simply returns `nil`. For any subsequent method calls, the stored server ID is used to trigger the appropriate export, ensuring efficient and dynamic behavior.

---

### Usage Example
```lua
local src = 1
local xPlayer = ESX.Player(src)
if (not xPlayer) then
    print("player not found")
    return
end

print(xPlayer.getIdentifier())

local identifier = "char1:12754a0705e35cda21ced87c7daf329730135087"
local xTarget = ESX.Player(identifier)
if (not xTarget) then
    print("target not found")
    return
end

print(xTarget.getIdentifier())

```
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
