### PR TITLE
Refactor name validation: remove numeric check and simplify character validation

### DIFF
--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -39,6 +39,14 @@ Config.AdminGroups = {
     ["admin"] = true,
 }
 
+Config.ValidCharacterSets = { -- Only enable additional charsets if your server is multilingual. By default everything is false.
+    ['el'] = false, -- Greek
+    ['sr'] = false, -- Cyrillic
+    ['he'] = false, -- Hebrew
+    ['ar'] = false, -- Arabic
+    ['zh-cn'] = false -- Chinese, Japanese, Korean
+}
+
 Config.EnablePaycheck = true -- enable paycheck
 Config.LogPaycheck = false -- Logs paychecks to a nominated Discord channel via webhook (default is false)
 Config.EnableSocietyPayouts = false -- pay from the society account that the player is employed at? Requirement: esx_society

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -212,8 +212,9 @@ function ESX.Await(conditionFunc, errorMessage, timeoutMs)
 end
 
 ---@param str string
+---@param allowDigits boolean? Allow numbers if necessary
 ---@return boolean
-function ESX.IsValidLocaleString(str)
+function ESX.IsValidLocaleString(str, allowDigits)
     if not ESX.ValidateType(str, 'string') then
         return false
     end
@@ -227,6 +228,10 @@ function ESX.IsValidLocaleString(str)
         {0x002D, 0x002D}, -- Dash
         {0x00C0, 0x02AF}  -- Latin Extended
     }
+
+    if allowDigits then
+        defaultRanges[#defaultRanges + 1] = {0x0030, 0x0039} -- 0-9 Numbers
+    end
 
     local localeRanges = {
         ["el"] = { {0x0370, 0x03FF} }, -- Greek

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -214,6 +214,10 @@ end
 ---@param str string
 ---@return boolean
 function ESX.IsValidLocaleString(str)
+    if not ESX.ValidateType(str, 'string') then
+        return false
+    end
+
     local locale = string.lower(Config.Locale)
 
     local defaultRanges ={
@@ -265,7 +269,8 @@ function ESX.IsValidLocaleString(str)
     for _, code in utf8.codes(str) do
         local isValid = false
 
-        for _, range in ipairs(validRanges) do
+        for i = 1, #validRanges do
+            local range = validRanges[i]
             if code >= range[1] and code <= range[2] then
                 isValid = true
                 break

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -244,11 +244,7 @@ function ESX.IsValidLocaleString(str)
         ["zh-cn"] ={ {0x4E00, 0x9FFF} } -- CJK
     }
 
-    local validRanges = {}
-
-    for i = 1, #defaultRanges do
-        validRanges[#validRanges + 1] = defaultRanges[i]
-    end
+    local validRanges = { table.unpack(defaultRanges) }
 
     if localeRanges[locale] then
         for i = 1, #localeRanges[locale] do

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -86,28 +86,30 @@ end
 
 local function checkValidCharacter(str)
     for _, code in utf8.codes(str) do
+        if not (
 
-        local isBasicLatin = (code >= 0x0041 and code <= 0x005A) or (code >= 0x0061 and code <= 0x007A)
-        local isSpaceOrDash = (code == 0x0020 or code == 0x002D)
-        local isLatinExtended = (code >= 0x00C0 and code <= 0x02AF)
-        local isGreek = (code >= 0x0370 and code <= 0x03FF)
-        local isCyrillic = (code >= 0x0400 and code <= 0x04FF)
-        local isHebrew = (code >= 0x05D0 and code <= 0x05EA)
-        local isArabic =
-            (code >= 0x0620 and code <= 0x063F) or
-            (code >= 0x0641 and code <= 0x064A) or
-            (code >= 0x066E and code <= 0x066F) or
-            (code >= 0x0671 and code <= 0x06D3) or
-            (code == 0x06D5) or
-            (code >= 0x0750 and code <= 0x077F) or
-            (code >= 0x08A0 and code <= 0x08BD)
-        local isCJK = (code >= 0x4E00 and code <= 0x9FFF)
-
-        if not (isBasicLatin or isSpaceOrDash or isLatinExtended or isGreek or isCyrillic or isHebrew or isArabic or isCJK) then
+                (code >= 0x0041 and code <= 0x005A) or -- Basic Latin uppercase
+                (code >= 0x0061 and code <= 0x007A) or -- Basic Latin lowercase
+                (code == 0x0020 or code == 0x002D) or -- Space or dash
+                (code >= 0x00C0 and code <= 0x02AF) or -- Latin Extended
+                (code >= 0x0370 and code <= 0x03FF) or -- Greek
+                (code >= 0x0400 and code <= 0x04FF) or -- Cyrillic
+                (code >= 0x05D0 and code <= 0x05EA) or -- Hebrew letters
+                ( -- Arabic
+                    (code >= 0x0620 and code <= 0x063F) or
+                    (code >= 0x0641 and code <= 0x064A) or
+                    (code >= 0x066E and code <= 0x066F) or
+                    (code >= 0x0671 and code <= 0x06D3) or
+                    (code == 0x06D5) or
+                    (code >= 0x0750 and code <= 0x077F) or
+                    (code >= 0x08A0 and code <= 0x08BD)
+                ) or
+                (code >= 0x4E00 and code <= 0x9FFF) -- CJK
+            )
+        then
             return false
         end
     end
-
     return true
 end
 

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -84,16 +84,35 @@ local function formatDate(str)
     return date
 end
 
-local function checkAlphanumeric(str)
-    return (string.match(str, "%W"))
-end
+local function checkValidCharacter(str)
+    for _, code in utf8.codes(str) do
 
-local function checkForNumbers(str)
-    return (string.match(str, "%d"))
+        local isBasicLatin = (code >= 0x0041 and code <= 0x005A) or (code >= 0x0061 and code <= 0x007A)
+        local isSpaceOrDash = (code == 0x0020 or code == 0x002D)
+        local isLatinExtended = (code >= 0x00C0 and code <= 0x02AF)
+        local isGreek = (code >= 0x0370 and code <= 0x03FF)
+        local isCyrillic = (code >= 0x0400 and code <= 0x04FF)
+        local isHebrew = (code >= 0x05D0 and code <= 0x05EA)
+        local isArabic =
+            (code >= 0x0620 and code <= 0x063F) or
+            (code >= 0x0641 and code <= 0x064A) or
+            (code >= 0x066E and code <= 0x066F) or
+            (code >= 0x0671 and code <= 0x06D3) or
+            (code == 0x06D5) or
+            (code >= 0x0750 and code <= 0x077F) or
+            (code >= 0x08A0 and code <= 0x08BD)
+        local isCJK = (code >= 0x4E00 and code <= 0x9FFF)
+
+        if not (isBasicLatin or isSpaceOrDash or isLatinExtended or isGreek or isCyrillic or isHebrew or isArabic or isCJK) then
+            return false
+        end
+    end
+
+    return true
 end
 
 local function checkNameFormat(name)
-    if not checkAlphanumeric(name) and not checkForNumbers(name) then
+    if checkValidCharacter(name) then
         local stringLength = string.len(name)
         return stringLength > 0 and stringLength < Config.MaxNameLength
     end

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -84,37 +84,8 @@ local function formatDate(str)
     return date
 end
 
-local function checkValidCharacter(str)
-    for _, code in utf8.codes(str) do
-        if not (
-
-                (code >= 0x0041 and code <= 0x005A) or -- Basic Latin uppercase
-                (code >= 0x0061 and code <= 0x007A) or -- Basic Latin lowercase
-                (code == 0x0020 or code == 0x002D) or -- Space or dash
-                (code >= 0x00C0 and code <= 0x02AF) or -- Latin Extended
-                (code >= 0x0370 and code <= 0x03FF) or -- Greek
-                (code >= 0x0400 and code <= 0x04FF) or -- Cyrillic
-                (code >= 0x05D0 and code <= 0x05EA) or -- Hebrew letters
-                ( -- Arabic
-                    (code >= 0x0620 and code <= 0x063F) or
-                    (code >= 0x0641 and code <= 0x064A) or
-                    (code >= 0x066E and code <= 0x066F) or
-                    (code >= 0x0671 and code <= 0x06D3) or
-                    (code == 0x06D5) or
-                    (code >= 0x0750 and code <= 0x077F) or
-                    (code >= 0x08A0 and code <= 0x08BD)
-                ) or
-                (code >= 0x4E00 and code <= 0x9FFF) -- CJK
-            )
-        then
-            return false
-        end
-    end
-    return true
-end
-
 local function checkNameFormat(name)
-    if checkValidCharacter(name) then
+    if ESX.IsValidLocaleString(name) then
         local stringLength = string.len(name)
         return stringLength > 0 and stringLength < Config.MaxNameLength
     end


### PR DESCRIPTION
### Description
This PR refactors the name validation logic by removing the redundant numeric check and simplifying the character validation to handle various character sets like Latin, Greek, Cyrillic, Hebrew, Arabic, and CJK. This change improves the validation process and ensures that only valid characters are accepted, making it more flexible for different language users within the community.

---
### Motivation
The previous validation logic had a redundant numeric check, which was unnecessary because it was already covered by the new character validation logic. This update simplifies the code, improving code readability and making the validation process more flexible. It better supports a wider range of languages and scripts, which is an important step toward making the framework more inclusive for a global community.

---

### **Implementation Details**
- The 'checkValidCharacter()' function is now responsible for validating characters based on their Unicode code ranges, including Latin, Greek, Cyrillic, Hebrew, Arabic, and CJK characters.

- The numeric check has been removed as it was redundant.

- The 'checkNameFormat()' function now solely depends on 'checkValidCharacter()' to validate names.

- This change is also a step toward ensuring that the ESX framework continues to grow in a way that is inclusive and beneficial for developers around the world.
---

### Usage Example
The following function validates a name:
```lua
local function checkNameFormat(name)
    if checkValidCharacter(name) then
        local stringLength = string.len(name)
        return stringLength > 0 and stringLength < Config.MaxNameLength
    end

    return false
end
```
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
