### PR TITLE
feat(functions.lua): add ESX.GetJob() function to retrieve job data b…

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -561,6 +561,18 @@ function ESX.GetJobs()
     return ESX.Jobs
 end
 
+---@param jobName string
+---@return table|nil
+function ESX.GetJob(jobName)
+    local job = ESX.Jobs[jobName]
+    if job then
+        return job
+    else
+        print(("[^3WARNING^7] Attempting to get invalid job: ^5%s^7"):format(jobName))
+        return nil
+    end
+end
+
 ---@return table
 function ESX.GetItems()
     return ESX.Items


### PR DESCRIPTION
Adds a new function `ESX.GetJob(jobName)` that returns the full job data for a given job name from the `ESX.Jobs` table.

If the job name is invalid or not found, the function returns nil and logs a warning.

This provides a simple way to access job metadata by name.

---

### Description
Adds a utility function to retrieve a single job's full data using its name.

---

### Motivation
To provide a cleaner and more consistent way to access job data, especially in cases where only one specific job is needed.

---

### Implementation Details
- Looks up the job in `ESX.Jobs` by key.
- If found, returns the full job table.
- If not found, returns nil and prints a warning to the console.

---

### Usage Example
```lua
local job = ESX.GetJob("police")
if job then
    print(job.name, job.type)
end

--
### PR Checklist
- []  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- []  My changes have been tested locally and function as expected.
- []  My PR does not introduce any breaking changes.
- []  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
