### PR TITLE
fix(esx_multicharacter): cleanup stale player obj

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -71,20 +71,6 @@ end
 ---@param reason string
 ---@param cb function?
 local function onPlayerDropped(playerId, reason, cb)
-    local xPlayer = ESX.GetPlayerFromId(playerId)
-
-    if not xPlayer then
-        return
-    end
-
-    TriggerEvent("esx:playerDropped", playerId, reason)
-    local job = xPlayer.getJob().name
-    local currentJob = Core.JobsPlayerCount[job]
-    Core.JobsPlayerCount[job] = ((currentJob and currentJob > 0) and currentJob or 1) - 1
-
-    GlobalState[("%s:count"):format(job)] = Core.JobsPlayerCount[job]
-    Core.playersByIdentifier[xPlayer.identifier] = nil
-
     local p = not cb and promise:new()
     local function resolve()
         if cb then
@@ -93,6 +79,18 @@ local function onPlayerDropped(playerId, reason, cb)
             return p:resolve()
         end
     end
+
+    local xPlayer = ESX.GetPlayerFromId(playerId)
+    if not xPlayer then
+        return resolve()
+    end
+
+    TriggerEvent("esx:playerDropped", playerId, reason)
+    local job = xPlayer.getJob().name
+    local currentJob = Core.JobsPlayerCount[job]
+    Core.JobsPlayerCount[job] = ((currentJob and currentJob > 0) and currentJob or 1) - 1
+
+    GlobalState[("%s:count"):format(job)] = Core.JobsPlayerCount[job]
 
     Core.SavePlayer(xPlayer, function()
         GlobalState["playerCount"] = GlobalState["playerCount"] - 1
@@ -164,7 +162,7 @@ if not Config.Multichar then
             return deferrals.done()
         end
 
-        if DoesPlayerExist(xPlayer.source --[[@as string]]) then
+        if GetPlayerPing(xPlayer.source --[[@as string]]) > 0 then
             return deferrals.done(
                 ("[ESX] There was an error loading your character!\nError code: identifier-active\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same account.\n\nYour identifier: %s"):format(identifier)
             )

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -95,6 +95,8 @@ local function onPlayerDropped(playerId, reason, cb)
     Core.SavePlayer(xPlayer, function()
         GlobalState["playerCount"] = GlobalState["playerCount"] - 1
         ESX.Players[playerId] = nil
+        Core.playersByIdentifier[xPlayer.identifier] = nil
+
         resolve()
     end)
 

--- a/[core]/esx_multicharacter/server/modules/functions.lua
+++ b/[core]/esx_multicharacter/server/modules/functions.lua
@@ -70,7 +70,7 @@ function Server:OnConnecting(source, deferrals)
 
     local plyRef = ESX.Players[identifier] ---@type number|string If player has not chosen character yet, plyRef = source, otherwise plyRef = identifier prefix ("char1", "char2", etc.)
     if type(plyRef) == "number" then
-        if DoesPlayerExist(plyRef --[[@as string]]) then
+        if GetPlayerPing(plyRef --[[@as string]]) > 0 then
             return reject()
         end
 
@@ -83,7 +83,7 @@ function Server:OnConnecting(source, deferrals)
         return deferrals.done()
     end
 
-    if DoesPlayerExist(xPlayer.source --[[@as string]]) then
+    if GetPlayerPing(xPlayer.source --[[@as string]]) > 0 then
         return reject()
     end
 

--- a/[core]/esx_multicharacter/server/modules/functions.lua
+++ b/[core]/esx_multicharacter/server/modules/functions.lua
@@ -47,34 +47,47 @@ function Server:OnConnecting(source, deferrals)
 
     if not identifier then return deferrals.done(("[ESX Multicharacter] Unable to retrieve player identifier.\nIdentifier type: %s"):format(Server.identifierType)) end
 
-    if ESX.GetConfig().EnableDebug or not ESX.Players[identifier] then 
-        ESX.Players[identifier] = true
+    if ESX.GetConfig().EnableDebug or not ESX.Players[identifier] then
+        ESX.Players[identifier] = source
         return deferrals.done()
     end
 
-    if ESX.Players[identifier] == true then
+    ---@param staleSrc number
+    local function cleanupStalePlayer(staleSrc)
+        deferrals.update(("[ESX Multicharacter] Cleaning stale player entry..."):format(identifier))
+        TriggerEvent("esx:onPlayerDropped", staleSrc, "esx_stale_player_obj", function()
+            ESX.Players[identifier] = source
+            deferrals.done()
+        end)
+    end
+
+    local function reject()
         return deferrals.done(
-            ("[ESX Multicharacter] There was an error loading your character!\nError code: identifier-active\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same account.\n\nYour identifier: %s"):format(identifier)
+            ("[ESX Multicharacter] There was an error loading your character!\nError code: identifier-active\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same account.\n\nYour identifier: %s"):format(
+                identifier)
         )
     end
 
-    local xPlayer = ESX.GetPlayerFromIdentifier(("%s:%s"):format(ESX.Players[identifier], identifier))
+    local plyRef = ESX.Players[identifier] ---@type number|string If player has not chosen character yet, plyRef = source, otherwise plyRef = identifier prefix ("char1", "char2", etc.)
+    if type(plyRef) == "number" then
+        if DoesPlayerExist(plyRef --[[@as string]]) then
+            return reject()
+        end
+
+        return cleanupStalePlayer(plyRef)
+    end
+
+    local xPlayer = ESX.GetPlayerFromIdentifier(("%s:%s"):format(plyRef, identifier))
     if not xPlayer then
-        ESX.Players[identifier] = true
+        ESX.Players[identifier] = source
         return deferrals.done()
     end
 
     if DoesPlayerExist(xPlayer.source --[[@as string]]) then
-        return deferrals.done(
-            ("[ESX Multicharacter] There was an error loading your character!\nError code: identifier-active\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same account.\n\nYour identifier: %s"):format(identifier)
-        )
+        return reject()
     end
 
-    deferrals.update(("[ESX Multicharacter] Cleaning stale player entry..."):format(identifier))
-    TriggerEvent("esx:onPlayerDropped", xPlayer.source, "esx_stale_player_obj", function()
-        ESX.Players[identifier] = true
-        deferrals.done()
-    end)
+    return cleanupStalePlayer(xPlayer.source)
 end
 
 

--- a/[core]/esx_multicharacter/server/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/server/modules/multicharacter.lua
@@ -11,7 +11,7 @@ function Multicharacter:SetupCharacters(source)
     end
 
     local identifier = Server:GetIdentifier(source)
-    ESX.Players[identifier] = true
+    ESX.Players[identifier] = source
 
     local slots = Database:GetPlayerSlots(identifier)
     identifier = Server.prefix .. "%:" .. identifier


### PR DESCRIPTION
### Description
Clean up stale player entries even for players who crashed during multichar select.

---
### Motivation
We already introduced a cleanup mechanism for players who already chose a character, but no such mechancism existed for players who crashed during char select.

---

### **Implementation Details**
Save source to ESX.Players table so we can later test if that source is still an active player. Otherwise we can initiate cleanup of the stale player obj.
---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
