### PR TITLE
feat: sync player data inv & loadout

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -196,6 +196,25 @@ if not Config.CustomInventory then
         end
     end)
 
+    ESX.SecureNetEvent("esx:addLoadoutItem", function(weaponName, weaponLabel, ammo)
+        table.insert(ESX.PlayerData.loadout, {
+            name = weaponName,
+            ammo = ammo,
+            label = weaponLabel,
+            components = {},
+            tintIndex = 0,
+        })
+    end)
+
+    ESX.SecureNetEvent("esx:removeLoadoutItem", function(weaponName, weaponLabel)
+        for i = 1, #ESX.PlayerData.loadout do
+            if ESX.PlayerData.loadout[i].name == weaponName then
+                table.remove(ESX.PlayerData.loadout, i)
+                break
+            end
+        end
+    end)
+
     RegisterNetEvent("esx:addWeapon", function()
         error("event ^5'esx:addWeapon'^1 Has Been Removed. Please use ^5xPlayer.addWeapon^1 Instead!")
     end)

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -48,6 +48,45 @@ if not IsDuplicityVersion() then -- Only register this event for the client
         ESX.PlayerData = {}
     end)
 
+    if not ESX.GetConfig("CustomInventory") then
+        ESX.SecureNetEvent("esx:addInventoryItem", function(item, count, showNotification)
+            for k, v in ipairs(ESX.PlayerData.inventory) do
+                if v.name == item then
+                    ESX.PlayerData.inventory[k].count = count
+                    break
+                end
+            end
+        end)
+
+        ESX.SecureNetEvent("esx:removeInventoryItem", function(item, count, showNotification)
+            for i = 1, #ESX.PlayerData.inventory do
+                if ESX.PlayerData.inventory[i].name == item then
+                    ESX.PlayerData.inventory[i].count = count
+                    break
+                end
+            end
+        end)
+
+        ESX.SecureNetEvent("esx:addLoadoutItem", function(weaponName, weaponLabel, ammo)
+            table.insert(ESX.PlayerData.loadout, {
+                name = weaponName,
+                ammo = ammo,
+                label = weaponLabel,
+                components = {},
+                tintIndex = 0,
+            })
+        end)
+
+        ESX.SecureNetEvent("esx:removeLoadoutItem", function(weaponName, weaponLabel)
+            for i = 1, #ESX.PlayerData.loadout do
+                if ESX.PlayerData.loadout[i].name == weaponName then
+                    table.remove(ESX.PlayerData.loadout, i)
+                    break
+                end
+            end
+        end)
+    end
+
     local external = { { "Class", "class.lua" }, { "Point", "point.lua" } }
     for i = 1, #external do
         local module = external[i]

--- a/[core]/es_extended/imports.lua
+++ b/[core]/es_extended/imports.lua
@@ -50,9 +50,9 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 
     if not ESX.GetConfig("CustomInventory") then
         ESX.SecureNetEvent("esx:addInventoryItem", function(item, count, showNotification)
-            for k, v in ipairs(ESX.PlayerData.inventory) do
-                if v.name == item then
-                    ESX.PlayerData.inventory[k].count = count
+            for i = 1, #ESX.PlayerData.inventory do
+                if ESX.PlayerData.inventory[i].name == item then
+                    ESX.PlayerData.inventory[i].count = count
                     break
                 end
             end

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -580,6 +580,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
             GiveWeaponToPed(GetPlayerPed(self.source), joaat(weaponName), ammo, false, false)
             self.triggerEvent("esx:addInventoryItem", weaponLabel, false, true)
+            self.triggerEvent("esx:addLoadoutItem", weaponName, weaponLabel, ammo)
         end
     end
 
@@ -692,6 +693,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
         if weaponLabel then
             self.triggerEvent("esx:removeInventoryItem", weaponLabel, false, true)
+            self.triggerEvent("esx:removeLoadoutItem", weaponName, weaponLabel)
         end
     end
 

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -31,7 +31,11 @@ end
 ---@param key? string Key pair to get specific value of config
 ---@return unknown Returns the whole config if no key is passed, or a specific value
 function ESX.GetConfig(key)
-    return key and Config[key] or Config
+    if key then
+        return Config[key]
+    end
+
+    return Config
 end
 
 ---@param weaponName string


### PR DESCRIPTION

### Description

This PR ensures the `ESX.PlayerData.inventory` and `ESX.PlayerData.loadout` tables remain synchronized between client and server & importing resources. It listens for secure events (`esx:addInventoryItem`, `esx:removeInventoryItem`, `esx:addLoadoutItem`, `esx:removeLoadoutItem`) and updates the client-side data accordingly. This feature is only enabled when `ESX.GetConfig("CustomInventory")` is false, maintaining compatibility with custom inventory systems.

---

### Motivation

The changes are necessary to maintain consistency between server-side inventory/loadout state and the client's `ESX.PlayerData`. As of now, you have to use `ESX.GetPlayerData()` just to get an updated state of the inventory. And the loadout is out of sync regardless.

---

### Implementation Details

- Listens to secure net events:
  - `esx:addInventoryItem`
  - `esx:removeInventoryItem`
  - `esx:addLoadoutItem`
  - `esx:removeLoadoutItem`
- Updates the relevant fields in `ESX.PlayerData` only if `CustomInventory` is disabled.
- Uses `table.insert` and `table.remove` to manage `loadout`, and directly modifies counts in `inventory`.


---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.