### PR TITLE
fix(esx_multicharacter/server/modules/database): fix conn string parser

### DIFF
--- a/[core]/esx_multicharacter/server/modules/database.lua
+++ b/[core]/esx_multicharacter/server/modules/database.lua
@@ -14,12 +14,12 @@ function Database:GetConnection()
         self.name = connectionString:sub(connectionString:find("/") + 1, -1):gsub("[%?]+[%w%p]*$", "")
         self.found = true
     else
-        local connectionExtracted = { string.strsplit(";", connectionString) }
-
-        for i = 1, #connectionExtracted do
-            local v = connectionExtracted[i]
-            if v:match("database") then
-                self.name = connectionString:sub(connectionString:find("/") + 1, -1):gsub("[%?]+[%w%p]*$", "")
+        local confPairs = { string.strsplit(";", connectionString) }
+        for i = 1, #confPairs do
+            local confPair = confPairs[i]
+            local key, value = confPair:match("^%s*(.-)%s*=%s*(.-)%s*$")
+            if key == "database" then
+                self.name = value
                 self.found = true
                 break
             end


### PR DESCRIPTION
### Description
Fixes the database name extraction for key-value pair connection strings.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
