### PR TITLE
fix(es_extended): text color formatting in warning message

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -62,7 +62,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
         local command = Core.RegisteredCommands[name]
 
         if not command.allowConsole and playerId == 0 then
-            print(("[^3WARNING^7] ^5%s"):format(TranslateCap("commanderror_console")))
+            print(("[^3WARNING^7] ^5%s^0"):format(TranslateCap("commanderror_console")))
         else
             local xPlayer, error = ESX.Players[playerId], nil
 


### PR DESCRIPTION
added ^0 to ensure proper color reset at the end of the string in console output for command warnings
