### PR TITLE
Update functions.lua

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -556,6 +556,17 @@ function ESX.GetItemLabel(item)
     end
 end
 
+---@param job string
+---@return string?
+function ESX.GetJobLabel(job)
+    if ESX.Jobs[job] then
+        return ESX.Jobs[job].label
+    else
+        print(("[^3WARNING^7] Attempting to get invalid job label -> ^5%s^7"):format(job))
+        return nil
+    end
+end
+
 ---@return table
 function ESX.GetJobs()
     return ESX.Jobs


### PR DESCRIPTION
feat(functions.lua): add ESX.GetJobLabel function to retrieve job labels

### Description
Adds a new utility function `ESX.GetJobLabel` that retrieves the human-readable label for a given job key from the ESX job definitions. The function also logs a warning if an invalid job key is requested.

---
### Motivation
To centralize and simplify the retrieval of job labels throughout the project and improve error handling when invalid job keys are used.

---

### Implementation Details
The function checks if the job exists in the global `ESX.Jobs` table and returns its label. If the job does not exist, it prints a warning message and returns `nil`.

---

### Usage Example
```lua
local label = ESX.GetJobLabel('police')
if label then
    print("Job label:", label)
else
    print("Job not found")
end```
