### PR TITLE
fix(es_extended/client/functions): add nil check for inventory entries

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -66,7 +66,7 @@ function ESX.SearchInventory(items, count)
     for i = 1, #ESX.PlayerData.inventory do
         local e = ESX.PlayerData.inventory[i]
         for ii = 1, #items do
-            if e.name == items[ii] then
+            if e and e.name == items[ii] then
                 data[table.remove(items, ii)] = count and e.count or e
                 break
             end


### PR DESCRIPTION
### Description

<!-- Explain What this PR does -->

This PR adds a simple null‐check in the `ESX.SearchInventory` function to guard against `nil` entries in the player’s inventory. By verifying that `e` is not `nil` before attempting to index `e.name`, it prevents runtime script errors when unexpected `nil` values are present in `ESX.PlayerData.inventory`.

---

### Motivation

<!-- Explain why you are making this PR -->

A customer reported a crash in their FiveM server with the error:

```
^1SCRIPT ERROR: @es_extended/client/functions.lua:69: attempt to index a nil value (local 'e')^7
^3> ref^7 (^5@es_extended/client/functions.lua^7:69)
^3> DoRadioCheck^7 (^5@izzy-classicradio/client/client.lua^7:274)
^3> handler^7 (^5@izzy-classicradio/client/client.lua^7:495)
^3> updateInventory^7 (^5@ox_inventory/client.lua^7:977)
^3> handler^7 (^5@ox_inventory/client.lua^7:981)
^1SCRIPT ERROR: error object is not a string^7
^3> updateInventory^7 (^5@ox_inventory/client.lua^7:977)
^3> handler^7 (^5@ox_inventory/client.lua^7:981)
```

This occurred because the `ESX.PlayerData.inventory` table contained a `nil` entry, causing the loop to fail when indexing `e.name`. Adding this guard ensures more robust behavior when inventory data is incomplete or temporarily invalid.

---

### **Implementation Details**

<!-- Explain how your implemenation meets your goal -->

* Wrapped the existing comparison in the inner loop with `if e and e.name == items[ii] then … end`.
* No other logic changes; behavior is identical when `e` is valid.
* This extra check prevents attempts to index `nil` and returns the correct result when valid entries are found.

```lua
function ESX.SearchInventory(items, count)
    local item
    if type(items) == 'string' then
        item, items = items, {items}
    end

    local data = {}
    for i = 1, #ESX.PlayerData.inventory do
        local e = ESX.PlayerData.inventory[i]
        for ii = 1, #items do
            if e and e.name == items[ii] then
                data[table.remove(items, ii)] = count and e.count or e
                break
            end
        end
        if #items == 0 then
            break
        end
    end

    return not item and data or data[item]
end
```

---

### Usage Example

<!-- If you are adding or editing functions/events show usage examples -->

```lua
local items = ESX.SearchInventory('radio', true) 

if not items or items == nil then
    hasRadio = false
    return
end

if items > 0 then
    hasRadio = true
else
    hasRadio = false
end
```

---

### PR Checklist

* [X] My commit messages and PR title follow the [[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) standard.
* [X] My changes have been tested locally and function as expected.
* [X] My PR does not introduce any breaking changes.
* [X] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
