### PR TITLE
fix(es_extended/shared/config/adjustments): enable ambient peds & veh

### DIFF
--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -37,10 +37,10 @@ Config.RemoveHudComponents = {
 Config.Multipliers = {
     pedDensity = 1.0,
     scenarioPedDensityInterior = 0.0,
-    scenarioPedDensityExterior = 0.0,
+    scenarioPedDensityExterior = 1.0,
     ambientVehicleRange = 1.0,
     parkedVehicleDensity = 1.0,
-    randomVehicleDensity = 0.0,
+    randomVehicleDensity = 1.0,
     vehicleDensity = 1.0
 }
 


### PR DESCRIPTION
### Description

Enable ambient peds & vehicles by default.

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
