### PR TITLE
feat(es_extended): Add Awaited Versions Of ESX.OneSync.Spawn Functions

### DIFF
--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -40,6 +40,28 @@ function Actions:TrackPedCoords()
     ESX.SetPlayerData("coords", coords)
 end
 
+function Actions:TrackPedCoordsOnce()
+    CreateThread(function()
+        while not ESX.IsPlayerLoaded() then
+            Wait(250)
+        end
+
+        ESX.PlayerData.coords = nil
+
+        setmetatable(ESX.PlayerData, {
+            __index = function(self, key)
+                if key ~= "coords" then
+                    return
+                end
+
+                local coords = GetEntityCoords(ESX.PlayerData.ped)
+
+                return { x = coords.x, y = coords.y, z = coords.z }
+            end
+        })
+    end)
+end
+
 function Actions:TrackPed()
     local playerPed = ESX.PlayerData.ped
     local newPed = PlayerPedId()
@@ -193,7 +215,7 @@ end
 function Actions:SlowLoop()
     CreateThread(function()
         while ESX.PlayerLoaded do
-            self:TrackPedCoords()
+            -- self:TrackPedCoords()
             self:TrackPauseMenu()
             self:TrackVehicle()
             self:TrackWeapon()
@@ -217,3 +239,4 @@ function Actions:Init()
 end
 
 Actions:Init()
+Actions:TrackPedCoordsOnce()


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
This adds an Async-Await like functionality to all the other OneSync.Spawn functions.
---
### Motivation
<!-- Explain why you are making this PR -->
This was a very useful feature in my old modified ESX core as callback hell can be annoying. I saw that the ESX.OneSync.SpawnVehicle function already had something similar and that the others lacked the same functionality so I added one to each of the rest.
---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
We make use of FiveM's promises library and Citizen.Await() to make non-callback versions of the OneSync.Spawn functions.
---

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
```lua
local objNetId = ESX.OneSync.SpawnObject(hash, coords, heading)
local pedNetId = ESX.OneSync.SpawnPed(hash, coords, heading)
local vehNetId = ESX.OneSync.SpawnPedInVehicle(hash, vehicle, seat)

-- Users may still use the callback versions of the functions should they wish.
```
---

### PR Checklist
- [X]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ]  My changes have been tested locally and function as expected.
- [X]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
