### PR TITLE
Fix event registration and improve error handling

### DIFF
--- a/[core]/es_extended/client/functions.lua
+++ b/[core]/es_extended/client/functions.lua
@@ -22,18 +22,19 @@ function ESX.SecureNetEvent(name, func)
         Core.Events[invokingResource] = {}
     end
 
-    local event = RegisterNetEvent(name, function(...)
-        if source == '' then
+    RegisterNetEvent(name)
+    AddEventHandler(name, function(...)
+        if not source or source == 0 then
             return
         end
 
         local success, result = pcall(func, ...)
         if not success then
-            error(("%s"):format(result))
+            print(('[ESX.SecureNetEvent] Error in event "%s": %s'):format(name, result))
         end
     end)
     local eventIndex = #Core.Events[invokingResource] + 1
-    Core.Events[invokingResource][eventIndex] = event
+    Core.Events[invokingResource][eventIndex] = name
 end
 
 local addonResourcesState = {


### PR DESCRIPTION
This update fixes how events are registered by properly separating the registration and the handler setup, instead of passing a function directly to RegisterNetEvent. It wraps the callback in a safe pcall to catch errors without breaking the script, and instead of throwing errors, it just logs them so things keep running smoothly.


