### PR TITLE
fix(es_extended/server/main): GlobalState jobcount infinitely increasing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug] - esx_script - Issue"
-labels: bug, enhancement
-assignees: Kenshiin13, Arctos2win
+labels: bug
+assignees: Arctos2win, Kenshiin13
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,10 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug] - esx_script - Issue"
-labels: bug
-assignees:
-  - TheFantomas
-  - Gellipapa
+labels: bug, enhancement
+assignees: Kenshiin13, Arctos2win
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Help us improve esx with your ideas
 title: "[Feature Request] - esx_script - Add better configuration"
 labels: enhancement
-assignees: Kenshiin13, Arctos2win
+assignees: Arctos2win, Kenshiin13
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,9 +3,7 @@ name: Feature Request
 about: Help us improve esx with your ideas
 title: "[Feature Request] - esx_script - Add better configuration"
 labels: enhancement
-assignees:
-  - TheFantomas
-  - Gellipapa
+assignees: Kenshiin13, Arctos2win
 
 ---
 

--- a/[core]/cron/fxmanifest.lua
+++ b/[core]/cron/fxmanifest.lua
@@ -4,6 +4,6 @@ game 'gta5'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 server_script 'server/main.lua'

--- a/[core]/cron/fxmanifest.lua
+++ b/[core]/cron/fxmanifest.lua
@@ -4,6 +4,6 @@ game 'gta5'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 server_script 'server/main.lua'

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'The Core resource that provides the functionalities for all other resources.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 shared_scripts {
 	'locale.lua',

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'The Core resource that provides the functionalities for all other resources.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 shared_scripts {
 	'locale.lua',

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -353,6 +353,11 @@ end)
 
 AddEventHandler("esx:playerLogout", function(playerId, cb)
     local xPlayer = ESX.GetPlayerFromId(playerId)
+    local job = xPlayer.getJob().name
+    
+    Core.JobsPlayerCount[job] = Core.JobsPlayerCount[job] - 1
+    GlobalState[("%s:count"):format(job)] = Core.JobsPlayerCount[job]
+        
     if xPlayer then
         TriggerEvent("esx:playerDropped", playerId)
 

--- a/[core]/esx_chat_theme/fxmanifest.lua
+++ b/[core]/esx_chat_theme/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.12.3'
+version '1.12.4'
 author 'ESX-Framework'
 description 'A ESX Stylised theme for the chat resource.'
 

--- a/[core]/esx_chat_theme/fxmanifest.lua
+++ b/[core]/esx_chat_theme/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.12.2'
+version '1.12.3'
 author 'ESX-Framework'
 description 'A ESX Stylised theme for the chat resource.'
 

--- a/[core]/esx_context/fxmanifest.lua
+++ b/[core]/esx_context/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'gta5'
 author 'ESX-Framework & Brayden'
 description 'A simplistic context menu for ESX.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 ui_page 'index.html'
 

--- a/[core]/esx_context/fxmanifest.lua
+++ b/[core]/esx_context/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'gta5'
 author 'ESX-Framework & Brayden'
 description 'A simplistic context menu for ESX.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 ui_page 'index.html'
 

--- a/[core]/esx_identity/fxmanifest.lua
+++ b/[core]/esx_identity/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'Allows the player to Pick their characters: Name, Gender, Height and Date-of-birth.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 shared_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_identity/fxmanifest.lua
+++ b/[core]/esx_identity/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'Allows the player to Pick their characters: Name, Gender, Height and Date-of-birth.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 shared_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_loadingscreen/fxmanifest.lua
+++ b/[core]/esx_loadingscreen/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'common'
 fx_version 'cerulean'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 loadscreen 'index.html'

--- a/[core]/esx_loadingscreen/fxmanifest.lua
+++ b/[core]/esx_loadingscreen/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'common'
 fx_version 'cerulean'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 loadscreen 'index.html'

--- a/[core]/esx_menu_default/fxmanifest.lua
+++ b/[core]/esx_menu_default/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic menu system for ESX Legacy.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 client_scripts { '@es_extended/imports.lua', 'client/main.lua' }
 

--- a/[core]/esx_menu_default/fxmanifest.lua
+++ b/[core]/esx_menu_default/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic menu system for ESX Legacy.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 client_scripts { '@es_extended/imports.lua', 'client/main.lua' }
 

--- a/[core]/esx_menu_dialog/fxmanifest.lua
+++ b/[core]/esx_menu_dialog/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic input dialog for ESX Legacy.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 client_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_menu_dialog/fxmanifest.lua
+++ b/[core]/esx_menu_dialog/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic input dialog for ESX Legacy.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 client_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_menu_list/fxmanifest.lua
+++ b/[core]/esx_menu_list/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic table-based menu system for ESX Legacy.'
 lua54 'yes'
-version '1.12.3'
+version '1.12.4'
 
 
 client_scripts {

--- a/[core]/esx_menu_list/fxmanifest.lua
+++ b/[core]/esx_menu_list/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic table-based menu system for ESX Legacy.'
 lua54 'yes'
-version '1.12.2'
+version '1.12.3'
 
 
 client_scripts {

--- a/[core]/esx_multicharacter/fxmanifest.lua
+++ b/[core]/esx_multicharacter/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 author 'ESX-Framework - Linden - KASH'
 description 'Allows players to have multiple characters on the same account.'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 dependencies { 'es_extended', 'esx_context', 'esx_identity', 'esx_skin' }

--- a/[core]/esx_multicharacter/fxmanifest.lua
+++ b/[core]/esx_multicharacter/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 author 'ESX-Framework - Linden - KASH'
 description 'Allows players to have multiple characters on the same account.'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 dependencies { 'es_extended', 'esx_context', 'esx_identity', 'esx_skin' }

--- a/[core]/esx_notify/fxmanifest.lua
+++ b/[core]/esx_notify/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 lua54 'yes'
 game 'gta5'
-version '1.12.3'
+version '1.12.4'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI notification system for ESX'
 

--- a/[core]/esx_notify/fxmanifest.lua
+++ b/[core]/esx_notify/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 lua54 'yes'
 game 'gta5'
-version '1.12.2'
+version '1.12.3'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI notification system for ESX'
 

--- a/[core]/esx_progressbar/fxmanifest.lua
+++ b/[core]/esx_progressbar/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI progress bar for ESX'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 client_scripts { 'Progress.lua' }

--- a/[core]/esx_progressbar/fxmanifest.lua
+++ b/[core]/esx_progressbar/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI progress bar for ESX'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 client_scripts { 'Progress.lua' }

--- a/[core]/esx_skin/fxmanifest.lua
+++ b/[core]/esx_skin/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Allows players to customise their character\'s appearance'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 shared_scripts {

--- a/[core]/esx_skin/fxmanifest.lua
+++ b/[core]/esx_skin/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Allows players to customise their character\'s appearance'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 shared_scripts {

--- a/[core]/esx_textui/fxmanifest.lua
+++ b/[core]/esx_textui/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple Persistent Notification system for ESX.'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 client_scripts { 'TextUI.lua' }

--- a/[core]/esx_textui/fxmanifest.lua
+++ b/[core]/esx_textui/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple Persistent Notification system for ESX.'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 client_scripts { 'TextUI.lua' }

--- a/[core]/skinchanger/fxmanifest.lua
+++ b/[core]/skinchanger/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Saves/loads character appearances for ESX Legacy.'
-version '1.12.2'
+version '1.12.3'
 lua54 'yes'
 
 client_scripts {

--- a/[core]/skinchanger/fxmanifest.lua
+++ b/[core]/skinchanger/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Saves/loads character appearances for ESX Legacy.'
-version '1.12.3'
+version '1.12.4'
 lua54 'yes'
 
 client_scripts {


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
GlobalState Jobcount didn't decrease on logout and increased on char select, this way players could infinitely increase the value by relogging multiple times

### Motivation
<!-- Explain why you are making this PR -->
Fixed this bug for my Server and decided to create a PR

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
globalstate decreases on logout and increases again on login

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
no example
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
