### PR TITLE
fix(es_extended): remove usage of SecureNetEvent where it's not needed

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -1541,11 +1541,11 @@ function ESX.ShowInventory()
     end)
 end
 
-ESX.SecureNetEvent('esx:showNotification', ESX.ShowNotification)
+RegisterNetEvent('esx:showNotification', ESX.ShowNotification)
 
-ESX.SecureNetEvent('esx:showAdvancedNotification', ESX.ShowAdvancedNotification)
+RegisterNetEvent('esx:showAdvancedNotification', ESX.ShowAdvancedNotification)
 
-ESX.SecureNetEvent('esx:showHelpNotification', ESX.ShowHelpNotification)
+RegisterNetEvent('esx:showHelpNotification', ESX.ShowHelpNotification)
 
 AddEventHandler("onResourceStop", function(resourceName)
     for i = 1, #ESX.UI.Menu.Opened, 1 do

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -1,6 +1,6 @@
 local pickups = {}
 
-ESX.SecureNetEvent("esx:requestModel", function(model)
+RegisterNetEvent("esx:requestModel", function(model)
     ESX.Streaming.RequestModel(model)
 end)
 
@@ -397,7 +397,7 @@ if not Config.CustomInventory then
 end
 
 ----- Admin commands from esx_adminplus
-ESX.SecureNetEvent("esx:tpm", function()
+RegisterNetEvent("esx:tpm", function()
     local GetEntityCoords = GetEntityCoords
     local GetGroundZFor_3dCoord = GetGroundZFor_3dCoord
     local GetFirstBlipInfoId = GetFirstBlipInfoId
@@ -529,7 +529,7 @@ local function noclipThread()
     end
 end
 
-ESX.SecureNetEvent("esx:noclip", function()
+RegisterNetEvent("esx:noclip", function()
     ESX.TriggerServerCallback("esx:isUserAdmin", function(admin)
         if not admin then
             return
@@ -553,11 +553,11 @@ ESX.SecureNetEvent("esx:noclip", function()
     end)
 end)
 
-ESX.SecureNetEvent("esx:killPlayer", function()
+RegisterNetEvent("esx:killPlayer", function()
     SetEntityHealth(ESX.PlayerData.ped, 0)
 end)
 
-ESX.SecureNetEvent("esx:repairPedVehicle", function()
+RegisterNetEvent("esx:repairPedVehicle", function()
     local ped = ESX.PlayerData.ped
     local vehicle = GetVehiclePedIsIn(ped, false)
     SetVehicleEngineHealth(vehicle, 1000)
@@ -566,7 +566,7 @@ ESX.SecureNetEvent("esx:repairPedVehicle", function()
     SetVehicleDirtLevel(vehicle, 0)
 end)
 
-ESX.SecureNetEvent("esx:freezePlayer", function(input)
+RegisterNetEvent("esx:freezePlayer", function(input)
     if input == "freeze" then
         SetEntityCollision(ESX.PlayerData.ped, false, false)
         FreezeEntityPosition(ESX.PlayerData.ped, true)


### PR DESCRIPTION
### Description
Remove the usage of ESX.SecureNetEvent where it doesn't make sense.
---
### Motivation
People have been comlaining that they cannot use esx:showNotification events client-side, among other things.

---

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
