### PR TITLE
fix(es_extended/shared/functions): fix ESX.GetConfig bug

### DIFF
--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -31,7 +31,11 @@ end
 ---@param key? string Key pair to get specific value of config
 ---@return unknown Returns the whole config if no key is passed, or a specific value
 function ESX.GetConfig(key)
-    return key and Config[key] or Config
+    if key then
+        return Config[key]
+    end
+
+    return Config
 end
 
 ---@param weaponName string


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Fixes a bug in `ESX.GetConfig` where falsy config values (e.g., `false`, `nil`) would incorrectly cause the function to return the entire `Config` table instead of the actual value. This ensures accurate value retrieval even for falsy config values.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

The previous inline logic using `and`/`or` would fall back to returning the full config if `Config[key]` was falsy. This behavior was incorrect and caused issues when a config value was intentionally `false`. This change fixes that logic.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

Replaced the ternary-style one-liner with a simple `if` statement to explicitly check if the `key` parameter is not `nil`. This avoids misinterpreting falsy values and ensures proper return values.

Updated function:

```lua
---@param key? string Key pair to get specific value of config
---@return unknown Returns the whole config if no key is passed, or a specific value
function ESX.GetConfig(key)
    if key ~= nil then
        return Config[key]
    end

    return Config
end
```

---

### Usage Example

```lua
local value = ESX.GetConfig("SomeKey") -- Will now correctly return false if Config["SomeKey"] = false
local fullConfig = ESX.GetConfig()     -- Returns entire Config table
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
