### PR TITLE
fix(es_extended/client/modules/events.lua): Fix VehicleProperties Not…

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -133,9 +133,8 @@ AddStateBagChangeHandler("VehicleProperties", nil, function(bagName, _, value)
         return
     end
 
-    local vehicle = NetToVeh(netId)
-
     local tries = 0
+    
     while not NetworkDoesEntityExistWithNetworkId(netId) do
         Wait(200)
         tries = tries + 1
@@ -143,6 +142,8 @@ AddStateBagChangeHandler("VehicleProperties", nil, function(bagName, _, value)
             return error(("Invalid entity - ^5%s^7!"):format(netId))
         end
     end
+
+    local vehicle = NetToVeh(netId)
 
     if NetworkGetEntityOwner(vehicle) ~= ESX.playerId then
         return


### PR DESCRIPTION
… Updating Properly

### Description
<!-- Explain What this PR does -->
```
This PR fixes "VehicleProperties" not applying due to entity not existing yet.
```
---
### Motivation
<!-- Explain why you are making this PR -->

---

### **Implementation Details**
<!-- Explain how your implemenation meets your goal -->

The previous code was already calling `NetToVeh()` before the `while not NetworkDoesEntityExistWithNetworkId(netId) do` line code. This causes models that take long to stream/spawn such as custom cars to run `NetToVeh()` while not yet existing and will return a message in F8 console saying "No object by ID exists" or something similar.

---

### Usage Example
<!-- If you are adding or editing functions/events show usage examples -->
---

### PR Checklist
- [X]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X]  My changes have been tested locally and function as expected.
- [X]  My PR does not introduce any breaking changes.
- [X]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
