### PR TITLE
feat(es_extended): add SSN

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -385,6 +385,7 @@ CREATE TABLE `society_moneywash` (
 
 CREATE TABLE `users` (
   `identifier` varchar(60) NOT NULL,
+	`ssn` VARCHAR(11) NOT NULL,
   `accounts` longtext DEFAULT NULL,
   `group` varchar(50) DEFAULT 'user',
   `inventory` longtext DEFAULT NULL,
@@ -846,6 +847,9 @@ ALTER TABLE `society_moneywash`
 ALTER TABLE `users`
   ADD PRIMARY KEY (`identifier`),
   ADD UNIQUE KEY `id` (`id`);
+
+ALTER TABLE `users`
+  ADD UNIQUE KEY `unique_ssn` (`ssn`);
 
 --
 -- Indexes for table `user_licenses`

--- a/[core]/es_extended/es_extended.sql
+++ b/[core]/es_extended/es_extended.sql
@@ -10,6 +10,7 @@ USE `es_extended`;
 
 CREATE TABLE `users` (
 	`identifier` VARCHAR(60) NOT NULL,
+	`ssn` VARCHAR(11) NOT NULL,
 	`accounts` LONGTEXT NULL DEFAULT NULL,
 	`group` VARCHAR(50) NULL DEFAULT 'user',
 	`inventory` LONGTEXT NULL DEFAULT NULL,
@@ -19,7 +20,8 @@ CREATE TABLE `users` (
 	`metadata` LONGTEXT NULL DEFAULT NULL,
 	`position` longtext NULL DEFAULT NULL,
 
-	PRIMARY KEY (`identifier`)
+	PRIMARY KEY (`identifier`),
+	UNIQUE KEY `unique_ssn` (`ssn`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `items` (

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -48,6 +48,7 @@
 ---@field coords table              # Player's coordinates {x, y, z, heading}.
 ---@field group string              # Player permission group.
 ---@field identifier string         # Unique identifier (usually Steam or license).
+---@field ssn string                # Player's social security number.
 ---@field license string            # Player license string.
 ---@field inventory ESXInventoryItem[] # Player's inventory items.
 ---@field job ESXJob                # Player's current job.
@@ -105,6 +106,7 @@
 ---@field getWeaponTint fun(weaponName: string): number                  # Get weapon tint.
 --- Player State Functions
 ---@field getIdentifier fun(): string                              # Get player's unique identifier.
+---@field getSSN fun(): string                                      # Get player's social security number.
 ---@field getSource fun(): number                                  # Get player source/server ID.
 ---@field getPlayerId fun(): number                                # Alias for getSource.
 ---@field getName fun(): string                                     # Get player's name.
@@ -263,11 +265,10 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
         return self.identifier
     end
 
-    ---@return string
     function self.getSSN()
         return self.ssn
     end
-  
+
     function self.setGroup(newGroup)
         local lastGroup = self.group
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -19,6 +19,7 @@
 
 ---@param playerId number
 ---@param identifier string
+---@param ssn string
 ---@param group string
 ---@param accounts table
 ---@param inventory table
@@ -28,7 +29,7 @@
 ---@param name string
 ---@param coords table | vector4
 ---@param metadata table
-function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, weight, job, loadout, name, coords, metadata)
+function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, inventory, weight, job, loadout, name, coords, metadata)
     ---@class xPlayer
     local self = {}
 
@@ -36,6 +37,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     self.coords = coords
     self.group = group
     self.identifier = identifier
+    self.ssn = ssn
     self.inventory = inventory
     self.job = job
     self.loadout = loadout
@@ -171,6 +173,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
     ---@return string
     function self.getIdentifier()
         return self.identifier
+    end
+
+    ---@return string
+    function self.getSSN()
+        return self.ssn
     end
 
     ---@param newGroup string

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -804,6 +804,51 @@ function Core.IsPlayerAdmin(playerSrc)
     return xPlayer and Config.AdminGroups[xPlayer.getGroup()] or false
 end
 
+-- Generates a unique 9-digit SSN in dashed format (XXX-XX-XXXX).
+---@return string
+function Core.generateSSN()
+    local reservedSSNs = {
+        ["078-05-1120"] = true,
+        ["219-09-9999"] = true,
+        ["123-45-6789"] = true
+    }
+
+    while true do
+        -- Generate the first part (area number)
+        local area = math.random(1, 899)
+
+        -- 666 is never assigned
+        if area == 666 then
+            goto continue
+        end
+
+        -- Generate the second part (group number)
+        local group = math.random(1, 99)
+
+        -- Generate the last part (serial number)
+        local serial = math.random(1, 9999)
+
+        -- Skip reserved SSN range (987-65-4320..4329)
+        if area == 987 and group == 65 and serial >= 4320 and serial <= 4329 then
+            goto continue
+        end
+
+        local candidate = string.format("%03d-%02d-%04d", area, group, serial)
+
+        if reservedSSNs[candidate] then
+            goto continue
+        end
+
+        local exists = MySQL.scalar.await("SELECT 1 FROM `users` WHERE `ssn` = ? LIMIT 1", { candidate })
+
+        if not exists then
+            return candidate
+        end
+
+        ::continue::
+    end
+end
+
 ---@param owner string
 ---@param plate string
 ---@param coords vector4


### PR DESCRIPTION
### Description

Adds a new `ssn` field to the `users` table and updates player logic to handle Social Security Numbers (SSNs). Introduces a utility function to generate valid, unique SSNs, ensures uniqueness via a database constraint, and integrates SSN handling into player creation and loading.

---

### Motivation

To provide each player with a unique SSN that behaves like a real-world identifier, enabling RP mechanics such as identity verification, criminal records, and administrative checks. This enhances immersion and supports gameplay features that rely on unique player identities.

---

### Implementation Details

- Added `ssn` column to `users` table in both SQL schemas, with a unique constraint.
- Updated player creation logic to generate and store a unique SSN when a new player joins.
- Modified player loading functions to fetch and attach SSN to the player object.
- Added a utility function `generateSSN()` in Lua that ensures valid formatting and uniqueness (with database check using `MySQL.scalar.await`).
- All SSNs are stored and handled **with dashes** for readability (e.g., `123-45-6789`).

---

### Usage Example

```lua
-- Server-side
print(xPlayer.getSSN()) -- e.g., "123-45-6789"

-- Client-side
print(ESX.PlayerData.ssn) -- e.g., "123-45-6789"
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
