### PR TITLE
feat(es_extended) Adds adjustment to lower woman and man player strength

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -233,29 +233,22 @@ function Adjustments:Multipliers()
             Wait(0)
         end
     end)
-end
 
-function Adjustments:WeakerWoman()
-    if Config.WeakerWoman then
-        AddEventHandler("esx:PlayerLoaded",function (_, skin)
-            if not skin or skin.sex == nil then
-                return -- Early Exit
-            end
+    AddEventHandler("esx:playerLoaded",function (xPlayer)
+        if not xPlayer or xPlayer.get("sex") == nil then
+            return -- Early Exit
+        end
 
-            if skin.sex ~= 1 then
-                return -- Early Exit
-            end
+        local multipliers = xPlayer.get("sex") == "m" and Config.Multipliers.man or Config.Multipliers.woman
 
-            SetWeaponDamageModifier(`WEAPON_UNARMED`, Config.WeakerWoman.strength)
+        if multipliers.strength ~= 1.0 then
+            SetWeaponDamageModifier(`WEAPON_UNARMED`, man.strength)
+        end
+
+        if multipliers.stamina ~= 1.0 then
             SetPlayerStamina(PlayerId(), Config.WeakerWoman.stamina)
-        end)
-
-        -- Removes multiplayers - in case of the logout/relog
-        ESX.SecureNetEvent("esx:onPlayerLogout", function()
-            SetWeaponDamageModifier(`WEAPON_UNARMED`, 1.0)
-            SetPlayerStamina(PlayerId(), 1.0)
-        end)
-    end
+        end
+    end)
 end
 
 function Adjustments:Load()
@@ -273,5 +266,4 @@ function Adjustments:Load()
     self:WantedLevel()
     self:DisableRadio()
     self:Multipliers()
-    self:WeakerWoman()
 end

--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -242,11 +242,11 @@ function Adjustments:Multipliers()
         local multipliers = xPlayer.get("sex") == "m" and Config.Multipliers.man or Config.Multipliers.woman
 
         if multipliers.strength ~= 1.0 then
-            SetWeaponDamageModifier(`WEAPON_UNARMED`, man.strength)
+            SetWeaponDamageModifier(`WEAPON_UNARMED`, multipliers.strength)
         end
 
         if multipliers.stamina ~= 1.0 then
-            SetPlayerStamina(PlayerId(), Config.WeakerWoman.stamina)
+            SetPlayerStamina(PlayerId(), multipliers.stamina)
         end
     end)
 end

--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -235,6 +235,29 @@ function Adjustments:Multipliers()
     end)
 end
 
+function Adjustments:WeakerWoman()
+    if Config.WeakerWoman then
+        AddEventHandler("esx:PlayerLoaded",function (_, skin)
+            if not skin or skin.sex == nil then
+                return -- Early Exit
+            end
+
+            if skin.sex ~= 1 then
+                return -- Early Exit
+            end
+
+            SetWeaponDamageModifier(`WEAPON_UNARMED`, Config.WeakerWoman.strength)
+            SetPlayerStamina(PlayerId(), Config.WeakerWoman.stamina)
+        end)
+
+        -- Removes multiplayers - in case of the logout/relog
+        ESX.SecureNetEvent("esx:onPlayerLogout", function()
+            SetWeaponDamageModifier(`WEAPON_UNARMED`, 1.0)
+            SetPlayerStamina(PlayerId(), 1.0)
+        end)
+    end
+end
+
 function Adjustments:Load()
     self:RemoveHudComponents()
     self:DisableAimAssist()
@@ -250,4 +273,5 @@ function Adjustments:Load()
     self:WantedLevel()
     self:DisableRadio()
     self:Multipliers()
+    self:WeakerWoman()
 end

--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -41,7 +41,16 @@ Config.Multipliers = {
     ambientVehicleRange = 1.0,
     parkedVehicleDensity = 1.0,
     randomVehicleDensity = 1.0,
-    vehicleDensity = 1.0
+    vehicleDensity = 1.0,
+    --- Won't update when set to 1.0
+    man = {
+        strength = 1.0,
+        stamina = 1.0,
+    },
+    woman = {
+        strength = 1.0,
+        stamina = 1.0,
+    }
 }
 
 -- Pattern string format
@@ -77,15 +86,4 @@ Config.DiscordActivity = {
     },
     presence = "{player_name} [{player_id}] | {server_players}/{server_maxplayers}",
     refresh = 1 * 60 * 1000, -- 1 minute
-}
-
-
--- Must be either a FALSE or
--- Config.WeakerWoman = { 
---     stamina = float, 
---     strength = float
--- }
-Config.WeakerWoman = { 
-    stamina = 0.9, -- Must be a float from 0.0 to 1.0 (1.0 is 100%)
-    strength = 0.8 -- Must be a float from 0.0 to 1.0 (1.0 is 100%) - modifies weapon_unarmed strength
 }

--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -78,3 +78,14 @@ Config.DiscordActivity = {
     presence = "{player_name} [{player_id}] | {server_players}/{server_maxplayers}",
     refresh = 1 * 60 * 1000, -- 1 minute
 }
+
+
+-- Must be either a FALSE or
+-- Config.WeakerWoman = { 
+--     stamina = float, 
+--     strength = float
+-- }
+Config.WeakerWoman = { 
+    stamina = 0.9, -- Must be a float from 0.0 to 1.0 (1.0 is 100%)
+    strength = 0.8 -- Must be a float from 0.0 to 1.0 (1.0 is 100%) - modifies weapon_unarmed strength
+}


### PR DESCRIPTION
### Description

It sets by listening to PlayerLoaded and onPlayerLogout event and using SetWeaponDamageModifier and SetPlayerStamina a lower strength of the player.

---

### Motivation

This change isn't neccessary but is a good feature for Hard RP servers.

### DISCLAIMER:
This script applies different stamina/strength settings based on the player's in-game gender.
It is purely a GAMEPLAY MECHANIC for balancing or roleplay purposes, not a statement about real-life gender.
The values and labels here should not be interpreted outside of the context of the game.
If you use or modify this code, please ensure it is respectful of your community’s preferences.

### PR Checklist

-   [-] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [-] My changes have been tested locally and function as expected.
-   [-] My PR does not introduce any breaking changes.
-   [-] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
