### PR TITLE
feat(modules/createJob): triggerevent for created jobs

### DIFF
--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -90,5 +90,7 @@ function ESX.CreateJob(name, label, grades)
 
     notify("SUCCESS", currentResourceName, 'Job created successfully: `%s`', name)
 
+    TriggerEvent('esx:jobCreated', name, ESX.Jobs[name])
+
     return success
 end


### PR DESCRIPTION
Added a TriggerEvent when a job is created successfully, allowing developers to use an event listener and update ESX.Jobs, instead of importing the whole ESX object.

### Description
Adds a TriggerEvent "esx:jobCreated" with job name (string) and job data (table), to allow allow developers to update/sync ESX.Jobs, using an event listener, without importing the ESX object. 

---
### Motivation
Allowing developers to easily update ESX.Jobs in their script with an event listener, instead of important the whole ESX object to sync the newly created job(s).

---

### **Implementation Details**
The event has job name and job data as parameters, so instead of replacing the whole ESX.Jobs, you only add the relevant updates.

---

### Usage Example
```lua
RegisterNetEvent("esx:jobCreated", function(jobName, jobData)
    if not jobName or type(jobName) ~= 'string' then
        return 
    end
    if not jobData or type(jobData) ~= 'table' then 
        return 
    end
    ESX.Jobs[jobName] = jobData
end)
```
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
