### PR TITLE
fix: prevent ox_inventory from loading before character registration completes

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -354,6 +354,11 @@ function loadESXPlayer(identifier, playerId, isNew)
     if not Config.CustomInventory then
         xPlayer.triggerEvent("esx:createMissingPickups", Core.Pickups)
     elseif setPlayerInventory then
+        if not Config.Multichar and isNew and not xPlayer.get("firstName") and not xPlayer.get("lastName") then
+			while not xPlayer.get("firstName") and not xPlayer.get("lastName") do
+				Wait(3000)
+			end
+		end
         setPlayerInventory(playerId, xPlayer, userData.inventory, isNew)
     end
 

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -354,11 +354,22 @@ function loadESXPlayer(identifier, playerId, isNew)
     if not Config.CustomInventory then
         xPlayer.triggerEvent("esx:createMissingPickups", Core.Pickups)
     elseif setPlayerInventory then
-        if not Config.Multichar and isNew and not xPlayer.get("firstName") and not xPlayer.get("lastName") then
-			while not xPlayer.get("firstName") and not xPlayer.get("lastName") do
-				Wait(3000)
-			end
-		end
+        -- Wait for identity to be set before loading inventory (for non-multichar)
+        if not Config.Multichar and isNew and not xPlayer.get("firstName") then
+            local sleep = 5000
+            local registrationTimeout = 120 * 1000 -- 2 minutes
+
+            while not xPlayer.get("firstName") do
+                registrationTimeout = registrationTimeout - sleep
+
+                if registrationTimeout <= 0 then
+                    print(('[^3WARNING^7] Player ^5"%s"^7 Registration Timeout Reached (Loading Inventory Anyway).'):format(xPlayer.getName()))
+                    break
+                end
+
+                Wait(sleep)
+            end
+        end
         setPlayerInventory(playerId, xPlayer, userData.inventory, isNew)
     end
 


### PR DESCRIPTION
### Description

ox_inventory was loading before player registration completed, displaying 'nil nil' as the player name in the inventory UI when multicharacter mode is disabled.

Fix:
* Check if multicharacter is disabled (Config.Multichar)
* Identify new characters (isNew)
* Wait for firstName and lastName to be registered
* Recheck every 3 seconds until identity data is available
* Ensures inventory UI displays correct player name on load

---

### Motivation

On non-multicharacter servers, new players would see 'nil nil' displayed in their ox_inventory UI because the inventory was initializing before the character registration process finished writing firstName and lastName to the database. This creates a poor user experience and can cause inventory sync issues.

This fix prevents ox_inventory from loading until the character registration is fully complete.


---

### Implementation Details

The solution adds a validation check before ox_inventory initialization:
1. Detects if multicharacter is disabled via `Config.Multichar`
2. Uses the `isNew` flag to identify newly created characters
3. Validates that both `firstName` and `lastName` exist in the character data
4. Implements a retry mechanism that polls every 3 seconds until identity data is registered

---

### PR Checklist

-   [x ] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x ] My changes have been tested locally and function as expected.
-   [x ] My PR does not introduce any breaking changes.
-   [x ] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
