### PR TITLE
feat(esx_core) Add optional player identifier type.

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -52,10 +52,10 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     if Config.Multichar then
         local startIndex = identifier:find(":", 1)
         if startIndex then
-            self.license = ("license%s"):format(identifier:sub(startIndex, identifier:len()))
+            self.license = ("%s%s"):format(Config.Identifier, identifier:sub(startIndex, identifier:len()))
         end
     else
-        self.license = ("license:%s"):format(identifier)
+        self.license = ("%s:%s"):format(Config.Identifier, identifier)
     end
 
     if type(self.metadata.jobDuty) ~= "boolean" then

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -380,8 +380,9 @@ function ESX.GetIdentifier(playerId)
 
     playerId = tostring(playerId)
 
-    local identifier = GetPlayerIdentifierByType(playerId, "license")
-    return identifier and identifier:gsub("license:", "")
+    local identifierType = Config.Identifier
+    local identifier = GetPlayerIdentifierByType(playerId, identifierType)
+    return identifier and identifier:gsub(("%s:"):format(identifierType), "")
 end
 
 ---@param model string|number

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -72,3 +72,4 @@ if GetResourceState("ox_inventory") ~= "missing" then
 end
 
 Config.EnableDefaultInventory = Config.CustomInventory == false -- Display the default Inventory ( F2 )
+Config.Identifier = GetConvar("esx:identifier", "license")

--- a/[core]/esx_multicharacter/server/main.lua
+++ b/[core]/esx_multicharacter/server/main.lua
@@ -4,7 +4,7 @@ Server._index = Server
 Server.oneSync = GetConvar("onesync", "off")
 Server.slots = Config.Slots or 4
 Server.prefix = Config.Prefix or "char"
-Server.identifierType = ESX.GetConfig().Identifier or GetConvar("sv_lan", "") == "true" and "ip" or "license"
+Server.identifierType = ESX.GetConfig("Identifier") or GetConvar("sv_lan", "") == "true" and "ip" or "license"
 
 AddEventHandler("playerConnecting", function(_, _, deferrals)
    local source = source

--- a/[core]/esx_multicharacter/server/modules/database.lua
+++ b/[core]/esx_multicharacter/server/modules/database.lua
@@ -73,7 +73,7 @@ MySQL.ready(function()
 end)
 
 function Database:DeleteCharacter(source, charid)
-    local identifier = ("%s%s:%s"):format(Server.prefix, charid, Server:GetIdentifier(source))
+    local identifier = ("%s%s:%s"):format(Server.prefix, charid, ESX.GetIdentifier(source))
     local query = "DELETE FROM `%s` WHERE %s = ?"
     local queries = {}
     local count = 0

--- a/[core]/esx_multicharacter/server/modules/functions.lua
+++ b/[core]/esx_multicharacter/server/modules/functions.lua
@@ -1,15 +1,5 @@
 ESX.Players = {}
 
-function Server:GetIdentifier(source)
-    local fxDk = GetConvarInt("sv_fxdkMode", 0)
-    if fxDk == 1 then
-        return "ESX-DEBUG-LICENCE"
-    end
-
-    local identifier = GetPlayerIdentifierByType(source, self.identifierType)
-    return identifier and identifier:gsub(self.identifierType .. ":", "")
-end
-
 function Server:ResetPlayers()
     if next(ESX.Players) then
         local players = table.clone(ESX.Players)

--- a/[core]/esx_multicharacter/server/modules/functions.lua
+++ b/[core]/esx_multicharacter/server/modules/functions.lua
@@ -6,7 +6,7 @@ function Server:ResetPlayers()
         table.wipe(ESX.Players)
 
         for _, v in pairs(players) do
-            ESX.Players[self:GetIdentifier(v.source)] = v.identifier
+            ESX.Players[ESX.GetIdentifier(v.source)] = v.identifier
         end
     else
         ESX.Players = {}
@@ -16,7 +16,7 @@ end
 function Server:OnConnecting(source, deferrals)
     deferrals.defer()
     Wait(0) -- Required
-    local identifier = self:GetIdentifier(source)
+    local identifier = ESX.GetIdentifier(source)
 
     -- luacheck: ignore
     if not SetEntityOrphanMode then


### PR DESCRIPTION
### Description
This PR introduces a configurable way to choose the player identifier type used by ESX.
Currently, es_extended hardcodes the "license" identifier, but the codebase is already compatible with other types like "steam" or "discord".

This change adds a server-side convar & Config Value to allow server owners to select their preferred identifier type without modifying the source code.

---
### Motivation
- Improve flexibility and customization for server owners
- Avoid hardcoding the identifier type
- Enable use of alternative ID systems like Discord or Steam

---

### **Implementation Details**
- Added a new convar: esx:identifier
- Added a new config value: Config.Identifier
- Default fallback is "license" if the convar is missing or invalid

---

### Usage Example
Change `server.cfg`: "set esx:identifier discord"
Or
Change `shared/config/main.lua`: `Config.Identifier = "discord"`

---

### PR Checklist
- [1]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- []  My PR does not introduce any breaking changes.
- [1]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
