### PR TITLE
Update callback.lua

### DIFF
--- a/[core]/es_extended/server/modules/callback.lua
+++ b/[core]/es_extended/server/modules/callback.lua
@@ -26,9 +26,11 @@ function Callbacks:Execute(cb, ...)
 
     if not success then
         print(("[^1ERROR^7] Failed to execute Callback with RequestId: ^5%s^7"):format(self.currentId))
-        error(errorString)
+        print("^3Callback Error:^7 " .. tostring(errorString))  -- just log, don't throw
+        self.currentId = nil
         return
     end
+
     self.currentId = nil
 end
 


### PR DESCRIPTION
### Description
This PR modifies the Callbacks:Execute method to improve error handling when a callback fails.
---
### Motivation
Using error() after pcall() defeats the purpose of safe error handling and can cause disruptive stack traces or unwanted crashes during runtime (e.g., when spawning an invalid vehicle model). This change allows errors to be logged without halting execution.

---

### **Implementation Details**
- Replaced error(errorString) with print() to prevent script crashes when a callback throws an error.
- Ensures callback execution failures are logged cleanly without interrupting overall execution flow.
---
