### PR TITLE
fix(es_extended/server/functions): fix admin logs

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -445,6 +445,11 @@ end
 ---@param fields table
 ---@return nil
 function ESX.DiscordLogFields(name, title, color, fields)
+    for i = 1, #fields do
+        local field = fields[i]
+        field.value = tostring(field.value)
+    end
+
     local webHook = Config.DiscordLogs.Webhooks[name] or Config.DiscordLogs.Webhooks.default
     local embedData = {
         {


### PR DESCRIPTION
### Description
Discord expects field values to be strings. Before sending them to the webhook, we convert everything to string.

---
### Motivation
https://github.com/esx-framework/esx_core/issues/1604

---


### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
