### PR TITLE
Fix Discord Rich Presence integration

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -175,8 +175,7 @@ function Adjustments:ReplacePlaceholders(text)
         local success, result = pcall(cb)
 
         if not success then
-            error(("Failed to execute placeholder: ^5%s^7"):format(placeholder))
-            error(result)
+            error(("Failed to execute placeholder: ^5%s^7\n%s"):format(placeholder, result))
             result = "Unknown"
         end
 

--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -184,17 +184,12 @@ function Adjustments:ReplacePlaceholders(text)
     return text
 end
 
-function Adjustments:PresencePlaceholders()
-    local presence = self:ReplacePlaceholders(Config.DiscordActivity.presence)
-    return presence
-end
-
 function Adjustments:DiscordPresence()
     if Config.DiscordActivity.appId ~= 0 then
         CreateThread(function()
             while true do
                 SetDiscordAppId(Config.DiscordActivity.appId)
-                SetRichPresence(self:PresencePlaceholders())
+                SetRichPresence(self:ReplacePlaceholders(Config.DiscordActivity.presence))
                 SetDiscordRichPresenceAsset(Config.DiscordActivity.assetName)
                 SetDiscordRichPresenceAssetText(self:ReplacePlaceholders(Config.DiscordActivity.assetText))
 


### PR DESCRIPTION
### Description

Fix the discord activity that was not working. The problem before was that some variable in for example {server_endpoint}, were never replaced so it created invalid URL and in assetText {server_name} was not replaced too.

---

### Motivation

To fix the discord Presence

---

### Implementation Details

New function Adjustments:ReplacePlaceholders(text) that replace correctly all the placeholder in a text
Adjustments:PresencePlaceholders() use the new ReplacePlaceholders function to create the presence text.
SetDiscordRichPresenceAssetText and buttonUrl use ReplacePlaceholders to replace the placeholders by the actuals values

---

### Usage Example

```lua
function Adjustments:ReplacePlaceholders(text)
    for placeholder, cb in pairs(placeHolders) do
        local success, result = pcall(cb)

        if not success then
            error(("Failed to execute placeholder: ^5%s^7"):format(placeholder))
            error(result)
            result = "Unknown"
        end

        text = text:gsub(("{%s}"):format(placeholder), tostring(result))
    end
    return text
end

function Adjustments:PresencePlaceholders()
    local presence = self:ReplacePlaceholders(Config.DiscordActivity.presence)
    print(presence)
    return presence
end

function Adjustments:DiscordPresence()
    if Config.DiscordActivity.appId ~= 0 then
        CreateThread(function()
            while true do
                SetDiscordAppId(Config.DiscordActivity.appId)
                SetRichPresence(self:PresencePlaceholders())
                SetDiscordRichPresenceAsset(Config.DiscordActivity.assetName)
                SetDiscordRichPresenceAssetText(self:ReplacePlaceholders(Config.DiscordActivity.assetText))
                for i = 1, #Config.DiscordActivity.buttons do
                    local button = Config.DiscordActivity.buttons[i]
                    local buttonUrl = self:ReplacePlaceholders(button.url)
                    SetDiscordRichPresenceAction(i - 1, button.label, buttonUrl)
                end
                Wait(Config.DiscordActivity.refresh)
            end
        end)
    end
end
```

---

### PR Checklist

-   [ ] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [ ] My PR does not introduce any breaking changes.
-   [ ] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
