### PR TITLE
fix(es_extended/server/functions): use string for IsPlayerAceAllowed only 

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -607,8 +607,7 @@ end
 ---@param playerId string | number
 ---@return boolean
 function Core.IsPlayerAdmin(playerId)
-    playerId = tostring(playerId)
-    if (IsPlayerAceAllowed(playerId, "command") or GetConvar("sv_lan", "") == "true") then
+    if (IsPlayerAceAllowed(tostring(playerId), "command") or GetConvar("sv_lan", "") == "true") then
         return true
     end
 


### PR DESCRIPTION
### Description
This PR ensures that playerId is only converted to a string for IsPlayerAceAllowed, while keeping it numeric for ESX.Players lookup.

### Motivation
Previously, playerId was being converted to a string globally in IsPlayerAdmin, which caused issues when looking up players in ESX.Players, as it uses numeric indexes. This fix ensures proper compatibility.

### **Implementation Details**
- playerId is now converted to a string only when calling IsPlayerAceAllowed.
- Everywhere else, playerId remains numeric to match ESX.Players indexing.
- This prevents lookup issues while maintaining proper permission checks.

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
