### PR TITLE
feat(es_extended/server/modules/commands.lua): Add Validation Number

### DIFF
--- a/[core]/es_extended/server/classes/overrides/oxinventory.lua
+++ b/[core]/es_extended/server/classes/overrides/oxinventory.lua
@@ -1,4 +1,5 @@
 local Inventory
+local MAX_AMOUNT = 1.79769e+308
 
 if Config.CustomInventory ~= "ox" then return end
 
@@ -45,6 +46,7 @@ Core.PlayerFunctionOverrides.OxInventory = {
     setAccountMoney = function(self)
         return function(accountName, money, reason)
             reason = reason or "unknown"
+            money = money <= MAX_AMOUNT and money or MAX_AMOUNT
             if money < 0 then return end
             local account = self.getAccount(accountName)
 
@@ -64,6 +66,7 @@ Core.PlayerFunctionOverrides.OxInventory = {
     addAccountMoney = function(self)
         return function(accountName, money, reason)
             reason = reason or "unknown"
+            money = money <= MAX_AMOUNT and money or MAX_AMOUNT
             if money < 1 then return end
 
             local account = self.getAccount(accountName)
@@ -82,6 +85,7 @@ Core.PlayerFunctionOverrides.OxInventory = {
     removeAccountMoney = function(self)
         return function(accountName, money, reason)
             reason = reason or "unknown"
+            money = money <= MAX_AMOUNT and money or MAX_AMOUNT
             if money < 1 then return end
 
             local account = self.getAccount(accountName)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -407,15 +407,14 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     ---@return nil
     function self.addInventoryItem(itemName, count)
         local item = self.getInventoryItem(itemName)
+        if not item then return end
 
-        if item then
-            count = ESX.Math.Round(count)
-            item.count = item.count + count
-            self.weight = self.weight + (item.weight * count)
+        count += item.count
+        item.count = (count <= MAX_AMOUNT and count) or MAX_AMOUNT
+        self.weight += (item.weight * count)
 
-            TriggerEvent("esx:onAddInventoryItem", self.source, item.name, item.count)
-            self.triggerEvent("esx:addInventoryItem", item.name, item.count)
-        end
+        TriggerEvent("esx:onAddInventoryItem", self.source, item.name, item.count)
+        self.triggerEvent("esx:addInventoryItem", item.name, item.count)
     end
 
     ---@param itemName string

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -407,10 +407,9 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     ---@return nil
     function self.addInventoryItem(itemName, count)
         local item = self.getInventoryItem(itemName)
-        if not item then return end
 
         count += item.count
-        item.count = (count <= MAX_AMOUNT and count) or MAX_AMOUNT
+        item.count = ESX.Math.Round(count) <= MAX_AMOUNT and ESX.Math.Round(count) or MAX_AMOUNT
         self.weight += (item.weight * count)
 
         TriggerEvent("esx:onAddInventoryItem", self.source, item.name, item.count)

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -31,6 +31,7 @@
 function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, weight, job, loadout, name, coords, metadata)
     ---@class xPlayer
     local self = {}
+    local MAX_AMOUNT = 1.79769e+308
 
     self.accounts = accounts
     self.coords = coords
@@ -313,6 +314,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
             error(("Tried To Set Account ^5%s^1 For Player ^5%s^1 To An Invalid Number -> ^5%s^1"):format(accountName, self.playerId, money))
             return
         end
+        money = money <= MAX_AMOUNT and money or MAX_AMOUNT
         if money >= 0 then
             local account = self.getAccount(accountName)
 
@@ -340,6 +342,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
             error(("Tried To Set Account ^5%s^1 For Player ^5%s^1 To An Invalid Number -> ^5%s^1"):format(accountName, self.playerId, money))
             return
         end
+        money = money <= MAX_AMOUNT and money or MAX_AMOUNT
         if money > 0 then
             local account = self.getAccount(accountName)
             if account then
@@ -366,6 +369,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
             error(("Tried To Set Account ^5%s^1 For Player ^5%s^1 To An Invalid Number -> ^5%s^1"):format(accountName, self.playerId, money))
             return
         end
+        money = money <= MAX_AMOUNT and money or MAX_AMOUNT
         if money > 0 then
             local account = self.getAccount(accountName)
 

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -307,9 +307,9 @@ if not Config.CustomInventory then
         "giveitem",
         "admin",
         function(xPlayer, args)
-            local MAX_AMOUNT = 1.79769e+308
-            if args.amount > MAX_AMOUNT then
-                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
+            local MAX_COUNT = 1.79769e+308
+            if args.count > MAX_COUNT then
+                return showError(("Count must be between 1 and %s"):format(MAX_COUNT))
             end
             args.playerId.addInventoryItem(args.item, args.count)
             if Config.AdminLogging then
@@ -338,12 +338,12 @@ if not Config.CustomInventory then
         "giveweapon",
         "admin",
         function(xPlayer, args, showError)
-            local MAX_AMOUNT = 1.79769e+308
+            local MAX_AMMO = 1.79769e+308
             if args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveweapon_hasalready"))
             end
-            if args.amount > MAX_AMOUNT then
-                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
+            if args.ammo > MAX_AMMO then
+                return showError(("Ammo must be between 1 and %s"):format(MAX_AMMO))
             end
             args.playerId.addWeapon(args.weapon, args.ammo)
             if Config.AdminLogging then
@@ -372,12 +372,12 @@ if not Config.CustomInventory then
         "giveammo",
         "admin",
         function(xPlayer, args, showError)
-            local MAX_AMOUNT = 1.79769e+308
+            local MAX_AMMO = 1.79769e+308
             if not args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveammo_noweapon_found"))
             end
-            if args.amount > MAX_AMOUNT then
-                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
+            if args.ammo > MAX_AMMO then
+                return showError(("Ammo must be between 1 and %s"):format(MAX_AMMO))
             end
             args.playerId.addWeaponAmmo(args.weapon, args.ammo)
             if Config.AdminLogging then

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -204,12 +204,8 @@ ESX.RegisterCommand(
     "setaccountmoney",
     "admin",
     function(xPlayer, args, showError)
-        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_giveaccountmoney_invalid"))
-        end
-        if args.amount > MAX_AMOUNT then
-            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.setAccountMoney(args.account, args.amount, "Government Grant")
         if Config.AdminLogging then
@@ -238,12 +234,8 @@ ESX.RegisterCommand(
     "giveaccountmoney",
     "admin",
     function(xPlayer, args, showError)
-        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_giveaccountmoney_invalid"))
-        end
-        if args.amount > MAX_AMOUNT then
-            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.addAccountMoney(args.account, args.amount, "Government Grant")
         if Config.AdminLogging then
@@ -272,12 +264,8 @@ ESX.RegisterCommand(
     "removeaccountmoney",
     "admin",
     function(xPlayer, args, showError)
-        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_removeaccountmoney_invalid"))
-        end
-        if args.amount > MAX_AMOUNT then
-            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.removeAccountMoney(args.account, args.amount, "Government Tax")
         if Config.AdminLogging then
@@ -307,10 +295,6 @@ if not Config.CustomInventory then
         "giveitem",
         "admin",
         function(xPlayer, args)
-            local MAX_COUNT = 1.79769e+308
-            if args.count > MAX_COUNT then
-                return showError(("Count must be between 1 and %s"):format(MAX_COUNT))
-            end
             args.playerId.addInventoryItem(args.item, args.count)
             if Config.AdminLogging then
                 ESX.DiscordLogFields("UserActions", "Give Item /giveitem Triggered!", "pink", {
@@ -338,12 +322,8 @@ if not Config.CustomInventory then
         "giveweapon",
         "admin",
         function(xPlayer, args, showError)
-            local MAX_AMMO = 1.79769e+308
             if args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveweapon_hasalready"))
-            end
-            if args.ammo > MAX_AMMO then
-                return showError(("Ammo must be between 1 and %s"):format(MAX_AMMO))
             end
             args.playerId.addWeapon(args.weapon, args.ammo)
             if Config.AdminLogging then
@@ -372,12 +352,8 @@ if not Config.CustomInventory then
         "giveammo",
         "admin",
         function(xPlayer, args, showError)
-            local MAX_AMMO = 1.79769e+308
             if not args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveammo_noweapon_found"))
-            end
-            if args.ammo > MAX_AMMO then
-                return showError(("Ammo must be between 1 and %s"):format(MAX_AMMO))
             end
             args.playerId.addWeaponAmmo(args.weapon, args.ammo)
             if Config.AdminLogging then

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -204,8 +204,12 @@ ESX.RegisterCommand(
     "setaccountmoney",
     "admin",
     function(xPlayer, args, showError)
+        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_giveaccountmoney_invalid"))
+        end
+        if args.amount > MAX_AMOUNT then
+            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.setAccountMoney(args.account, args.amount, "Government Grant")
         if Config.AdminLogging then
@@ -234,8 +238,12 @@ ESX.RegisterCommand(
     "giveaccountmoney",
     "admin",
     function(xPlayer, args, showError)
+        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_giveaccountmoney_invalid"))
+        end
+        if args.amount > MAX_AMOUNT then
+            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.addAccountMoney(args.account, args.amount, "Government Grant")
         if Config.AdminLogging then

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -272,8 +272,12 @@ ESX.RegisterCommand(
     "removeaccountmoney",
     "admin",
     function(xPlayer, args, showError)
+        local MAX_AMOUNT = 1.79769e+308
         if not args.playerId.getAccount(args.account) then
             return showError(TranslateCap("command_removeaccountmoney_invalid"))
+        end
+        if args.amount > MAX_AMOUNT then
+            return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
         end
         args.playerId.removeAccountMoney(args.account, args.amount, "Government Tax")
         if Config.AdminLogging then

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -307,6 +307,10 @@ if not Config.CustomInventory then
         "giveitem",
         "admin",
         function(xPlayer, args)
+            local MAX_AMOUNT = 1.79769e+308
+            if args.amount > MAX_AMOUNT then
+                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
+            end
             args.playerId.addInventoryItem(args.item, args.count)
             if Config.AdminLogging then
                 ESX.DiscordLogFields("UserActions", "Give Item /giveitem Triggered!", "pink", {
@@ -334,8 +338,12 @@ if not Config.CustomInventory then
         "giveweapon",
         "admin",
         function(xPlayer, args, showError)
+            local MAX_AMOUNT = 1.79769e+308
             if args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveweapon_hasalready"))
+            end
+            if args.amount > MAX_AMOUNT then
+                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
             end
             args.playerId.addWeapon(args.weapon, args.ammo)
             if Config.AdminLogging then
@@ -364,8 +372,12 @@ if not Config.CustomInventory then
         "giveammo",
         "admin",
         function(xPlayer, args, showError)
+            local MAX_AMOUNT = 1.79769e+308
             if not args.playerId.hasWeapon(args.weapon) then
                 return showError(TranslateCap("command_giveammo_noweapon_found"))
+            end
+            if args.amount > MAX_AMOUNT then
+                return showError(("Amount must be between 1 and %s"):format(MAX_AMOUNT))
             end
             args.playerId.addWeaponAmmo(args.weapon, args.ammo)
             if Config.AdminLogging then


### PR DESCRIPTION
### Description
This prevents the use of values exceeding the IEEE 754 double-precision floating-point limit.
Entering a value higher than this limit would cause ox to stop functioning and produce the following error: `SEND_NUI_MESSAGE: invalid JSON passed in frame (rapidjson error code 3)`.
Additionally, if you attempt to remove money exceeding this limit, ox would no longer be functioning and you would no longer be able to give any more money. This would require manually resetting your money and removing cash-based items from the database to restore normal functionality.

---
### Motivation
This change prevents admins from unintentionally or maliciously causing issues for players.

---

### **Implementation Details**
Improving server-side protections is crucial, as you can never fully anticipate the intentions of people you don’t know well.
More security is always better than less.

---

### Usage Example
When attempting to give an item, add, or remove money, an error will be displayed if the value exceeds the maximum allowed limit: `1.79769e+308.`

---

### PR Checklist
- [X]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X]  My changes have been tested locally and function as expected.
- [X]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
