### PR TITLE
fix(es_extended/server/modules/onesync): decouple player proximity from veh spawning

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -401,6 +401,8 @@ function ESX.GetVehicleType(model, player, cb)
         elseif cb then
             cb(result)
         end
+
+        return result
     end
 
     model = type(model) == "string" and joaat(model) or model

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -114,10 +114,11 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
 
     CreateThread(function()
         if not vehicleType then
-            local src, xPlayer = next(ESX.Players)
-
-            if xPlayer then
-                vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
+            for src, xPlayer in pairs(ESX.GetExtendedPlayers()) do
+                if(GetPlayerPing(src) > 0) then
+                    vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
+                    break
+                end
             end
         end
 

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -114,11 +114,9 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
 
     CreateThread(function()
         if not vehicleType then
-            for i, xPlayer in ipairs(ESX.GetExtendedPlayers()) do
-                if(GetPlayerPing(xPlayer.source) > 0) then
-                    vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
-                    break
-                end
+            local xPlayer = ESX.GetExtendedPlayers()[1]
+            if xPlayer then
+                vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
             end
         end
 

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -113,10 +113,13 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
     end
 
     CreateThread(function()
-        local closestPlayer = ESX.OneSync.GetClosestPlayer(coords, 300)
-        local closestPlayerFound = next(closestPlayer) ~= nil
+        if not vehicleType then
+            local src, xPlayer = next(ESX.Players)
 
-        vehicleType = vehicleType or (closestPlayerFound and ESX.GetVehicleType(vehicleModel, closestPlayer.id) or nil)
+            if xPlayer then
+                vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
+            end
+        end
 
         if not vehicleType then
             return reject("No players found nearby to check vehicle type! Alternatively, you can specify the vehicle type manually.")
@@ -125,12 +128,11 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
         local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
         local tries = 0
 
-        local closestNetOwner = ESX.OneSync.GetClosestPlayer(coords, 300, nil, 0)
-        local closestNetOwnerFound = next(closestNetOwner) ~= nil
+        local hasNetOwner = next(ESX.OneSync.GetClosestPlayer(coords, 300, nil, 0)) ~= nil
 
         while not createdVehicle or createdVehicle == 0
-            or (closestNetOwnerFound and NetworkGetEntityOwner(createdVehicle) == -1)
-            or (not closestNetOwnerFound and not DoesEntityExist(createdVehicle)) do
+            or (hasNetOwner and NetworkGetEntityOwner(createdVehicle) == -1)
+            or (not hasNetOwner and not DoesEntityExist(createdVehicle)) do
             Wait(200)
             tries = tries + 1
             if tries > 40 then

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -4,11 +4,13 @@ ESX.OneSync = {}
 ---@param closest boolean
 ---@param distance? number
 ---@param ignore? table
-local function getNearbyPlayers(source, closest, distance, ignore)
+---@param routingBucket? number
+local function getNearbyPlayers(source, closest, distance, ignore, routingBucket)
     local result = {}
     local count = 0
     local playerPed
     local playerCoords
+    ignore = ignore or {}
 
     if not distance then
         distance = 100
@@ -19,14 +21,12 @@ local function getNearbyPlayers(source, closest, distance, ignore)
 
         if not source then
             error("Received invalid first argument (source); should be playerId")
-            return result
         end
 
         playerCoords = GetEntityCoords(playerPed)
 
         if not playerCoords then
             error("Received nil value (playerCoords); perhaps source is nil at first place?")
-            return result
         end
     end
 
@@ -35,12 +35,11 @@ local function getNearbyPlayers(source, closest, distance, ignore)
 
         if not playerCoords then
             error("Received nil value (playerCoords); perhaps source is nil at first place?")
-            return result
         end
     end
 
     for _, xPlayer in pairs(ESX.Players) do
-        if not ignore or not ignore[xPlayer.source] then
+        if not ignore[xPlayer.source] and (not routingBucket or GetPlayerRoutingBucket(xPlayer.source) == routingBucket) then
             local entity = GetPlayerPed(xPlayer.source)
             local coords = GetEntityCoords(entity)
 
@@ -67,15 +66,17 @@ end
 ---@param source vector3|number playerId or vector3 coordinates
 ---@param maxDistance number
 ---@param ignore? table playerIds to ignore, where the key is playerId and value is true
-function ESX.OneSync.GetPlayersInArea(source, maxDistance, ignore)
-    return getNearbyPlayers(source, false, maxDistance, ignore)
+---@param routingBucket? number
+function ESX.OneSync.GetPlayersInArea(source, maxDistance, ignore, routingBucket)
+    return getNearbyPlayers(source, false, maxDistance, ignore, routingBucket)
 end
 
 ---@param source vector3|number playerId or vector3 coordinates
 ---@param maxDistance number
 ---@param ignore? table playerIds to ignore, where the key is playerId and value is true
-function ESX.OneSync.GetClosestPlayer(source, maxDistance, ignore)
-    return getNearbyPlayers(source, true, maxDistance, ignore)
+---@param routingBucket? number
+function ESX.OneSync.GetClosestPlayer(source, maxDistance, ignore, routingBucket)
+    return getNearbyPlayers(source, true, maxDistance, ignore, routingBucket)
 end
 
 ---@param vehicleModel number|string
@@ -124,9 +125,12 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
         local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
         local tries = 0
 
+        local closestNetOwner = ESX.OneSync.GetClosestPlayer(coords, 300, nil, 0)
+        local closestNetOwnerFound = next(closestNetOwner) ~= nil
+
         while not createdVehicle or createdVehicle == 0
-            or (closestPlayerFound and NetworkGetEntityOwner(createdVehicle) == -1)
-            or (not closestPlayerFound and not DoesEntityExist(createdVehicle)) do
+            or (closestNetOwnerFound and NetworkGetEntityOwner(createdVehicle) == -1)
+            or (not closestNetOwnerFound and not DoesEntityExist(createdVehicle)) do
             Wait(200)
             tries = tries + 1
             if tries > 40 then

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -100,6 +100,8 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
         elseif cb then
             cb(result)
         end
+
+        return result
     end
 
     local function reject(err)

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -129,7 +129,7 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
         local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)
         local tries = 0
 
-        local hasNetOwner = next(ESX.OneSync.GetClosestPlayer(coords, 300, nil, 0)) ~= nil
+        local hasNetOwner = next(ESX.OneSync.GetClosestPlayer(coords, 300, nil, 0) or {}) ~= nil
 
         while not createdVehicle or createdVehicle == 0
             or (hasNetOwner and NetworkGetEntityOwner(createdVehicle) == -1)

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -114,8 +114,8 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
 
     CreateThread(function()
         if not vehicleType then
-            for src, xPlayer in pairs(ESX.GetExtendedPlayers()) do
-                if(GetPlayerPing(src) > 0) then
+            for i, xPlayer in ipairs(ESX.GetExtendedPlayers()) do
+                if(GetPlayerPing(xPlayer.source) > 0) then
                     vehicleType = ESX.GetVehicleType(vehicleModel, xPlayer.source)
                     break
                 end


### PR DESCRIPTION
### Description
This PR refactors `ESX.OneSync.SpawnVehicle` to decouple vehicle spawning from the presence or proximity of any specific player, and introduces a new optional `routingBucket` parameter to `ESX.OneSync.GetClosestPlayer`.

Previously, we attempted to get the vehicle type from the closest player and then waited for that player to become the network owner (regardless of what dimension they are in). This caused issues when spawning vehicles in other dimensions, specifically when the player was not in dimension 0—blocking vehicle creation indefinitely. Since we spawn vehicles in dimension 0, getting a closest player that is not in that dimension will make it impossible for them to become the net owner of that vehicle and so the spawning will fail.

Now, the logic is much more robust:
- If a `vehicleType` is not provided, the server falls back to the first available player (if any) to determine it. Regardless of dimension or distance.
- If **no players are online** and no `vehicleType` is provided, spawning fails early with a clear error.
- Otherwise, vehicle creation proceeds without awaiting a network owner. If a player is nearby in dimension 0, ownership is handled normally. If not, the vehicle still spawns and the caller can set the vehicle into the correct dimension.
- Vehicle properties will still be applied once a player enters scope.

---

### Motivation
Issue https://github.com/esx-framework/esx_core/issues/1646

This change resolves a long-standing issue where `/car` and similar commands would fail in non-zero dimensions. By removing the requirement for a dimension 0 player and falling back to any player for type detection, vehicle spawning becomes reliable and dimension-agnostic.

Additionally:
- The vehicle spawn logic was far too limiting. To determine a vehicle type, a player doesn't need to be in scope of the vehicle, yet the old logic enforced that constraint without justification.
- The only case where awaiting a network owner makes sense is to apply vehicle properties immediately. Now, if no one is nearby, we skip waiting—properties will be synced automatically as soon as a player enters scope.

---

### **Implementation Details**
- Refactored `SpawnVehicle` to no longer rely on a closest player being in a specific dimension.
- Fallback to the first available player only if `vehicleType` is not explicitly provided.
- Added early rejection with a clear error if no players are online and no `vehicleType` is provided.
- Skipped awaiting a net owner if none is nearby, improving responsiveness.
- Added optional `routingBucket` filter to `ESX.OneSync.GetClosestPlayer` to support scoped searches.
- Ensured that even when no one is in scope, vehicle spawning and eventual property syncing still work reliably.

---

### PR Checklist
- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
