### PR TITLE
Fix `onPlayerDropped` to pass in `cb`

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -391,7 +391,7 @@ AddEventHandler("esx:setJob", function(_, job, lastJob)
 end)
 
 AddEventHandler("esx:playerLogout", function(playerId, cb)
-    onPlayerDropped(playerId, "esx_player_logout")
+    onPlayerDropped(playerId, "esx_player_logout", cb)
     TriggerClientEvent("esx:onPlayerLogout", playerId)
 end)
 


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
Fixed missing `cb` parameter in `onPlayerDropped` function

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
Resolving issues with the required `cb` callback function when certain third-party scripts use the `esx:playerLogout` event.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->
Add the `cb` parameter to the `onPlayerDropped` function again.

---

### Usage Example

```lua
debugPrint('[LOGOUT] Awaiting Player to be unloaded [/]')
TriggerEvent('esx:playerLogout', source, function()
	cb()
	debugPrint('[LOGOUT] Player unloaded.')
end)
```

---

### PR Checklist

-   [X] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [X] My changes have been tested locally and function as expected.
-   [X] My PR does not introduce any breaking changes.
-   [X] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
