### PR TITLE
feat(es_extended): Added Config.MakeNPCFriendly adjustment

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -225,6 +225,26 @@ function Adjustments:DisableRadio()
     end
 end
 
+function Adjustments:MakeNPCFriendly()
+    if Config.MakeNPCFriendly then
+        local hash = GetHashKey("PLAYER")
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_LOST"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_SALVA"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_HILLBILLY"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_BALLAS"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_MEXICAN"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_FAMILY"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("AMBIENT_GANG_MARABUNTE"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("GANG_1"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("GANG_1"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("GANG_9"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("GANG_10"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("FIREMAN"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("MEDIC"), hash)
+        SetRelationshipBetweenGroups(1, GetHashKey("COP"), hash)
+    end
+end
+
 function Adjustments:Load()
     self:RemoveHudComponents()
     self:DisableAimAssist()
@@ -239,4 +259,5 @@ function Adjustments:Load()
     self:DiscordPresence()
     self:WantedLevel()
     self:DisableRadio()
+    self:MakeNPCFriendly()
 end

--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -8,6 +8,7 @@ Config.DisableVehicleSeatShuff = false -- Disables vehicle seat shuff
 Config.DisableDisplayAmmo = false -- Disable ammunition display
 Config.EnablePVP = true -- Allow Player to player combat
 Config.EnableWantedLevel = false -- Use Normal GTA wanted Level?
+Config.MakeNPCFriendly = false -- Makes NPCs friendly towards players
 
 Config.RemoveHudComponents = {
     [1] = false, --WANTED_STARS,


### PR DESCRIPTION
Added `Config.MakeNPCFriendly`, which makes all NPCs friendly toward the player, preventing them from attacking.

### Description
Adds a new configuration option `Config.MakeNPCFriendly` that, when enabled, sets all NPCs to be friendly toward the player. This prevents NPCs from engaging in combat or shooting at the player.

---
### Motivation
I noticed that many servers experienced issues with NPCs attacking players and were unsure how to disable this behavior. This addition provides a simple and configurable way to prevent NPC aggression and improve the user experience.

---

### **Implementation Details**
- Config flag: Introduced Config.MakeNPCFriendly = false in config.lua, defaulting to false to preserve current behavior.
- Behavior override: In @es_extended/client/modules/adjustments.lua (following esx_core patterns)