### PR TITLE
feat(es_extended): refresh/add items during runtime

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -85,7 +85,7 @@ end
 function ESX.SetPlayerData(key, val)
     local current = ESX.PlayerData[key]
     ESX.PlayerData[key] = val
-    if key ~= "inventory" and key ~= "loadout" then
+    if key ~= "loadout" then
         if type(val) == "table" or val ~= current then
             TriggerEvent("esx:setPlayerData", key, val, current)
         end

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -57,6 +57,10 @@ ESX.SecureNetEvent("esx:setMaxWeight", function(newMaxWeight)
     ESX.SetPlayerData("maxWeight", newMaxWeight)
 end)
 
+ESX.SecureNetEvent("esx:setInventory", function(newInventory)
+    ESX.SetPlayerData("inventory", newInventory)
+end)
+
 local function onPlayerSpawn()
     ESX.SetPlayerData("ped", PlayerPedId())
     ESX.SetPlayerData("dead", false)

--- a/[core]/es_extended/locales/en.lua
+++ b/[core]/es_extended/locales/en.lua
@@ -65,6 +65,8 @@ return {
     ["command_repair_success_target"] = "An admin repaired your vehicle",
     ["command_clear"] = "Clear chat Text",
     ["command_clearall"] = "Clear chat Text for all players",
+    ["command_refreshitems"] = "Reload all items from the database.",
+    ["command_refreshitems_success"] = "Successfully reloaded %d items.",
     ["command_clearinventory"] = "Remove All items from the Players Inventory",
     ["command_clearloadout"] = "Remove All weapons from the Players Loadout",
     ["command_freeze"] = "Freeze a player",

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -36,11 +36,9 @@ end
 
 MySQL.ready(function()
     Core.DatabaseConnected = true
+
     if not Config.CustomInventory then
-        local items = MySQL.query.await("SELECT * FROM items")
-        for _, v in ipairs(items) do
-            ESX.Items[v.name] = { label = v.label, weight = v.weight, rare = v.rare, canRemove = v.can_remove }
-        end
+        ESX.RefreshItems()
     end
 
     ESX.RefreshJobs()

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -668,15 +668,19 @@ if not Config.CustomInventory then
         end
     end
 
+    ---@return number newItemCount
     function ESX.RefreshItems()
         ESX.Items = {}
 
         local items = MySQL.query.await("SELECT * FROM items")
-        for i = 1, #items do
+        local itemCount = #items
+        for i = 1, itemCount do
             local item = items[i]
             ESX.Items[item.name] = { label = item.label, weight = item.weight, rare = item.rare, canRemove = item.can_remove }
         end
         refreshPlayerInventories()
+
+        return itemCount
     end
 
     ---@param items { name: string, label: string, weight?: number, rare?: boolean, canRemove?: boolean }[]

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -684,7 +684,8 @@ if not Config.CustomInventory then
         local toInsert = {}
         local toInsertIndex = 1
 
-        for _, item in ipairs(items) do
+        for i = 1, #items do
+            local item = items[i]
             local name = item.name
             local label = item.label
             local weight = item.weight or 1

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -677,15 +677,19 @@ if not Config.CustomInventory then
 
     ---@param name string
     ---@param label string
-    ---@param weight number
+    ---@param weight number?
     ---@param rare boolean?
     ---@param canRemove boolean?
     function ESX.AddItem(name, label, weight, rare, canRemove)
         assert(type(name) == "string", "Item name must be a string")
         assert(type(label) == "string", "Item label must be a string")
-        assert(type(weight) == "number", "Item weight must be a number")
+        assert(type(weight) == "number" or weight == nil, "Item weight must be a number or nil")
         assert(type(rare) == "boolean" or rare == nil, "Item rare must be a boolean or nil")
         assert(type(canRemove) == "boolean" or canRemove == nil, "Item canRemove must be a boolean or nil")
+
+        weight = weight or 1
+        rare = rare or false
+        canRemove = canRemove ~= false
 
         if ESX.Items[name] then
             return
@@ -695,15 +699,15 @@ if not Config.CustomInventory then
             name,
             label,
             weight,
-            rare or false,
-            canRemove or false,
+            rare,
+            canRemove,
         })
 
         ESX.Items[name] = {
             label = label,
             weight = weight,
-            rare = rare or false,
-            canRemove = canRemove or false,
+            rare = rare,
+            canRemove = canRemove,
         }
 
         refreshPlayerInventories()

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -442,7 +442,7 @@ if not Config.CustomInventory then
     ESX.RegisterCommand("refreshitems", "admin", function(xPlayer)
         ESX.RefreshItems()
 
-        xPlayer.showNotification(TranslateCap("command_refreshitems_success", #ESX.Items), true, false, 140)
+        xPlayer.showNotification(Translate("command_refreshitems_success", #ESX.Items), true, false, 140)
     end, true, { help = TranslateCap("command_refreshitems") })
 
     ESX.RegisterCommand(

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -439,9 +439,11 @@ ESX.RegisterCommand("refreshjobs", "admin", function()
 end, true, { help = TranslateCap("command_clearall") })
 
 if not Config.CustomInventory then
-    ESX.RegisterCommand("refreshitems", "admin", function()
+    ESX.RegisterCommand("refreshitems", "admin", function(xPlayer)
         ESX.RefreshItems()
-    end, true, { help = TranslateCap("command_clearall") })
+
+        xPlayer.showNotification(TranslateCap("command_refreshitems_success", #ESX.Items), true, false, 140)
+    end, true, { help = TranslateCap("command_refreshitems") })
 
     ESX.RegisterCommand(
         "clearinventory",

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -440,9 +440,9 @@ end, true, { help = TranslateCap("command_clearall") })
 
 if not Config.CustomInventory then
     ESX.RegisterCommand("refreshitems", "admin", function(xPlayer)
-        ESX.RefreshItems()
+        local itemCount = ESX.RefreshItems()
 
-        xPlayer.showNotification(Translate("command_refreshitems_success", #ESX.Items), true, false, 140)
+        xPlayer.showNotification(Translate("command_refreshitems_success", itemCount), true, false, 140)
     end, true, { help = TranslateCap("command_refreshitems") })
 
     ESX.RegisterCommand(

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -438,11 +438,11 @@ ESX.RegisterCommand("refreshjobs", "admin", function()
     ESX.RefreshJobs()
 end, true, { help = TranslateCap("command_clearall") })
 
-ESX.RegisterCommand("refreshitems", "admin", function()
-    ESX.RefreshItems()
-end, true, { help = TranslateCap("command_clearall") })
-
 if not Config.CustomInventory then
+    ESX.RegisterCommand("refreshitems", "admin", function()
+        ESX.RefreshItems()
+    end, true, { help = TranslateCap("command_clearall") })
+
     ESX.RegisterCommand(
         "clearinventory",
         "admin",

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -438,6 +438,10 @@ ESX.RegisterCommand("refreshjobs", "admin", function()
     ESX.RefreshJobs()
 end, true, { help = TranslateCap("command_clearall") })
 
+ESX.RegisterCommand("refreshitems", "admin", function()
+    ESX.RefreshItems()
+end, true, { help = TranslateCap("command_clearall") })
+
 if not Config.CustomInventory then
     ESX.RegisterCommand(
         "clearinventory",


### PR DESCRIPTION
### Description
Adds support for creating and refreshing items at runtime.

---

### Motivation
Improves development workflows by allowing items to be added or refreshed dynamically.  
While it's not recommended to refresh items in prod, third-party scripts can call `ESX.AddItems` during startup to register required items without relying on a manual `items.sql` import.

---

### Usage

```lua
    ESX.AddItems({
		{
			name = "water", label = "Water"
		},
		{
			name = "pd_gadget", label = "PD-Gadget", weight = 10, rare = true, canRemove = false
		},
		{
			name = "bread", label = "Bread"
		},
	})
```

---

### PR Checklist
- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and work as intended.
- [x] This PR does not introduce any breaking changes.
- [x] I’ve included a clear explanation and context for the changes in this PR.
