### PR TITLE
feat(player-stats): add configurable stamina and strength modifiers by gender

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -287,23 +287,6 @@ function Adjustments:ApplyPlayerStats()
         end
     end
 
-    -- ADD NEW STATS HERE
-    -- ========================================================================
-    -- 1. Find your native: https://docs.fivem.net/natives/
-    -- 2. Uncomment template below (remove --)
-    -- 3. Replace "statName" with your stat name
-    -- 4. Replace "YourNative" with native from docs
-    -- 5. Add same stat to Config file
-    -- 6. Debug print is OPTIONAL (can be removed)
-    -- ========================================================================
-
-    -- if stats.statName then
-    --     YourNative(ESX.playerId, stats.statName)
-    --     if Config.EnableDebug then
-    --         print('[^2adjustments^7] statName: ' .. tostring(stats.statName))
-    --     end
-    -- end
-
     if Config.EnableDebug then
         print('[^2adjustments^7] stats applied for gender: ' .. gender)
     end

--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -44,17 +44,34 @@ Config.Multipliers = {
     vehicleDensity = 1.0
 }
 
+
 Config.PlayerStatsByGender = {
     enabled = true,
     debugMode = true,
     useCharacterData = true, -- true: uses ESX.PlayerData.sex | false: uses ped model/skin
+    malePeds = {
+        `mp_m_freemode_01`,
+    },
+    femalePeds = {
+        `mp_f_freemode_01`,
+    },
     male = {
         stamina = 1.0,
-        strength = 1.0
+        strength = 1.0,
+        swimSpeed = 1.25,
+        moveSpeed = 1.0,
+
+        -- ADD NEW STATS HERE
+        -- 1. Uncomment line below (remove --)
+        -- 2. Change value: 1.0 = normal, 1.5 = +50%, 0.5 = -50%
+        -- 3. Find natives: https://docs.fivem.net/natives/
+        -- statName = 1.0,
     },
-    female = {
+   female = {
         stamina = 1.15,
-        strength = 0.85
+        strength = 0.85,
+        swimSpeed = 1.25,
+        moveSpeed = 7.00,
     }
 }
 

--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -44,6 +44,20 @@ Config.Multipliers = {
     vehicleDensity = 1.0
 }
 
+Config.PlayerStatsByGender = {
+    enabled = true,
+    debugMode = true,
+    useCharacterData = true, -- true: uses ESX.PlayerData.sex | false: uses ped model/skin
+    male = {
+        stamina = 1.0,
+        strength = 1.0
+    },
+    female = {
+        stamina = 1.15,
+        strength = 0.85
+    }
+}
+
 -- Pattern string format
 --1 will lead to a random number from 0-9.
 --A will lead to a random letter from A-Z.


### PR DESCRIPTION
### Description

This PR adds the ability for server owners to configure different stamina and strength multipliers based on player gender/sex. The feature integrates seamlessly into the existing adjustments system and provides flexible configuration options for roleplay servers.

---

### Implementation Details

Added new configuration option Config.PlayerStatsByGender in adjustments config
Implements gender detection through two methods:

Character data from database (ESX.PlayerData.sex)
Visual ped model detection (freemode models)


Uses native multipliers for real-time gameplay effects:

SetRunSprintMultiplierForPlayer() for sprint speed
SetSwimMultiplierForPlayer() for swim speed
SetPlayerMeleeWeaponDamageModifier() for melee damage
SetPedMoveRateOverride() for movement speed


Listens to ESX events for automatic stat updates:

esx:playerLoaded - Initial application
skinchanger:modelLoaded - On skin change
esx:onPlayerSpawn - On respawn


No server-side code required, uses only ESX.PlayerData

---

### Usage Example

```lua
-- In shared/config/adjustments.lua
Config.PlayerStatsByGender = {
    enabled = true,                    -- Enable/disable the feature
    useCharacterData = true,            -- true: uses ESX.PlayerData.sex | false: uses ped model/skin
    debugMode = false,                  -- Enable debug prints for testing
    male = {
        stamina = 1.0,                  -- Default multiplier (no change)
        strength = 1.0                  -- Default multiplier (no change)
    },
    female = {
        stamina = 1.15,                 -- 15% more stamina/speed
        strength = 0.85                 -- 15% less melee damage
    }
}

-- Feature is automatically applied when player loads
-- No additional setup required
```