### PR TITLE
feat: add esx job types

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -235,6 +235,7 @@ INSERT INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES
 CREATE TABLE `jobs` (
   `name` varchar(50) NOT NULL,
   `label` varchar(50) DEFAULT NULL,
+  `type` varchar(50) NOT NULL DEFAULT 'civ',
   `whitelisted` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB;
 
@@ -242,20 +243,20 @@ CREATE TABLE `jobs` (
 -- Dumping data for table `jobs`
 --
 
-INSERT INTO `jobs` (`name`, `label`, `whitelisted`) VALUES
-('ambulance', 'EMS', 0),
-('cardealer', 'Cardealer', 0),
-('fisherman', 'Fisherman', 0),
-('fueler', 'Fueler', 0),
-('lumberjack', 'Lumberjack', 0),
-('mechanic', 'Mechanic', 0),
-('miner', 'Miner', 0),
-('police', 'LSPD', 0),
-('reporter', 'Reporter', 0),
-('slaughterer', 'Butcher', 0),
-('tailor', 'Tailor', 0),
-('taxi', 'Taxi', 0),
-('unemployed', 'Unemployed', 0);
+INSERT INTO `jobs` (`name`, `label`, `type`, `whitelisted`) VALUES
+('ambulance', 'EMS', 'ems', 0),
+('cardealer', 'Cardealer', 'civ', 0),
+('fisherman', 'Fisherman', 'civ', 0),
+('fueler', 'Fueler', 'civ', 0),
+('lumberjack', 'Lumberjack', 'civ', 0),
+('mechanic', 'Mechanic', 'mechanic', 0),
+('miner', 'Miner', 'civ', 0),
+('police', 'LSPD', 'leo', 0),
+('reporter', 'Reporter', 'civ', 0),
+('slaughterer', 'Butcher', 'civ', 0),
+('tailor', 'Tailor', 'civ', 0),
+('taxi', 'Taxi', 'civ', 0),
+('unemployed', 'Unemployed', 'civ', 0);
 
 -- --------------------------------------------------------
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -585,6 +585,7 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
             id = jobObject.id,
             name = jobObject.name,
             label = jobObject.label,
+            type = jobObject.type,
             onDuty = onDuty,
 
             grade = tonumber(grade) or 0,

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -562,7 +562,7 @@ function ESX.RefreshJobs()
 
     if not Jobs then
         -- Fallback data, if no jobs exist
-        ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", whitelisted = false, grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
+        ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", type = "civ", whitelisted = false, grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
     else
         ESX.Jobs = Jobs
     end
@@ -628,13 +628,32 @@ function ESX.GetItemLabel(item)
     end
 end
 
+---@param jobType string|string[]?
 ---@return table
-function ESX.GetJobs()
+function ESX.GetJobs(jobType)
     while not Core.JobsLoaded do
         Citizen.Wait(200)
     end
 
-    return ESX.Jobs
+    if not jobType then
+        return ESX.Jobs
+    end
+
+    jobType = type(jobType) == "string" and { jobType } or jobType
+
+    local jobTypeLookup = {}
+    for i = 1, #jobType do
+        jobTypeLookup[jobType[i]] = true
+    end
+
+    local filteredJobs = {}
+    for jobName, jobObject in pairs(ESX.Jobs) do
+        if jobTypeLookup[jobObject.type] then
+            filteredJobs[jobName] = jobObject
+        end
+    end
+
+    return filteredJobs
 end
 
 ---@return table

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -234,6 +234,7 @@ function loadESXPlayer(identifier, playerId, isNew)
         id = jobObject.id,
         name = jobObject.name,
         label = jobObject.label,
+        type = jobObject.type,
 
         grade = tonumber(grade),
         grade_name = gradeObject.name,

--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -19,8 +19,8 @@ local function doesJobAndGradesExist(name, grades)
    return true
 end
 
-local function generateNewJobTable(name, label, grades)
-    local job = { name = name, label = label, grades = {} }
+local function generateNewJobTable(name, label, grades, jobType)
+    local job = { name = name, label = label, type = jobType, grades = {} }
     for _, v in pairs(grades) do
         job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = v.skin_male or '{}', skin_female = v.skin_female or '{}' }
     end
@@ -42,7 +42,8 @@ end
 --- @param name string
 --- @param label string
 --- @param grades table
-function ESX.CreateJob(name, label, grades)
+--- @param jobType string
+function ESX.CreateJob(name, label, grades, jobType)
     local currentResourceName = GetInvokingResource()
     local success = false
 
@@ -61,6 +62,10 @@ function ESX.CreateJob(name, label, grades)
         return success
     end
 
+    if type(jobType) ~= "string" then
+        jobType  "civ"
+    end
+
     local currentJobExist = doesJobAndGradesExist(name, grades)
 
     if currentJobExist then
@@ -69,7 +74,7 @@ function ESX.CreateJob(name, label, grades)
     end
 
     local queries = {
-        { query = 'INSERT INTO jobs (name, label) VALUES (?, ?)', values = { name, label } }
+        { query = 'INSERT INTO `jobs` (`name`, `label`, `type`) VALUES (?, ?, ?)', values = { name, label, jobType } }
     }
 
     for _, grade in pairs(grades) do
@@ -86,7 +91,7 @@ function ESX.CreateJob(name, label, grades)
         return success
     end
 
-    ESX.Jobs[name] = generateNewJobTable(name, label, grades)
+    ESX.Jobs[name] = generateNewJobTable(name, label, grades, jobType)
 
     notify("SUCCESS", currentResourceName, 'Job created successfully: `%s`', name)
 


### PR DESCRIPTION
### Description  
Introducing **job types** for ESX, inspired by the QB framework (`leo`, `ems`, etc.). Each job now has an associated type, making it easier to categorize and handle them without relying on manual whitelists.

---

### Motivation  
Currently, developers often resort to maintaining long, error-prone job whitelists for common tasks such as:  
- Dispatch notifications  
- Basic Permission checks  
- Shared logic between similar jobs  

By introducing job types, developers can check a player’s job type directly instead of maintaining and updating multiple job-specific conditions. This provides cleaner, more maintainable, and more scalable code.

---

### Implementation Details  
- Each job definition in `ESX.Jobs` can now include a `type` property (e.g., `"leo"`, `"ems"`, `"mechanic"`, `"civ"`, etc.).  
- A new utility `ESX.GetJobs(jobTypes)` was added to filter jobs by type.  
- Backwards compatibility is preserved — existing jobs without a `type` will continue to function as usual. The default jobType is 'civ'.

---

### Usage Example
```lua
-- Check if a player is in law enforcement (LEO)
if xPlayer.job.type == "leo" then
    print("Player is in law enforcement")
end

-- Get all EMS jobs
local emsJobs = ESX.GetJobs("ems")
for jobName, jobData in pairs(emsJobs) do
    print(jobName, jobData.label)
end

-- Get all jobs that are either EMS or LEO
local emergencyJobs = ESX.GetJobs({ "ems", "leo" })

if xPlayer.job.name == "police" or xPlayer.job.name == "sheriff" or xPlayer.job.name == "fib" then
    -- do something
end
```

### PR Checklist
- [x]  My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x]  My changes have been tested locally and function as expected.
- [x]  My PR does not introduce any breaking changes.
- [x]  I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.