### PR TITLE
(feat): add /setplaytime 

### DIFF
--- a/[core]/es_extended/locales/en.lua
+++ b/[core]/es_extended/locales/en.lua
@@ -126,6 +126,9 @@ Locales["en"] = {
     ["enabled"] = "~g~enabled~s~",
     ["disabled"] = "~r~disabled~s~",
 
+    ["command_setpt"] = "Set a player's playtime (in hours)",
+    ["command_setpt_playtime"] = "Playtime (hours)",
+
     -- Locale settings
     ["locale_digit_grouping_symbol"] = ",",
     ["locale_currency"] = "£%s",

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -134,6 +134,15 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
         return self.lastPlaytime + GetPlayerTimeOnline(self.source)
     end
 
+    ---@param playtime number
+    ---@return nil
+    function self.setPlayTime(playtime)
+        assert(type(playtime) == "number", "playtime should be number!")
+        playtime = ESX.Math.Round(playtime)
+        self.lastPlaytime = playtime
+        self.setMeta("lastPlaytime", playtime)
+    end
+
     ---@param money number
     ---@return nil
     function self.setMoney(money)

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -574,15 +574,25 @@ ESX.RegisterCommand(
     "setplaytime",
     "admin",
     function(xPlayer, args, showError)
-        local playtimeInHours = args.playtime
-        local playtimeInSeconds = playtimeInHours * 3600
-        local days = math.floor(playtimeInHours / 24)
-        local hours = playtimeInHours % 24
-        local minutes = math.floor((playtimeInSeconds % 3600) / 60)
+        local days = args.days or 0
+        local hours = args.hours or 0
+        local minutes = args.minutes or 0
+        local seconds = args.seconds or 0
+        
+        local playtimeInSeconds = (days * 86400) + (hours * 3600) + (minutes * 60) + seconds
         
         args.playerId.setPlayTime(playtimeInSeconds)
-        xPlayer.showNotification(("Set %s's playtime to %d days, %d hours, %d minutes"):format(args.playerId.getName(), days, hours, minutes))
-        args.playerId.showNotification(("Your playtime has been set to %d days, %d hours, %d minutes by %s"):format(days, hours, minutes, xPlayer.getName()))
+        
+        local timeString = ""
+        if days > 0 then timeString = timeString .. ("%d days, "):format(days) end
+        if hours > 0 then timeString = timeString .. ("%d hours, "):format(hours) end
+        if minutes > 0 then timeString = timeString .. ("%d minutes, "):format(minutes) end
+        if seconds > 0 then timeString = timeString .. ("%d seconds"):format(seconds) end
+        
+        timeString = timeString:gsub(", $", "")
+        
+        xPlayer.showNotification(("Set %s's playtime to %s"):format(args.playerId.getName(), timeString))
+        args.playerId.showNotification(("Your playtime has been set to %s by %s"):format(timeString, xPlayer.getName()))
     end,
     true,
     {
@@ -590,11 +600,13 @@ ESX.RegisterCommand(
         validate = true,
         arguments = {
             { name = "playerId", help = TranslateCap("commandgeneric_playerid"), type = "player" },
-            { name = "playtime", help = TranslateCap("command_setpt_playtime"), type = "number" },
+            { name = "days", help = "Days", type = "number" },
+            { name = "hours", help = "Hours", type = "number" },
+            { name = "minutes", help = "Minutes", type = "number" },
+            { name = "seconds", help = "Seconds", type = "number" },
         },
     }
 )
-
 ESX.RegisterCommand("coords", "admin", function(xPlayer)
     local ped = GetPlayerPed(xPlayer.source)
     local coords = GetEntityCoords(ped, false)

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -570,6 +570,31 @@ ESX.RegisterCommand("playtime", { "user", "admin" }, function(xPlayer)
     print(("Playtime: ^5%s^0 Days | ^5%s^0 Hours | ^5%s^0 Minutes"):format(days, hours, minutes))
 end, false)
 
+ESX.RegisterCommand(
+    "setplaytime",
+    "admin",
+    function(xPlayer, args, showError)
+        local playtimeInHours = args.playtime
+        local playtimeInSeconds = playtimeInHours * 3600
+        local days = math.floor(playtimeInHours / 24)
+        local hours = playtimeInHours % 24
+        local minutes = math.floor((playtimeInSeconds % 3600) / 60)
+        
+        args.playerId.setPlayTime(playtimeInSeconds)
+        xPlayer.showNotification(("Set %s's playtime to %d days, %d hours, %d minutes"):format(args.playerId.getName(), days, hours, minutes))
+        args.playerId.showNotification(("Your playtime has been set to %d days, %d hours, %d minutes by %s"):format(days, hours, minutes, xPlayer.getName()))
+    end,
+    true,
+    {
+        help = TranslateCap("command_setpt"),
+        validate = true,
+        arguments = {
+            { name = "playerId", help = TranslateCap("commandgeneric_playerid"), type = "player" },
+            { name = "playtime", help = TranslateCap("command_setpt_playtime"), type = "number" },
+        },
+    }
+)
+
 ESX.RegisterCommand("coords", "admin", function(xPlayer)
     local ped = GetPlayerPed(xPlayer.source)
     local coords = GetEntityCoords(ped, false)


### PR DESCRIPTION
### Description
This pull request adds a /setplaytime command that allows admins to set a players playtime that's stored.

---
### Motivation
Some of the server's I develop, they have playtime scripts which control what the players can do, Example; You can't use weapons without 24 hours of playtime. And there is times where they need to set a players playtime for whatever reasons.

---

### **Implementation Details**
This Implements /setplaytime [playerId] [hours] for admins to manually set a player's total playtime. The new value is saved immediately.

### Usage Example
```
local serverId = 1 

local xPlayer = ESX.GetPlayerFromId(serverId)

if xPlayer then
    -- Set the player's playtime to 50 hours (converted to seconds)
    xPlayer.setPlayTime(50 * 3600)
end
```


### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
