### PR TITLE
feat(esx_core) Added pcall for checking player identifier as new ESX.GetIdentifier retruns error when identifier isn't found.

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -140,7 +140,10 @@ if not Config.Multichar then
         local playerId = source
         deferrals.defer()
         Wait(0) -- Required
-        local identifier = ESX.GetIdentifier(playerId)
+        local identifier
+        local correctLicense, _ = pcall(function ()
+            identifier = ESX.GetIdentifier(playerId)
+        end)
 
         -- luacheck: ignore
         if not SetEntityOrphanMode then
@@ -155,11 +158,14 @@ if not Config.Multichar then
             return deferrals.done("[ESX] OxMySQL Was Unable To Connect to your database. Please make sure it is turned on and correctly configured in your server.cfg")
         end
 
-        if not identifier then
-            return deferrals.done("[ESX] There was an error loading your character!\nError code: identifier-missing\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.")
+        if not identifier or not correctLicense then
+            if GetResourceState("esx_identity") ~= "started" then
+                return deferrals.done("[ESX] There was an error loading your character!\nError code: identifier-missing\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.")
+            end
         end
 
         local xPlayer = ESX.GetPlayerFromIdentifier(identifier)
+
         if not xPlayer then
             return deferrals.done()
         end

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -166,10 +166,15 @@ end
     if not multichar then
         AddEventHandler("playerConnecting", function(_, _, deferrals)
             deferrals.defer()
-            local _, identifier = source, ESX.GetIdentifier(source)
+            local _, identifier = source, nil
+
+            local correctLicense, _ = pcall(function()
+                identifier = ESX.GetIdentifier(source)
+            end)
+            
             Wait(40)
 
-            if not identifier then
+            if not identifier or not correctLicense then
                 return deferrals.done(TranslateCap("no_identifier"))
             end
             MySQL.single("SELECT firstname, lastname, dateofbirth, sex, height FROM users WHERE identifier = ?", { identifier }, function(result)

--- a/[core]/esx_multicharacter/server/modules/functions.lua
+++ b/[core]/esx_multicharacter/server/modules/functions.lua
@@ -16,7 +16,10 @@ end
 function Server:OnConnecting(source, deferrals)
     deferrals.defer()
     Wait(0) -- Required
-    local identifier = ESX.GetIdentifier(source)
+    local identifier
+    local correctLicense, _ = pcall(function()
+        identifier = ESX.GetIdentifier(source)
+    end)
 
     -- luacheck: ignore
     if not SetEntityOrphanMode then
@@ -35,7 +38,7 @@ function Server:OnConnecting(source, deferrals)
         deferrals.done("[ESX Multicharacter] OxMySQL Was Unable To Connect to your database. Please make sure it is turned on and correctly configured in your server.cfg")
     end
 
-    if not identifier then return deferrals.done(("[ESX Multicharacter] Unable to retrieve player identifier.\nIdentifier type: %s"):format(Server.identifierType)) end
+    if not identifier or not correctLicense then return deferrals.done(("[ESX Multicharacter] Unable to retrieve player identifier.\nIdentifier type: %s"):format(Server.identifierType)) end
 
     if ESX.GetConfig().EnableDebug or not ESX.Players[identifier] then
         ESX.Players[identifier] = source


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
Adds a pcall for esx_identity, esx_multicharacter, es_exteneded, to prevent player from joining and to show them deffer error. 
---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
It solves a loop of resource_name deferring. connection.. As it didn't notify a player when server owner set their license type wrong.
---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->
Adds a pcall to every playerConnecting
---

### Usage Example

No usage

---

### PR Checklist

-   [ +] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ +] My changes have been tested locally and function as expected.
-   [ +] My PR does not introduce any breaking changes.
-   [ +] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
<img width="1424" height="1002" alt="image" src="https://github.com/user-attachments/assets/5cb86cd1-e2da-4f29-b396-f2d6d06b1117" />
<img width="1726" height="1054" alt="image" src="https://github.com/user-attachments/assets/e11548c3-5aa8-4cfa-9695-e50ae4d5081b" />

