### PR TITLE
feat(callback): add `AwaitClientCallback` function

### DIFF
--- a/[core]/es_extended/server/modules/paycheck.lua
+++ b/[core]/es_extended/server/modules/paycheck.lua
@@ -9,29 +9,30 @@ function StartPayCheck()
                 local salary = (job == "unemployed" or onDuty) and xPlayer.job.grade_salary or ESX.Math.Round(xPlayer.job.grade_salary * Config.OffDutyPaycheckMultiplier)
 
                 if xPlayer.paycheckEnabled then
+                    TriggerEvent("esx:paycheckReceived", xPlayer.source, salary, job, jobLabel, onDuty)
                     if salary > 0 then
                         if job == "unemployed" then -- unemployed
                             xPlayer.addAccountMoney("bank", salary, "Welfare Check")
                             TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)
                             if Config.LogPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Unemployment Benefits", "green", {
-                                    { name = "Player", value = xPlayer.name, inline = true },
-                                    { name = "ID", value = xPlayer.source, inline = true },
-                                    { name = "Amount", value = salary, inline = true },
+                                    { name = "Player", value = xPlayer.name,   inline = true },
+                                    { name = "ID",     value = xPlayer.source, inline = true },
+                                    { name = "Amount", value = salary,         inline = true },
                                 })
                             end
-                        elseif Config.EnableSocietyPayouts then -- possibly a society
+                        elseif Config.EnableSocietyPayouts then         -- possibly a society
                             TriggerEvent("esx_society:getSociety", xPlayer.job.name, function(society)
-                                if society ~= nil then -- verified society
+                                if society ~= nil then                  -- verified society
                                     TriggerEvent("esx_addonaccount:getSharedAccount", society.account, function(account)
                                         if account.money >= salary then -- does the society money to pay its employees?
                                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
                                             account.removeMoney(salary)
                                             if Config.LogPaycheck then
                                                 ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
-                                                    { name = "Player", value = xPlayer.name, inline = true },
-                                                    { name = "ID", value = xPlayer.source, inline = true },
-                                                    { name = "Amount", value = salary, inline = true },
+                                                    { name = "Player", value = xPlayer.name,   inline = true },
+                                                    { name = "ID",     value = xPlayer.source, inline = true },
+                                                    { name = "Amount", value = salary,         inline = true },
                                                 })
                                             end
 
@@ -44,9 +45,9 @@ function StartPayCheck()
                                     xPlayer.addAccountMoney("bank", salary, "Paycheck")
                                     if Config.LogPaycheck then
                                         ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
-                                            { name = "Player", value = xPlayer.name, inline = true },
-                                            { name = "ID", value = xPlayer.source, inline = true },
-                                            { name = "Amount", value = salary, inline = true },
+                                            { name = "Player", value = xPlayer.name,   inline = true },
+                                            { name = "ID",     value = xPlayer.source, inline = true },
+                                            { name = "Amount", value = salary,         inline = true },
                                         })
                                     end
                                     TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
@@ -56,9 +57,9 @@ function StartPayCheck()
                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
                             if Config.LogPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Generic", "green", {
-                                    { name = "Player", value = xPlayer.name, inline = true },
-                                    { name = "ID", value = xPlayer.source, inline = true },
-                                    { name = "Amount", value = salary, inline = true },
+                                    { name = "Player", value = xPlayer.name,   inline = true },
+                                    { name = "ID",     value = xPlayer.source, inline = true },
+                                    { name = "Amount", value = salary,         inline = true },
                                 })
                             end
                             TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)

--- a/[core]/es_extended/server/modules/paycheck.lua
+++ b/[core]/es_extended/server/modules/paycheck.lua
@@ -9,30 +9,29 @@ function StartPayCheck()
                 local salary = (job == "unemployed" or onDuty) and xPlayer.job.grade_salary or ESX.Math.Round(xPlayer.job.grade_salary * Config.OffDutyPaycheckMultiplier)
 
                 if xPlayer.paycheckEnabled then
-                    TriggerEvent("esx:paycheckReceived", xPlayer.source, salary, job, jobLabel, onDuty)
                     if salary > 0 then
                         if job == "unemployed" then -- unemployed
                             xPlayer.addAccountMoney("bank", salary, "Welfare Check")
                             TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)
                             if Config.LogPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Unemployment Benefits", "green", {
-                                    { name = "Player", value = xPlayer.name,   inline = true },
-                                    { name = "ID",     value = xPlayer.source, inline = true },
-                                    { name = "Amount", value = salary,         inline = true },
+                                    { name = "Player", value = xPlayer.name, inline = true },
+                                    { name = "ID", value = xPlayer.source, inline = true },
+                                    { name = "Amount", value = salary, inline = true },
                                 })
                             end
-                        elseif Config.EnableSocietyPayouts then         -- possibly a society
+                        elseif Config.EnableSocietyPayouts then -- possibly a society
                             TriggerEvent("esx_society:getSociety", xPlayer.job.name, function(society)
-                                if society ~= nil then                  -- verified society
+                                if society ~= nil then -- verified society
                                     TriggerEvent("esx_addonaccount:getSharedAccount", society.account, function(account)
                                         if account.money >= salary then -- does the society money to pay its employees?
                                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
                                             account.removeMoney(salary)
                                             if Config.LogPaycheck then
                                                 ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
-                                                    { name = "Player", value = xPlayer.name,   inline = true },
-                                                    { name = "ID",     value = xPlayer.source, inline = true },
-                                                    { name = "Amount", value = salary,         inline = true },
+                                                    { name = "Player", value = xPlayer.name, inline = true },
+                                                    { name = "ID", value = xPlayer.source, inline = true },
+                                                    { name = "Amount", value = salary, inline = true },
                                                 })
                                             end
 
@@ -45,9 +44,9 @@ function StartPayCheck()
                                     xPlayer.addAccountMoney("bank", salary, "Paycheck")
                                     if Config.LogPaycheck then
                                         ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
-                                            { name = "Player", value = xPlayer.name,   inline = true },
-                                            { name = "ID",     value = xPlayer.source, inline = true },
-                                            { name = "Amount", value = salary,         inline = true },
+                                            { name = "Player", value = xPlayer.name, inline = true },
+                                            { name = "ID", value = xPlayer.source, inline = true },
+                                            { name = "Amount", value = salary, inline = true },
                                         })
                                     end
                                     TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
@@ -57,9 +56,9 @@ function StartPayCheck()
                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
                             if Config.LogPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Generic", "green", {
-                                    { name = "Player", value = xPlayer.name,   inline = true },
-                                    { name = "ID",     value = xPlayer.source, inline = true },
-                                    { name = "Amount", value = salary,         inline = true },
+                                    { name = "Player", value = xPlayer.name, inline = true },
+                                    { name = "ID", value = xPlayer.source, inline = true },
+                                    { name = "Amount", value = salary, inline = true },
                                 })
                             end
                             TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)


### PR DESCRIPTION
### Description
Adds the `ESX.AwaitClientCallback` function.
#1628 

---
### Motivation
To match `ESX.AwaitServerCallback` and just personal preference.

---
### **Implementation Details**
Added the same logic that is used on the client-side to await the server callbacks.
---

### Usage Example
```lua
local data = ESX.AwaitClientCallback(source, 'test:client:receiveData', false)
print(json.encode(data))
```
Which can be seen equivalent to
```lua
ESX.TriggerClientCallback(source, 'test:client:receiveData', function(data)
    print(json.encode(data))
end)
```
---

### PR Checklist
- [X]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X]  My changes have been tested locally and function as expected.
- [X]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
