### PR TITLE
Fix the error causing the function to always return false.

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -612,7 +612,7 @@ end
 ---@param playerId string | number
 ---@return boolean
 function Core.IsPlayerAdmin(playerId)
-    playerId = tostring(playerId)
+    playerId = tonumber(playerId)
     if (IsPlayerAceAllowed(playerId, "command") or GetConvar("sv_lan", "") == "true") then
         return true
     end


### PR DESCRIPTION
Fix the error causing the function always returning false if player doesn't have access to all commands. The key in the players table should be a number not a string, it caused the function to return false even if the group is in config.

### Description
<!-- Explain What this PR does -->

---
### Motivation
<!-- Explain why you are making this PR -->

---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
---

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
