### PR TITLE
feat(es_extended/client/imports): Blip Helper Class

### DIFF
--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -19,6 +19,13 @@ function Blip:setColour(colour)
 	SetBlipColour(self.handle, self.colour)
 end
 
+---@param display? number
+function Blip:setDisplay(display)
+	self.display = display or 2
+	SetBlipDisplay(self.handle, self.display)
+end
+
+
 ---@param shortRange? boolean
 function Blip:setShortRange(shortRange)
 	self.shortRange = shortRange ~= nil and shortRange or true
@@ -50,7 +57,8 @@ end
 ---@param scale? number
 ---@param colour? number
 ---@param shortRange? boolean
-function Blip:new(position, label, sprite, scale, colour, shortRange)
+---@param display? number
+function Blip:new(position, label, sprite, scale, colour, shortRange, display)
 	return setmetatable({
 		position = position,
 		label = label,
@@ -58,6 +66,7 @@ function Blip:new(position, label, sprite, scale, colour, shortRange)
 		scale = scale,
 		colour = colour,
 		shortRange = shortRange,
+		display = display
 	}, Blip)
 end
 
@@ -82,6 +91,7 @@ function Blip:create()
 	self:setColour(self.colour)
 	self:setShortRange(self.shortRange)
 	self:setLabel(self.label)
+	self:setDisplay(self.display)
 end
 
 function Blip:delete()

--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -1,0 +1,92 @@
+local Blip = {}
+Blip.__gc = Blip.delete
+
+---@param sprite? number
+function Blip:setSprite(sprite)
+	self.sprite = sprite or 1
+	SetBlipSprite(self.handle, self.sprite)
+end
+
+---@param scale? number
+function Blip:setScale(scale)
+	self.scale = scale or 1
+	SetBlipScale(self.handle, self.scale)
+end
+
+---@param colour? number
+function Blip:setColour(colour)
+	self.colour = colour or 1
+	SetBlipColour(self.handle, self.colour)
+end
+
+---@param shortRange? boolean
+function Blip:setShortRange(shortRange)
+	self.shortRange = shortRange ~= nil and shortRange or true
+	SetBlipAsShortRange(self.handle, self.shortRange)
+end
+
+---@param label? string
+function Blip:setLabel(label)
+	self.label = label or "Blip"
+	BeginTextCommandSetBlipName('ESX_BLIP')
+    AddTextComponentSubstringPlayerName(self.label)
+    EndTextCommandSetBlipName(self.handle)
+end
+
+---@param position vector3 | number | vector4 | table
+function Blip:setPosition(position)
+	if not position then return end
+	self.position = position
+	if self.handle then
+		self:delete()
+		Wait(0)
+		self:create()
+	end
+end
+
+---@param position vector3 | number
+---@param label? string
+---@param sprite? number
+---@param scale? number
+---@param colour? number
+---@param shortRange? boolean
+function Blip:new(position, label, sprite, scale, colour, shortRange)
+	return setmetatable({
+		position = position,
+		label = label,
+		sprite = sprite,
+		scale = scale,
+		colour = colour,
+		shortRange = shortRange,
+	}, Blip)
+end
+
+function Blip:create()
+	if type(self.position) == "number" then
+		if not DoesEntityExist(self.position) then return end
+		self.handle = AddBlipForEntity(self.position)
+	elseif type(self.position) == "vector3" then
+		self.handle = AddBlipForCoord(self.position.x, self.position.y, self.position.z)
+	elseif type(self.position) == "vector4" then
+		self.handle = AddBlipForRadius(self.position.x, self.position.y, self.position.z, self.position.w)
+	elseif type(self.position) == "table" then
+		self.handle = AddBlipForArea(self.position.x, self.position.y, self.position.z, self.position.width, self.position.height)
+	end
+
+	if not self.handle then
+		error("Failed to create Blip")
+	end
+
+	self:setSprite(self.sprite)
+	self:setScale(self.scale)
+	self:setColour(self.colour)
+	self:setShortRange(self.shortRange)
+	self:setLabel(self.label)
+end
+
+function Blip:delete()
+	RemoveBlip(self.handle)
+	self.handle = nil
+end
+
+return Blip

--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -13,6 +13,7 @@
 ---@field scale number
 ---@field colour number
 ---@field display number
+---@field handle number
 ---@field shortRange boolean
 ---@field label string
 ---@field position  vector3 | number | vector4 | table

--- a/[core]/es_extended/client/imports/blip.lua
+++ b/[core]/es_extended/client/imports/blip.lua
@@ -1,3 +1,21 @@
+---@class Blip
+---@field setSprite function
+---@field setScale function
+---@field setColour function
+---@field setDisplay function
+---@field setShortRange function
+---@field setLabel function
+---@field setPosition function
+---@field new function
+---@field create function
+---@field delete function
+---@field sprite number
+---@field scale number
+---@field colour number
+---@field display number
+---@field shortRange boolean
+---@field label string
+---@field position  vector3 | number | vector4 | table
 local Blip = {}
 Blip.__gc = Blip.delete
 
@@ -25,7 +43,6 @@ function Blip:setDisplay(display)
 	SetBlipDisplay(self.handle, self.display)
 end
 
-
 ---@param shortRange? boolean
 function Blip:setShortRange(shortRange)
 	self.shortRange = shortRange ~= nil and shortRange or true
@@ -51,13 +68,14 @@ function Blip:setPosition(position)
 	end
 end
 
----@param position vector3 | number
+---@param position  vector3 | number | vector4 | table
 ---@param label? string
 ---@param sprite? number
 ---@param scale? number
 ---@param colour? number
 ---@param shortRange? boolean
 ---@param display? number
+---@return Blip blipCLass
 function Blip:new(position, label, sprite, scale, colour, shortRange, display)
 	return setmetatable({
 		position = position,


### PR DESCRIPTION
### Description
Adds a Blip Creation Class, to make blip creation easier, look nicer and feel better

---
### Motivation
Its a cool and useful feature to have

---
### **Implementation Details**
Add a class that is available with either `require` , or with the ESX Import using `ESX.Blip`

### Usage Example
```lua
local coord = Vector3(0, 0, 0) -- x, y, z
local entity = PlayerPedId() -- number for entity
local radius = vector4(0,0,0, 5) -- x, y, z, radius
local area = {x = 0, y = 0, z = 0, width = 5, height = 5} -- table for area

local coordBlip = ESX.Blip:new(coord, "Safe House", 40, 0.8, 11, true)  -- create a new blip
coordBlip:create() -- creates the blip on the map
coordBlip:setColour(3) -- change colour

local entityBlip = ESX.Blip:new(entity, "Police Car ", 56, 0.8, 11, true)  -- create a new blip
entityBlip:create() -- creates the blip on the map
entityBlip:setLabel("Off Duty Police Car") -- change blip label

local radiusBlip = ESX.Blip:new(radius , "Mystery Area", 9, 0.5, 2, true)  -- create a new blip
coordBlip:create() -- creates the blip on the map
coordBlip:setScale(1.0) -- change scale

local areaBlip = ESX.Blip:new(area,  "Mystery Area", 9, 0.5, 2, true)  -- create a new blip
areaBlip:create() -- creates the blip on the map
areaBlip:setShortRange(false) -- change showing as short Range
areaBlip:setDisplay(5) -- change display setttings (5 to only show on minmap, for example)

--- Cleanup
coordBlip:delete()
entityBlip:delete()
coordBlip:delete()
areaBlip:delete()
```
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
