### PR TITLE
Identity age validation

### DIFF
--- a/[core]/esx_identity/config.lua
+++ b/[core]/esx_identity/config.lua
@@ -13,8 +13,8 @@ Config.DateFormat = "DD/MM/YYYY"
 Config.MaxNameLength = 20 -- Max Name Length.
 Config.MinHeight = 120 -- 120 cm lowest height
 Config.MaxHeight = 220 -- 220 cm max height.
-Config.LowestYear = 1900 -- 112 years old is the oldest you can be.
-Config.HighestYear = 2005 -- 18 years old is the youngest you can be.
+Config.MinAge = 18 -- 18 years old is the youngest you can be.
+Config.MaxAge = 112 -- 112 years old is the oldest you can be.
 
 Config.FullCharDelete = true -- Delete all reference to character.
 Config.EnableDebugging = ESX.GetConfig().EnableDebug -- prints for debugging :)

--- a/[core]/esx_identity/config.lua
+++ b/[core]/esx_identity/config.lua
@@ -13,8 +13,7 @@ Config.DateFormat = "DD/MM/YYYY"
 Config.MaxNameLength = 20 -- Max Name Length.
 Config.MinHeight = 120 -- 120 cm lowest height
 Config.MaxHeight = 220 -- 220 cm max height.
-Config.MinAge = 18 -- 18 years old is the youngest you can be.
-Config.MaxAge = 112 -- 112 years old is the oldest you can be.
+Config.MaxAge = 100 -- 100 years old is the oldest you can be.
 
 Config.FullCharDelete = true -- Delete all reference to character.
 Config.EnableDebugging = ESX.GetConfig().EnableDebug -- prints for debugging :)

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -83,11 +83,7 @@ local function checkDOBFormat(dob)
     if month < 1 or month > 12 then return false end
 
     -- Days in each month (starting from January.)
-    local daysInMonth = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
-    if month == 2 and isLeapYear(year) then
-        daysInMonth[2] = 29
-    end
-
+    local daysInMonth = { 31, isLeapYear(year) and 29 or 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
     return day >= 1 and day <= daysInMonth[month]
 end
 

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -55,7 +55,7 @@ end
 local function checkDOBFormat(dob)
     dob = tostring(dob)
 
-    local dayStr, monthStr, yearStr = dob:match('^(%d%d?)/(%d%d?)/(%d%d%d%d)$')
+    local dayStr, monthStr, yearStr = dob:match("^(%d%d?)/(%d%d?)/(%d%d%d%d)$")
     if not dayStr or not monthStr or not yearStr then
         return false
     end

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -70,16 +70,7 @@ local function checkDOBFormat(dob)
     local minYear = currentYear - Config.MaxAge
     local maxYear = currentYear - 18
 
-    if year < minYear or year > maxYear  then
-        return false
-    end
-
-    if year == currentYear then
-        if month > currentDate.month or (month == currentDate.month and day > currentDate.day) then
-            return false
-        end
-    end
-
+    if year < minYear or year > maxYear  then return false end
     if month < 1 or month > 12 then return false end
 
     -- Days in each month (starting from January.)

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -68,13 +68,13 @@ local function checkDOBFormat(dob)
     local currentDate = os.date("*t")
     local currentYear = currentDate.year
     local minYear = currentYear - Config.MaxAge
-    local maxYear = currentYear - Config.MinAge
+    local maxYear = currentYear - 18
 
-    if year < minYear or year > maxYear or year > currentYear then
+    if year < minYear or year > maxYear or year > currentYear  then
         return false
     end
 
-    if year == maxYear then
+    if year == currentYear then
         if month > currentDate.month or (month == currentDate.month and day > currentDate.day) then
             return false
         end
@@ -259,7 +259,6 @@ end
 
     ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb, data)
         local xPlayer = ESX.GetPlayerFromId(source)
-        data.dateofbirth = formatDate(data.dateofbirth)
 
         if not checkNameFormat(data.firstname) then
             TriggerClientEvent("esx:showNotification", source, TranslateCap("invalid_firstname_format"), "error")
@@ -281,6 +280,7 @@ end
             TriggerClientEvent("esx:showNotification", source, TranslateCap("invalid_height_format"), "error")
             return cb(false)
         end
+
         if xPlayer then
             if alreadyRegistered[xPlayer.identifier] then
                 xPlayer.showNotification(TranslateCap("already_registered"), "error")
@@ -290,7 +290,7 @@ end
             playerIdentity[xPlayer.identifier] = {
                 firstName = formatName(data.firstname),
                 lastName = formatName(data.lastname),
-                dateOfBirth = data.dateofbirth,
+                dateOfBirth = formatDate(data.dateofbirth),
                 sex = data.sex,
                 height = data.height,
             }

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -65,8 +65,7 @@ local function checkDOBFormat(dob)
         return false
     end
 
-    local currentDate = os.date("*t")
-    local currentYear = currentDate.year
+    local currentYear = os.date("*t").year
     local minYear = currentYear - Config.MaxAge
     local maxYear = currentYear - 18
 

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -70,7 +70,7 @@ local function checkDOBFormat(dob)
     local minYear = currentYear - Config.MaxAge
     local maxYear = currentYear - 18
 
-    if year < minYear or year > maxYear or year > currentYear  then
+    if year < minYear or year > maxYear  then
         return false
     end
 


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
This PR refactors the age validation logic. It replaces the previous `LowestYear` and `HighestYear` with `MinAge` and `MaxAge`, making the age validation more dynamic and easier to configure. The logic now calculates the minimum and maximum valid birth years based on the current year and the configured `MinAge` and `MaxAge`.

---

### Motivation
<!-- Explain why you are making this PR -->
This PR was inspired by [#1626 Pull Request](https://github.com/esx-framework/esx_core/pull/1626), where a recent change only adjusted the `MinYear` configuration value. Rather than continuing with static year values, I aimed to provide a more flexible solution by introducing age-based configuration. This allows users to specify the age range directly, making it clearer and easier to manage, especially when maintaining the age validation across multiple versions.

---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
- The `Config.LowestYear` and `Config.HighestYear` have been replaced by `Config.MinAge` and `Config.MaxAge` in the main config file.
- The `checkDOBFormat` function has been updated to dynamically calculate the valid birth years based on the current year and the configured `MinAge` and `MaxAge`
- A simplified leap year check has been incorporated to ensure that 29.02 (Feb. 29) is validated properly for leap years (instead of having this unreadable logic in the same function)

This refactor improves clarity, flexbility and scalability, allowing the age range to be updated without changing hardcoded year values.
---

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
```
Config.MinAge = 15
Config.MaxAge = 45
```
Now, instead of adjusting the `LowestYear` and `HighestYear`, users can directly specify the minimum and maximum ages.
---

### PR Checklist
- []  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- []  My PR does not introduce any breaking changes.
- []  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
