### PR TITLE
Refactored Set vehicle Properties

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -997,12 +997,23 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
     if props.customSecondaryColor ~= nil then
         SetVehicleCustomSecondaryColour(vehicle, props.customSecondaryColor[1], props.customSecondaryColor[2], props.customSecondaryColor[3])
     end
+    
     if props.color1 ~= nil then
-        SetVehicleColours(vehicle, props.color1, colorSecondary)
+        if type(props.color1) == "table" then
+            SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
+        else
+            SetVehicleColours(vehicle, props.color1, colorSecondary)
+        end
     end
+
     if props.color2 ~= nil then
-        SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
+        if type(props.color2) == "table" then
+            SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
+        else
+            SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
+        end
     end
+
     if props.pearlescentColor ~= nil then
         SetVehicleExtraColours(vehicle, props.pearlescentColor, wheelColor)
     end

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -805,25 +805,26 @@ function ESX.Game.GetVehicleProperties(vehicle)
         return
     end
 
-    local colorPrimary, colorSecondary = GetVehicleColours(vehicle) ---@type number | number[], number | number[]
+    local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
     local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
     local hasCustomPrimaryColor = GetIsVehiclePrimaryColourCustom(vehicle)
-    local hasCustomSecondaryColor = GetIsVehicleSecondaryColourCustom(vehicle)
     local dashboardColor = GetVehicleDashboardColor(vehicle)
     local interiorColor = GetVehicleInteriorColour(vehicle)
-    
+    local customPrimaryColor = nil
     if hasCustomPrimaryColor then
-        colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
-    end
-
-    if hasCustomSecondaryColor then
-        colorSecondary = { GetVehicleCustomSecondaryColour(vehicle) }
+        customPrimaryColor = { GetVehicleCustomPrimaryColour(vehicle) }
     end
 
     local hasCustomXenonColor, customXenonColorR, customXenonColorG, customXenonColorB = GetVehicleXenonLightsCustomColor(vehicle)
     local customXenonColor = nil
     if hasCustomXenonColor then
         customXenonColor = { customXenonColorR, customXenonColorG, customXenonColorB }
+    end
+
+    local hasCustomSecondaryColor = GetIsVehicleSecondaryColourCustom(vehicle)
+    local customSecondaryColor = nil
+    if hasCustomSecondaryColor then
+        customSecondaryColor = { GetVehicleCustomSecondaryColour(vehicle) }
     end
 
     local extras = {}
@@ -878,6 +879,8 @@ function ESX.Game.GetVehicleProperties(vehicle)
         dirtLevel = ESX.Math.Round(GetVehicleDirtLevel(vehicle), 1),
         color1 = colorPrimary,
         color2 = colorSecondary,
+        customPrimaryColor = customPrimaryColor,
+        customSecondaryColor = customSecondaryColor,
 
         pearlescentColor = pearlescentColor,
         wheelColor = wheelColor,

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -805,26 +805,24 @@ function ESX.Game.GetVehicleProperties(vehicle)
         return
     end
 
+    ---@type number | number[], number | number[]
     local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
     local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
-    local hasCustomPrimaryColor = GetIsVehiclePrimaryColourCustom(vehicle)
     local dashboardColor = GetVehicleDashboardColor(vehicle)
     local interiorColor = GetVehicleInteriorColour(vehicle)
-    local customPrimaryColor = nil
-    if hasCustomPrimaryColor then
-        customPrimaryColor = { GetVehicleCustomPrimaryColour(vehicle) }
+
+    if GetIsVehiclePrimaryColourCustom(vehicle) then
+        colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
+    end
+
+    if GetIsVehicleSecondaryColourCustom(vehicle) then
+        colorSecondary = { GetVehicleCustomSecondaryColour(vehicle) }
     end
 
     local hasCustomXenonColor, customXenonColorR, customXenonColorG, customXenonColorB = GetVehicleXenonLightsCustomColor(vehicle)
     local customXenonColor = nil
     if hasCustomXenonColor then
         customXenonColor = { customXenonColorR, customXenonColorG, customXenonColorB }
-    end
-
-    local hasCustomSecondaryColor = GetIsVehicleSecondaryColourCustom(vehicle)
-    local customSecondaryColor = nil
-    if hasCustomSecondaryColor then
-        customSecondaryColor = { GetVehicleCustomSecondaryColour(vehicle) }
     end
 
     local extras = {}
@@ -879,8 +877,6 @@ function ESX.Game.GetVehicleProperties(vehicle)
         dirtLevel = ESX.Math.Round(GetVehicleDirtLevel(vehicle), 1),
         color1 = colorPrimary,
         color2 = colorSecondary,
-        customPrimaryColor = customPrimaryColor,
-        customSecondaryColor = customSecondaryColor,
 
         pearlescentColor = pearlescentColor,
         wheelColor = wheelColor,

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -991,13 +991,6 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
     if props.dirtLevel ~= nil then
         SetVehicleDirtLevel(vehicle, props.dirtLevel + 0.0)
     end
-    if props.customPrimaryColor ~= nil then
-        SetVehicleCustomPrimaryColour(vehicle, props.customPrimaryColor[1], props.customPrimaryColor[2], props.customPrimaryColor[3])
-    end
-    if props.customSecondaryColor ~= nil then
-        SetVehicleCustomSecondaryColour(vehicle, props.customSecondaryColor[1], props.customSecondaryColor[2], props.customSecondaryColor[3])
-    end
-    
     if props.color1 ~= nil then
         if type(props.color1) == "table" then
             SetVehicleCustomPrimaryColour(vehicle, props.color1[1], props.color1[2], props.color1[3])
@@ -1005,7 +998,6 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
             SetVehicleColours(vehicle, props.color1, colorSecondary)
         end
     end
-
     if props.color2 ~= nil then
         if type(props.color2) == "table" then
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
@@ -1013,7 +1005,6 @@ function ESX.Game.SetVehicleProperties(vehicle, props)
             SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
         end
     end
-
     if props.pearlescentColor ~= nil then
         SetVehicleExtraColours(vehicle, props.pearlescentColor, wheelColor)
     end

--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -805,26 +805,25 @@ function ESX.Game.GetVehicleProperties(vehicle)
         return
     end
 
-    local colorPrimary, colorSecondary = GetVehicleColours(vehicle)
+    local colorPrimary, colorSecondary = GetVehicleColours(vehicle) ---@type number | number[], number | number[]
     local pearlescentColor, wheelColor = GetVehicleExtraColours(vehicle)
     local hasCustomPrimaryColor = GetIsVehiclePrimaryColourCustom(vehicle)
+    local hasCustomSecondaryColor = GetIsVehicleSecondaryColourCustom(vehicle)
     local dashboardColor = GetVehicleDashboardColor(vehicle)
     local interiorColor = GetVehicleInteriorColour(vehicle)
-    local customPrimaryColor = nil
+    
     if hasCustomPrimaryColor then
-        customPrimaryColor = { GetVehicleCustomPrimaryColour(vehicle) }
+        colorPrimary = { GetVehicleCustomPrimaryColour(vehicle) }
+    end
+
+    if hasCustomSecondaryColor then
+        colorSecondary = { GetVehicleCustomSecondaryColour(vehicle) }
     end
 
     local hasCustomXenonColor, customXenonColorR, customXenonColorG, customXenonColorB = GetVehicleXenonLightsCustomColor(vehicle)
     local customXenonColor = nil
     if hasCustomXenonColor then
         customXenonColor = { customXenonColorR, customXenonColorG, customXenonColorB }
-    end
-
-    local hasCustomSecondaryColor = GetIsVehicleSecondaryColourCustom(vehicle)
-    local customSecondaryColor = nil
-    if hasCustomSecondaryColor then
-        customSecondaryColor = { GetVehicleCustomSecondaryColour(vehicle) }
     end
 
     local extras = {}
@@ -879,8 +878,6 @@ function ESX.Game.GetVehicleProperties(vehicle)
         dirtLevel = ESX.Math.Round(GetVehicleDirtLevel(vehicle), 1),
         color1 = colorPrimary,
         color2 = colorSecondary,
-        customPrimaryColor = customPrimaryColor,
-        customSecondaryColor = customSecondaryColor,
 
         pearlescentColor = pearlescentColor,
         wheelColor = wheelColor,


### PR DESCRIPTION
### Description
This PR enhances vehicle color compatibility by allowing props.color1 and props.color2 to accept RGB table values (e.g., {255, 255, 255}), in addition to the existing integer-based color indexes. This update ensures compatibility with scripts that utilize RGB values for vehicle customization.

---
### Motivation
Currently, using RGB tables (e.g., via mechanic menus or valet services) causes a runtime error because ESX.Game.SetVehicleProperties expects a number rather than a table. This change ensures a seamless experience for servers and scripts using RGB color customization, preventing native call failures and improving script robustness.

---

### **Implementation Details**
Checks if props.color1 or props.color2 is a table.

If so, it uses SetVehicleCustomPrimaryColour or SetVehicleCustomSecondaryColour respectively with the RGB values.

If not, it falls back to SetVehicleColours with default primary/secondary values to maintain backward compatibility.

---

### Usage Example
-- Example using RGB table
props = {
    color1 = {255, 0, 0},   -- Red (RGB)
    color2 = {0, 0, 255},   -- Blue (RGB)
}

-- Example using GTA color index
props = {
    color1 = 1,   -- Graphite
    color2 = 64,  -- Blue
}

props.color1 and props.color2 can be either:

An RGB table, e.g. {255, 255, 255}

A GTA default color index, e.g. 1

This ensures full compatibility with both modern and legacy vehicle color formats.
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
