### PR TITLE
feat(es_extended): allow users to change identifier type

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -52,10 +52,10 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     if Config.Multichar then
         local startIndex = identifier:find(":", 1)
         if startIndex then
-            self.license = ("license%s"):format(identifier:sub(startIndex, identifier:len()))
+            self.license = ("%s%s"):format(Config.Identifer, identifier:sub(startIndex, identifier:len()))
         end
     else
-        self.license = ("license:%s"):format(identifier)
+        self.license = ("%s:%s"):format(Config.Identifer, identifier)
     end
 
     if type(self.metadata.jobDuty) ~= "boolean" then

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -380,8 +380,8 @@ function ESX.GetIdentifier(playerId)
 
     playerId = tostring(playerId)
 
-    local identifier = GetPlayerIdentifierByType(playerId, "license")
-    return identifier and identifier:gsub("license:", "")
+    local identifier = GetPlayerIdentifierByType(playerId, Config.Identifier)
+    return identifier and identifier:gsub(Config.Identifier .. ":", "")
 end
 
 ---@param model string|number

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -64,3 +64,4 @@ if GetResourceState("ox_inventory") ~= "missing" then
 end
 
 Config.EnableDefaultInventory = Config.CustomInventory == false -- Display the default Inventory ( F2 )
+Config.Identifier = GetConvar("esx:identifier", "license")


### PR DESCRIPTION
### Description
Allows users to change the identifier type that ESX uses

---
### Motivation
Cfx not communicating changes

---

### **Implementation Details**
- Adds a convar: `esx:identifier`
- steamlines Identifier usage
- by default its `license` for compatibility
---

### Usage Example
- `set esx:identifier license2`
- `set esx:identifier steam`
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
