### PR TITLE
feat(es_extended): add static ESX.ExtendedPlayers

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -42,26 +42,7 @@
 ---@field label string              # Component display name.
 ---@field hash string|number        # Component hash or identifier.
 
----@class xPlayer
---- Properties
----@field accounts ESXAccount[]     # Array of the player's accounts.
----@field coords table              # Player's coordinates {x, y, z, heading}.
----@field group string              # Player permission group.
----@field identifier string         # Unique identifier (usually Steam or license).
----@field license string            # Player license string.
----@field inventory ESXInventoryItem[] # Player's inventory items.
----@field job ESXJob                # Player's current job.
----@field loadout ESXInventoryWeapon[] # Player's current weapons.
----@field name string               # Player's display name.
----@field playerId number           # Player's ID (server ID).
----@field source number             # Player's source (alias for playerId).
----@field variables table           # Custom player variables.
----@field weight number             # Current carried weight.
----@field maxWeight number          # Maximum carry weight.
----@field metadata table            # Custom metadata table.
----@field lastPlaytime number       # Last recorded playtime in seconds.
----@field paycheckEnabled boolean   # Whether paycheck is enabled.
----@field admin boolean             # Whether the player is an admin.
+---@class StaticPlayer
 --- Money Functions
 ---@field setMoney fun(money: number)                             # Set player's cash balance.
 ---@field getMoney fun(): number                                   # Get player's current cash balance.
@@ -129,6 +110,28 @@
 ---@field isPaycheckEnabled fun(): boolean       # Check if paycheck is enabled.
 ---@field executeCommand fun(command: string)    # Execute a server command.
 ---@field triggerEvent fun(eventName: string, ...) # Trigger client event for this player.
+
+
+---@class xPlayer:StaticPlayer
+--- Properties
+---@field accounts ESXAccount[]     # Array of the player's accounts.
+---@field coords table              # Player's coordinates {x, y, z, heading}.
+---@field group string              # Player permission group.
+---@field identifier string         # Unique identifier (usually Steam or license).
+---@field license string            # Player license string.
+---@field inventory ESXInventoryItem[] # Player's inventory items.
+---@field job ESXJob                # Player's current job.
+---@field loadout ESXInventoryWeapon[] # Player's current weapons.
+---@field name string               # Player's display name.
+---@field playerId number           # Player's ID (server ID).
+---@field source number             # Player's source (alias for playerId).
+---@field variables table           # Custom player variables.
+---@field weight number             # Current carried weight.
+---@field maxWeight number          # Maximum carry weight.
+---@field metadata table            # Custom metadata table.
+---@field lastPlaytime number       # Last recorded playtime in seconds.
+---@field paycheckEnabled boolean   # Whether paycheck is enabled.
+---@field admin boolean             # Whether the player is an admin.
 
 ---@param playerId number
 ---@param identifier string

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -277,7 +277,7 @@ end
 
 ESX.GetPlayers = GetPlayers
 
-local function checkTable(key, val, xPlayer, xPlayers)
+local function checkTable(key, val, xPlayer, xPlayers, minimal)
     for valIndex = 1, #val do
         local value = val[valIndex]
         if not xPlayers[value] then
@@ -285,23 +285,35 @@ local function checkTable(key, val, xPlayer, xPlayers)
         end
 
         if (key == "job" and xPlayer.job.name == value) or xPlayer[key] == value then
-            xPlayers[value][#xPlayers[value] + 1] = xPlayer
+            xPlayers[value][#xPlayers[value] + 1] = (minimal and xPlayer.source or xPlayer)
         end
     end
 end
 
 ---@param key? string
 ---@param val? string|table
----@return xPlayer[]|table<any, xPlayer[]>
-function ESX.GetExtendedPlayers(key, val)
+---@param minimal? boolean
+---@return xPlayer[]|number[]|table<any, xPlayer[]>|table<any, number[]>
+function ESX.GetExtendedPlayers(key, val, minimal)
     if not key then
-        return ESX.Table.ToArray(ESX.Players)
+        if not minimal then
+            return ESX.Table.ToArray(ESX.Players)
+        end
+
+        local xPlayers = {}
+        local index = 1
+        for src, _ in pairs(ESX.Players) do
+            xPlayers[index] = src
+            index += 1
+        end
+
+        return xPlayers
     end
 
     local xPlayers = {}
     if type(val) == "table" then
         for _, xPlayer in pairs(ESX.Players) do
-            checkTable(key, val, xPlayer, xPlayers)
+            checkTable(key, val, xPlayer, xPlayers, minimal)
         end
 
         return xPlayers
@@ -309,7 +321,7 @@ function ESX.GetExtendedPlayers(key, val)
 
     for _, xPlayer in pairs(ESX.Players) do
         if (key == "job" and xPlayer.job.name == val) or xPlayer[key] == val then
-            xPlayers[#xPlayers + 1] = xPlayer
+            xPlayers[#xPlayers + 1] = (minimal and xPlayer.source or xPlayer)
         end
     end
 


### PR DESCRIPTION
### Description

Adds `ESX.ExtendedPlayers` as a lightweight wrapper for `ESX.GetExtendedPlayers`. Returns tables of `StaticPlayer` objects (method-only wrappers) for multiple players, following the same pattern as the existing `ESX.Player` function.

---

### Motivation

`ESX.Player` provides a minimal interface for a single player by exposing only methods via `StaticPlayer`. This reduces bloat and avoids exposing full `xPlayer` properties. `ESX.ExtendedPlayers` extends this approach to multiple players, making it easier to work with groups of players while keeping the same clean, method-only interface.

---

### Implementation Details

- Introduces `StaticPlayer` class.
- Implements `ESX.ExtendedPlayers(key?, val?)` which:
  - Returns an array of `StaticPlayer` objects for a single filter.
  - Returns a table mapping groups to arrays of `StaticPlayer` objects for multi-group filters.
- Uses `ESX.GetExtendedPlayers` internally.
- Fully type-annotated for better IDE support and autocomplete.

---

### Usage Example

```lua
local groupedPlayers = ESX.ExtendedPlayers("job", { "ambulance", "police" }) --[[@as table<string, StaticPlayer[]>]]
for group, players in pairs(groupedPlayers) do
    for i, xPlayer in ipairs(players) do
        print(group, xPlayer.getName())
    end
end

local xPlayers = ESX.ExtendedPlayers() --[=[@as StaticPlayer[]]=]
for i, xPlayer in ipairs(xPlayers) do
    print(xPlayer.getName())
end
```

---

### PR Checklist

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.


