### PR TITLE
fix(es_extended/server/main): GlobalState jobcount infinitely increasing

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -353,6 +353,11 @@ end)
 
 AddEventHandler("esx:playerLogout", function(playerId, cb)
     local xPlayer = ESX.GetPlayerFromId(playerId)
+    local job = xPlayer.getJob().name
+
+    Core.JobsPlayerCount[job] = Core.JobsPlayerCount[job] - 1
+    GlobalState[("%s:count"):format(job)] = Core.JobsPlayerCount[job]
+        
     if xPlayer then
         TriggerEvent("esx:playerDropped", playerId)
 


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
GlobalState Jobcount didn't decrease on logout and increased on char select, this way players could infinitely increase the value by relogging multiple times

### Motivation
<!-- Explain why you are making this PR -->
Fixed this bug for my Server and decided to create a PR

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
globalstate decreases on logout and increases again on login

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
no example
### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
