### PR TITLE
fix(es_extended/server/functions): missing attributes for unemployed

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -512,7 +512,7 @@ function ESX.RefreshJobs()
 
     if not Jobs then
         -- Fallback data, if no jobs exist
-        ESX.Jobs["unemployed"] = { label = "Unemployed", grades = { ["0"] = { grade = 0, label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
+        ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
     else
         ESX.Jobs = Jobs
     end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -512,7 +512,7 @@ function ESX.RefreshJobs()
 
     if not Jobs then
         -- Fallback data, if no jobs exist
-        ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
+        ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", whitelisted = false, grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
     else
         ESX.Jobs = Jobs
     end

--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -75,7 +75,7 @@ function ESX.CreateJob(name, label, grades)
     for _, grade in pairs(grades) do
         queries[#queries + 1] = {
             query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
-            values = { name, grade.grade, grade.name, grade.label, grade.salary, json.encode(grade.skin_male) or '{}', json.encode(grade.skin_female) or '{}' }
+            values = { name, grade.grade, grade.name, grade.label, grade.salary, grade.skin_male and json.encode(grade.skin_male) or '{}', grade.skin_female and json.encode(grade.skin_female) or '{}' }
         }
     end
 

--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -72,10 +72,10 @@ function ESX.CreateJob(name, label, grades)
         { query = 'INSERT INTO jobs (name, label) VALUES (?, ?)', values = { name, label } }
     }
 
-    for _, grade in ipairs(grades) do
+    for _, grade in pairs(grades) do
         queries[#queries + 1] = {
             query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
-            values = { name, grade.grade, grade.name, grade.label, grade.salary, '{}', '{}' }
+            values = { name, grade.grade, grade.name, grade.label, grade.salary, json.encode(grade.skin_male) or '{}', json.encode(grade.skin_female) or '{}' }
         }
     end
 


### PR DESCRIPTION
Missing attributes when indexing unemployed job into ESX.Jobs. Database contains name column for jobs table  and for job_grades it also contain a grade name column.

Also fixed loop method for grades when inserting into queries.

### Description
Adds the missing attributes when assigning unemployed to ESX.Jobs if no jobs are found. 
Also fixed loop method for grades when inserting into queries.
---

### Motivation
Because it makes sense
---

### **Implementation Details**
N/A
---

### Usage Example
3rd party script that compares grades[<grade>].name wouldn't work if this attribute is missing.
Fixes issues where creators parse job grades indexed with strings.
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
