### PR TITLE
feat: add auto-migrations on startup

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -35,7 +35,9 @@ server_scripts {
 
 	'server/bridge/**/*.lua',
 	'server/modules/npwd.lua',
-	'server/modules/createJob.lua'
+	'server/modules/createJob.lua',
+	'server/migration/**/main.lua',
+	'server/migration/main.lua',
 }
 
 client_scripts {

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -818,8 +818,9 @@ function Core.IsPlayerAdmin(playerSrc)
 end
 
 -- Generates a unique 9-digit SSN in dashed format (XXX-XX-XXXX).
+---@param skipUniqueCheck boolean?
 ---@return string
-function Core.generateSSN()
+function Core.generateSSN(skipUniqueCheck)
     local reservedSSNs = {
         ["078-05-1120"] = true,
         ["219-09-9999"] = true,
@@ -850,6 +851,10 @@ function Core.generateSSN()
 
         if reservedSSNs[candidate] then
             goto continue
+        end
+
+        if skipUniqueCheck then
+            return candidate
         end
 
         local exists = MySQL.scalar.await("SELECT 1 FROM `users` WHERE `ssn` = ? LIMIT 1", { candidate })

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -1,0 +1,30 @@
+RegisterCommand("resetmigrations", function(src)
+	if src > 0 then
+		print("^1[ERROR]^7 This command can only be run from the server console.")
+		return
+	end
+
+	for version, _ in pairs(Migrations or {}) do
+		DeleteResourceKvp(("esx_migration:%s"):format(version))
+	end
+	print("^2[SUCCESS]^7 Reset all migrations. This will re-run all migrations on the next server start.")
+end)
+
+for esxVersion, migrations in pairs(Migrations or {}) do
+	---@cast esxVersion string
+	---@cast migrations table<string, function>
+
+	if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) ~= 1 then
+		print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
+
+		for migrationName, migration in pairs(migrations) do
+			local success, err = pcall(migration)
+			if not success then
+				error(("^1[ERROR]^7 Failed migration ^4['%s.%s']^7: %s"):format(esxVersion, migrationName, err))
+			end
+		end
+
+		SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
+		print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
+	end
+end

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -16,18 +16,20 @@ for esxVersion, migrations in pairs(Core.Migrations or {}) do
 	---@cast esxVersion string
 	---@cast migrations table<string, function>
 
-	print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
+	if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) ~= 1 then
+		print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
 
-	for migrationName, migration in pairs(migrations) do
-		local success, err = pcall(migration)
-		if not success then
-			error(("^1[ERROR]^7 Failed migration ^4['%s.%s']^7: %s"):format(esxVersion, migrationName, err))
+		for migrationName, migration in pairs(migrations) do
+			local success, err = pcall(migration)
+			if not success then
+				error(("^1[ERROR]^7 Failed migration ^4['%s.%s']^7: %s"):format(esxVersion, migrationName, err))
+			end
 		end
-	end
 
-	SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
-	print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
-	migrationsRan += 1
+		SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
+		print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
+		migrationsRan += 1
+	end
 end
 
 if migrationsRan > 0 then

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -16,20 +16,18 @@ for esxVersion, migrations in pairs(Core.Migrations or {}) do
 	---@cast esxVersion string
 	---@cast migrations table<string, function>
 
-	if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) ~= 1 then
-		print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
+	print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
 
-		for migrationName, migration in pairs(migrations) do
-			local success, err = pcall(migration)
-			if not success then
-				error(("^1[ERROR]^7 Failed migration ^4['%s.%s']^7: %s"):format(esxVersion, migrationName, err))
-			end
+	for migrationName, migration in pairs(migrations) do
+		local success, err = pcall(migration)
+		if not success then
+			error(("^1[ERROR]^7 Failed migration ^4['%s.%s']^7: %s"):format(esxVersion, migrationName, err))
 		end
-
-		SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
-		print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
-		migrationsRan += 1
 	end
+
+	SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
+	print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
+	migrationsRan += 1
 end
 
 if migrationsRan > 0 then

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -16,7 +16,7 @@ for esxVersion, migrations in pairs(Core.Migrations or {}) do
 	---@cast esxVersion string
 	---@cast migrations table<string, function>
 
-	if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) ~= 1 then
+	if ESX.Table.SizeOf(migrations) > 0 then
 		print(("^4[INFO]^7 Running migrations for ESX version %s"):format(esxVersion))
 
 		for migrationName, migration in pairs(migrations) do

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -10,6 +10,8 @@ RegisterCommand("resetmigrations", function(src)
 	print("^2[SUCCESS]^7 Reset all migrations. This will re-run all migrations on the next server start.")
 end)
 
+local migrationsRan = 0
+
 for esxVersion, migrations in pairs(Migrations or {}) do
 	---@cast esxVersion string
 	---@cast migrations table<string, function>
@@ -26,5 +28,13 @@ for esxVersion, migrations in pairs(Migrations or {}) do
 
 		SetResourceKvpInt(("esx_migration:%s"):format(esxVersion), 1)
 		print(("^2[SUCCESS]^7 Successfully completed migrations for ESX version %s"):format(esxVersion))
+		migrationsRan += 1
+	end
+end
+
+if migrationsRan > 0 then
+	while true do
+		print(("^4[INFO]^7 Ran migrations for %d ESX version(s). ^1Server restart required!^7"):format(migrationsRan))
+		Wait(500)
 	end
 end

--- a/[core]/es_extended/server/migration/main.lua
+++ b/[core]/es_extended/server/migration/main.lua
@@ -4,7 +4,7 @@ RegisterCommand("resetmigrations", function(src)
 		return
 	end
 
-	for version, _ in pairs(Migrations or {}) do
+	for version, _ in pairs(Core.Migrations or {}) do
 		DeleteResourceKvp(("esx_migration:%s"):format(version))
 	end
 	print("^2[SUCCESS]^7 Reset all migrations. This will re-run all migrations on the next server start.")
@@ -12,7 +12,7 @@ end)
 
 local migrationsRan = 0
 
-for esxVersion, migrations in pairs(Migrations or {}) do
+for esxVersion, migrations in pairs(Core.Migrations or {}) do
 	---@cast esxVersion string
 	---@cast migrations table<string, function>
 

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -1,7 +1,13 @@
-Core.Migrations = Core.Migrations or {}
-Core.Migrations["v1.13.3"] = Core.Migrations["v1.13.3"] or {}
+local esxVersion = "v1.13.3"
 
-Core.Migrations["v1.13.3"].ssn = function()
+Core.Migrations = Core.Migrations or {}
+Core.Migrations[esxVersion] = Core.Migrations[esxVersion] or {}
+
+if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
+  return
+end
+
+Core.Migrations[esxVersion].ssn = function()
   print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
   local col = MySQL.scalar.await([[
     SELECT COUNT(*)

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -1,7 +1,13 @@
-Core.Migrations = Core.Migrations or {}
-Core.Migrations["v1.13.3"] = Core.Migrations["v1.13.3"] or {}
+local esxVersion = "v1.13.3"
 
-Core.Migrations["v1.13.3"].ssn = function()
+if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
+  return
+end
+
+Core.Migrations = Core.Migrations or {}
+Core.Migrations[esxVersion] = Core.Migrations[esxVersion] or {}
+
+Core.Migrations[esxVersion].ssn = function()
   print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
   local col = MySQL.scalar.await([[
     SELECT COUNT(*)

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -7,6 +7,7 @@ if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
   return
 end
 
+---@return boolean restartRequired
 Core.Migrations[esxVersion].ssn = function()
   print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
   local col = MySQL.scalar.await([[
@@ -41,7 +42,7 @@ Core.Migrations[esxVersion].ssn = function()
   local Result = MySQL.query.await("SELECT `identifier` FROM `users` WHERE `ssn` IS NULL")
   if #Result == 0 then
     print("^4[esx_migration:v.1.13.3:ssn]^7 No users found without SSN, migration not needed.")
-    return
+    return false
   end
 
   print("^4[esx_migration:v.1.13.3:ssn]^7 Generating SSN for existing users.")
@@ -64,4 +65,6 @@ Core.Migrations[esxVersion].ssn = function()
   MySQL.update.await("ALTER TABLE `users` MODIFY `ssn` VARCHAR(11) NOT NULL")
 
   print(("^4[esx_migration:v.1.13.3:ssn]^7 Successfully migrated %d users."):format(#Parameters))
+
+  return true
 end

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -1,0 +1,61 @@
+Migrations = Migrations or {}
+Migrations["v1.13.3"] = Migrations["v1.13.3"] or {}
+
+Migrations["v1.13.3"].ssn = function()
+  print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
+  local col = MySQL.scalar.await([[
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND COLUMN_NAME = 'ssn'
+]])
+
+  local idx = MySQL.scalar.await([[
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users'
+      AND INDEX_NAME = 'unique_ssn'
+]])
+
+  if col == 0 and idx == 0 then
+    MySQL.update.await([[
+        ALTER TABLE `users`
+            ADD COLUMN `ssn` VARCHAR(11) NULL DEFAULT NULL AFTER `identifier`,
+            ADD UNIQUE KEY `unique_ssn` (`ssn`)
+    ]])
+  elseif col == 0 then
+    MySQL.update.await("ALTER TABLE `users` ADD COLUMN `ssn` VARCHAR(11) NULL DEFAULT NULL AFTER `identifier`")
+  elseif idx == 0 then
+    MySQL.update.await("ALTER TABLE `users` ADD UNIQUE KEY `unique_ssn` (`ssn`)")
+  end
+
+
+  local Result = MySQL.query.await("SELECT `identifier` FROM `users` WHERE `ssn` IS NULL")
+  if #Result == 0 then
+    print("^4[esx_migration:v.1.13.3:ssn]^7 No users found without SSN, migration not needed.")
+    return
+  end
+
+  print("^4[esx_migration:v.1.13.3:ssn]^7 Generating SSN for existing users.")
+  local GeneratedSSNs = {}
+  local Parameters = {}
+  for i = 1, #Result do
+    local ssn
+    repeat
+      ssn = Core.generateSSN(true)
+    until not GeneratedSSNs[ssn]
+
+    GeneratedSSNs[ssn] = true
+    Parameters[i] = { ssn, Result[i].identifier }
+  end
+
+  print("^4[esx_migration:v.1.13.3:ssn]^7 Updating users with generated SSN. This may take a minute...")
+  MySQL.prepare.await("UPDATE `users` SET `ssn` = ? WHERE `identifier` = ?", Parameters)
+
+  print("^4[esx_migration:v.1.13.3:ssn]^7 Removing SSN default value.")
+  MySQL.update.await("ALTER TABLE `users` MODIFY `ssn` VARCHAR(11) NOT NULL")
+
+  print(("^4[esx_migration:v.1.13.3:ssn]^7 Successfully migrated %d users."):format(#Parameters))
+end

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -1,7 +1,7 @@
-Migrations = Migrations or {}
-Migrations["v1.13.3"] = Migrations["v1.13.3"] or {}
+Core.Migrations = Core.Migrations or {}
+Core.Migrations["v1.13.3"] = Core.Migrations["v1.13.3"] or {}
 
-Migrations["v1.13.3"].ssn = function()
+Core.Migrations["v1.13.3"].ssn = function()
   print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
   local col = MySQL.scalar.await([[
     SELECT COUNT(*)

--- a/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
+++ b/[core]/es_extended/server/migration/v1.13.3/ssn/main.lua
@@ -1,13 +1,7 @@
-local esxVersion = "v1.13.3"
-
-if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
-  return
-end
-
 Core.Migrations = Core.Migrations or {}
-Core.Migrations[esxVersion] = Core.Migrations[esxVersion] or {}
+Core.Migrations["v1.13.3"] = Core.Migrations["v1.13.3"] or {}
 
-Core.Migrations[esxVersion].ssn = function()
+Core.Migrations["v1.13.3"].ssn = function()
   print("^4[esx_migration:v.1.13.3:ssn]^7 Adding SSN column to users table.")
   local col = MySQL.scalar.await([[
     SELECT COUNT(*)


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Introduces a migration system for ESX that allows adding database migrations for older versions.  
Includes a new migration for v1.13.3 that adds a unique `ssn` column to the `users` table, backfills existing users, and ensures the column is `NOT NULL`.  

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Previously, migrating users between ESX versions required manual SQL updates and ad-hoc scripts, which was error-prone and time-consuming.  
This new system standardizes migrations, allows safe execution, and can be extended to handle migrations for any older ESX version.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- Migrations are registered in a `Migrations` table keyed by ESX version.
- Each migration is a Lua function that executes SQL updates and any necessary data transformations.
- The runner iterates through all migrations for a given version and executes them.
- Each completed migration is tracked using `GetResourceKvpInt` to avoid re-running on server restart.
---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
