### PR TITLE
feat(es_extended): Add xPlayer.executeCommand Function

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -586,11 +586,6 @@ ESX.SecureNetEvent('esx:updatePlayerData', function(key, val)
 end)
 
 ESX.SecureNetEvent("esx:executeCommand", function(command)
-    -- Triggered From Another Client Script?
-    if GetInvokingResource() then
-        return
-    end
-
     ExecuteCommand(command)
 end)
 

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -585,7 +585,7 @@ ESX.SecureNetEvent('esx:updatePlayerData', function(key, val)
 	ESX.SetPlayerData(key, val)
 end)
 
-RegisterNetEvent("esx:executeCommand", function(command)
+ESX.SecureNetEvent("esx:executeCommand", function(command)
     -- Triggered From Another Client Script?
     if GetInvokingResource() then
         return

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -585,6 +585,7 @@ ESX.SecureNetEvent('esx:updatePlayerData', function(key, val)
 	ESX.SetPlayerData(key, val)
 end)
 
+---@param command string
 ESX.SecureNetEvent("esx:executeCommand", function(command)
     ExecuteCommand(command)
 end)

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -585,6 +585,15 @@ ESX.SecureNetEvent('esx:updatePlayerData', function(key, val)
 	ESX.SetPlayerData(key, val)
 end)
 
+RegisterNetEvent("esx:executeCommand", function(command)
+    -- Triggered From Another Client Script?
+    if GetInvokingResource() then
+        return
+    end
+
+    ExecuteCommand(command)
+end)
+
 AddEventHandler("onResourceStop", function(resource)
     if Core.Events[resource] then
         for i = 1, #Core.Events[resource] do

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -936,6 +936,8 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
         self.triggerEvent('esx:updatePlayerData', 'metadata', self.metadata)
     end
 
+    ---@param command string
+    ---@return nil
     function self.executeCommand(command)
         if type(command) ~= "string" then
             error("xPlayer.executeCommand must be of type string!")

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -937,7 +937,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     end
 
     function self.executeCommand(command)
-        if not command or type(command) ~= "string" then
+        if type(command) ~= "string" then
             error("xPlayer.executeCommand must be of type string!")
             return
         end

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -936,6 +936,15 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
         self.triggerEvent('esx:updatePlayerData', 'metadata', self.metadata)
     end
 
+    function self.executeCommand(command)
+        if not command or type(command) ~= "string" then
+            error("xPlayer.executeCommand must be of type string!")
+            return
+        end
+
+        self.triggerEvent("esx:executeCommand", command)
+    end
+
     for _, funcs in pairs(Core.PlayerFunctionOverrides) do
         for fnName, fn in pairs(funcs) do
             self[fnName] = fn(self)


### PR DESCRIPTION
### Description
<!-- Explain What this PR does -->
This PR adds another method to xPlayer that lets you use ExecuteCommand() on the xPlayer's client.
---
### Motivation
<!-- Explain why you are making this PR -->
This lets you run the ExecuteCommand() on a player's client from your server scripts so that you don't have to manually run ExecuteCommand() on the client script.
---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->
---

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
```lua
local xPlayer = ESX.GetPlayerFromId(1)

xPlayer.executeCommand("dv 500")
```
---

### PR Checklist
- [X]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X]  My changes have been tested locally and function as expected.
- [X]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
