### PR TITLE
fix(es_extended): remove admin fallback for superadmin group

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -271,16 +271,7 @@ function loadESXPlayer(identifier, playerId, isNew)
     end
 
     -- Group
-    if result.group then
-        if result.group == "superadmin" then
-            userData.group = "admin"
-            print("[^3WARNING^7] ^5Superadmin^7 detected, setting group to ^5admin^7")
-        else
-            userData.group = result.group
-        end
-    else
-        userData.group = "user"
-    end
+    userData.group = result.group or "user"
 
     -- Loadout
     if not Config.CustomInventory then

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -510,11 +510,9 @@ ESX.RegisterCommand(
         if not args.playerId then
             args.playerId = xPlayer.source
         end
-        if args.group == "superadmin" then
-            args.group = "admin"
-            print("[^3WARNING^7] ^5Superadmin^7 detected, setting group to ^5admin^7")
-        end
+
         args.playerId.setGroup(args.group)
+
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "/setgroup Triggered!", "pink", {
                 { name = "Player", value = xPlayer and xPlayer.name or "Server Console", inline = true },


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

This PR removes the hardcoded behavior that automatically converted the “superadmin” group to “admin.” From now on, “superadmin” is treated as a valid group on its own. Opinionated logic like this has no place in a framework — developers should have full control over how their permission groups are defined and used.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

ESX previously forced “superadmin” to fall back to “admin,” removing flexibility and making it harder for server owners to structure permissions their own way. A framework should never enforce arbitrary conventions or override developer intent. This change ensures group handling is neutral, predictable, and fully customizable.

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.