### PR TITLE
feat(es_extended/client/modules/death): add gameEventTriggered for pl…

### DIFF
--- a/[core]/es_extended/client/modules/death.lua
+++ b/[core]/es_extended/client/modules/death.lua
@@ -1,6 +1,40 @@
 Death = {}
 Death._index = Death
 
+AddEventHandler("gameEventTriggered", function(event, data)
+    if event ~= "CEventNetworkEntityDamage" then
+        return
+    end
+
+    local victim, victimDied = data[1], data[4]
+    if not IsPedAPlayer(victim) then
+        return
+    end
+
+    local playerPed = PlayerPedId()
+    local player = PlayerId()
+
+    if victim and NetworkGetPlayerIndexFromPed(victim) == player and (IsPedDeadOrDying(victim, true) or IsPedFatallyInjured(victim)) then
+        local killerEntity = GetPedSourceOfDeath(playerPed)
+        local deathCause = GetPedCauseOfDeath(playerPed)
+        local killerClientId = NetworkGetPlayerIndexFromPed(killerEntity)
+        local killerServerId = GetPlayerServerId(killerClientId)
+
+        Death.killerEntity = killerEntity
+        Death.deathCause = deathCause
+        Death.killerId = killerClientId
+        Death.killerServerId = killerServerId
+
+        if killerEntity ~= playerPed and killerClientId and NetworkIsPlayerActive(killerClientId) then
+            Death:ByPlayer()
+        else
+            Death:Natural()
+        end
+
+        Death:ResetValues()
+    end
+end)
+
 function Death:ResetValues()
     self.killerEntity = nil
     self.deathCause = nil


### PR DESCRIPTION
# feat(es_extended/client/modules/death): add gameEventTriggered for player death handling

---

## Description
This merge request implements the `gameEventTriggered` event to handle player deaths. The logic distinguishes between deaths caused by another player (`Death:ByPlayer`) and natural causes (`Death:Natural`), ensuring code robustness and optimization.

---

## Key Changes
- **Implemented `gameEventTriggered`** to manage `CEventNetworkEntityDamage` for player death detection.
- Added the following functions:
  - `Death:ByPlayer`: Handles deaths caused by other players.
  - `Death:Natural`: Handles deaths from natural causes.
  - `Death:ResetValues`: Resets death-related data after processing.
- Improved client-server event communication with `esx:onPlayerDeath`.

---

## Checklist
- [x] My PR title and commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and work as expected.
- [x] My PR does not introduce breaking changes.
- [x] I have provided a clear explanation and context for the changes.

---

## Rationale
- Fixes gaps in the player death handling system.
- Improves robustness and entity validation checks.
- Ensures better communication for client and server death events.

Thank you for reviewing this PR and helping improve death handling in ESX! 🎉
