### PR TITLE
fix(config): update minimum age year from 2005 to 2007 for accuracy

### DIFF
--- a/[core]/esx_identity/config.lua
+++ b/[core]/esx_identity/config.lua
@@ -14,7 +14,7 @@ Config.MaxNameLength = 20 -- Max Name Length.
 Config.MinHeight = 120 -- 120 cm lowest height
 Config.MaxHeight = 220 -- 220 cm max height.
 Config.LowestYear = 1900 -- 112 years old is the oldest you can be.
-Config.HighestYear = 2005 -- 18 years old is the youngest you can be.
+Config.HighestYear = 2007 -- 18 years old is the youngest you can be.
 
 Config.FullCharDelete = true -- Delete all reference to character.
 Config.EnableDebugging = ESX.GetConfig().EnableDebug -- prints for debugging :)


### PR DESCRIPTION
### Description
Just a update to match the right year because its 2025 and you can be 18 years old if you are born in 2007

---
### Motivation
I just opend the config and it bothered me

---

### **Implementation Details**
Just a Config value update
---

### Usage Example
None
---

### PR Checklist
- [ ]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
