### PR TITLE
feat(esx_lib) DUI Implementation

### DIFF
--- a/[core]/esx_lib/imports/dui/client.lua
+++ b/[core]/esx_lib/imports/dui/client.lua
@@ -1,0 +1,118 @@
+--[[
+    https://github.com/overextended/ox_lib
+
+    This file is licensed under LGPL-3.0 or higher <https://www.gnu.org/licenses/lgpl-3.0.en.html>
+
+    Copyright © 2025 Linden <https://github.com/thelindat>
+]]
+
+---@class DuiProperties
+---@field url string
+---@field width number
+---@field height number
+---@field debug? boolean
+
+---@class Dui
+---@field private private { id: string, debug: boolean }
+---@field url string
+---@field duiObject number
+---@field duiHandle string
+---@field runtimeTxd number
+---@field txdObject number
+---@field dictName string
+---@field txtName string
+xLib.dui = xLib.class()
+
+---@type table<string, Dui>
+local duis = {}
+
+local currentId = 0
+
+---@param data DuiProperties
+function xLib.dui:constructor(data)
+	local time = GetGameTimer()
+	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
+	currentId = currentId + 1
+	local dictName = ('ox_lib_dui_dict_%s'):format(id)
+	local txtName = ('ox_lib_dui_txt_%s'):format(id)
+	local duiObject = CreateDui(data.url, data.width, data.height)
+	local duiHandle = GetDuiHandle(duiObject)
+	local runtimeTxd = CreateRuntimeTxd(dictName)
+	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
+	self.private.id = id
+	self.private.debug = data.debug or false
+	self.url = data.url
+	self.duiObject = duiObject
+	self.duiHandle = duiHandle
+	self.runtimeTxd = runtimeTxd
+	self.txdObject = txdObject
+	self.dictName = dictName
+	self.txtName = txtName
+	duis[id] = self
+
+	if self.private.debug then
+		print(('Dui %s created'):format(id))
+	end
+end
+
+function xLib.dui:remove()
+	SetDuiUrl(self.duiObject, 'about:blank')
+	DestroyDui(self.duiObject)
+	duis[self.private.id] = nil
+
+	if self.private.debug then
+		print(('Dui %s removed'):format(self.private.id))
+	end
+end
+
+---@param url string
+function xLib.dui:setUrl(url)
+	self.url = url
+	SetDuiUrl(self.duiObject, url)
+
+	if self.private.debug then
+		print(('Dui %s url set to %s'):format(self.private.id, url))
+	end
+end
+
+---@param message table
+function xLib.dui:sendMessage(message)
+	SendDuiMessage(self.duiObject, json.encode(message))
+
+	if self.private.debug then
+		print(('Dui %s message sent with data :'):format(self.private.id), json.encode(message, { indent = true }))
+	end
+end
+
+---@param x number
+---@param y number
+function xLib.dui:sendMouseMove(x, y)
+	SendDuiMouseMove(self.duiObject, x, y)
+end
+
+---@param button 'left' | 'middle' | 'right'
+function xLib.dui:sendMouseDown(button)
+	SendDuiMouseDown(self.duiObject, button)
+end
+
+---@param button 'left' | 'middle' | 'right'
+function xLib.dui:sendMouseUp(button)
+	SendDuiMouseUp(self.duiObject, button)
+end
+
+---@param deltaX number
+---@param deltaY number
+function xLib.dui:sendMouseWheel(deltaX, deltaY)
+	SendDuiMouseWheel(self.duiObject, deltaY, deltaX)
+end
+
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if cache.resource ~= resourceName then return end
+
+	for _, dui in pairs(duis) do
+		dui:remove()
+	end
+end)
+
+return xLib.dui

--- a/[core]/esx_lib/imports/dui/client.lua
+++ b/[core]/esx_lib/imports/dui/client.lua
@@ -13,7 +13,8 @@
 ---@field debug? boolean
 
 ---@class Dui
----@field private private { id: string, debug: boolean }
+---@field private_id string
+---@field private_debug boolean
 ---@field url string
 ---@field duiObject number
 ---@field duiHandle string
@@ -24,7 +25,7 @@
 xLib.dui = xLib.class()
 
 ---@type table<string, Dui>
-local duis = {}
+local Duis = {}
 
 local currentId = 0
 
@@ -33,14 +34,14 @@ function xLib.dui:constructor(data)
 	local time = GetGameTimer()
 	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
 	currentId = currentId + 1
-	local dictName = ('ox_lib_dui_dict_%s'):format(id)
-	local txtName = ('ox_lib_dui_txt_%s'):format(id)
+	local dictName = ("ox_lib_dui_dict_%s"):format(id)
+	local txtName = ("ox_lib_dui_txt_%s"):format(id)
 	local duiObject = CreateDui(data.url, data.width, data.height)
 	local duiHandle = GetDuiHandle(duiObject)
 	local runtimeTxd = CreateRuntimeTxd(dictName)
 	local txdObject = CreateRuntimeTextureFromDuiHandle(runtimeTxd, txtName, duiHandle)
-	self.private.id = id
-	self.private.debug = data.debug or false
+	self.private_id = id
+	self.private_debug = data.debug or false
 	self.url = data.url
 	self.duiObject = duiObject
 	self.duiHandle = duiHandle
@@ -48,20 +49,20 @@ function xLib.dui:constructor(data)
 	self.txdObject = txdObject
 	self.dictName = dictName
 	self.txtName = txtName
-	duis[id] = self
+	Duis[id] = self
 
-	if self.private.debug then
-		print(('Dui %s created'):format(id))
+	if self.private_debug then
+		print(("Dui %s created"):format(id))
 	end
 end
 
 function xLib.dui:remove()
-	SetDuiUrl(self.duiObject, 'about:blank')
+	SetDuiUrl(self.duiObject, "about:blank")
 	DestroyDui(self.duiObject)
-	duis[self.private.id] = nil
+	Duis[self.private_id] = nil
 
-	if self.private.debug then
-		print(('Dui %s removed'):format(self.private.id))
+	if self.private_debug then
+		print(("Dui %s removed"):format(self.private_id))
 	end
 end
 
@@ -70,8 +71,8 @@ function xLib.dui:setUrl(url)
 	self.url = url
 	SetDuiUrl(self.duiObject, url)
 
-	if self.private.debug then
-		print(('Dui %s url set to %s'):format(self.private.id, url))
+	if self.private_debug then
+		print(("Dui %s url set to %s"):format(self.private_id, url))
 	end
 end
 
@@ -79,8 +80,8 @@ end
 function xLib.dui:sendMessage(message)
 	SendDuiMessage(self.duiObject, json.encode(message))
 
-	if self.private.debug then
-		print(('Dui %s message sent with data :'):format(self.private.id), json.encode(message, { indent = true }))
+	if self.private_debug then
+		print(("Dui %s message sent with data :"):format(self.private_id), json.encode(message, { indent = true }))
 	end
 end
 
@@ -90,12 +91,12 @@ function xLib.dui:sendMouseMove(x, y)
 	SendDuiMouseMove(self.duiObject, x, y)
 end
 
----@param button 'left' | 'middle' | 'right'
+---@param button "left" | "middle" | "right"
 function xLib.dui:sendMouseDown(button)
 	SendDuiMouseDown(self.duiObject, button)
 end
 
----@param button 'left' | 'middle' | 'right'
+---@param button "left" | "middle" | "right"
 function xLib.dui:sendMouseUp(button)
 	SendDuiMouseUp(self.duiObject, button)
 end
@@ -106,11 +107,10 @@ function xLib.dui:sendMouseWheel(deltaX, deltaY)
 	SendDuiMouseWheel(self.duiObject, deltaY, deltaX)
 end
 
-
-AddEventHandler('onResourceStop', function(resourceName)
+AddEventHandler("onResourceStop", function(resourceName)
 	if cache.resource ~= resourceName then return end
 
-	for _, dui in pairs(duis) do
+	for _, dui in pairs(Duis) do
 		dui:remove()
 	end
 end)

--- a/[core]/esx_lib/imports/dui/client.lua
+++ b/[core]/esx_lib/imports/dui/client.lua
@@ -24,6 +24,8 @@
 ---@field txtName string
 xLib.dui = xLib.class()
 
+local resource<const> = GetCurrentResourceName()
+
 ---@type table<string, Dui>
 local Duis = {}
 
@@ -32,10 +34,10 @@ local currentId = 0
 ---@param data DuiProperties
 function xLib.dui:constructor(data)
 	local time = GetGameTimer()
-	local id = ("%s_%s_%s"):format(cache.resource, time, currentId)
+	local id = ("%s_%s_%s"):format(resource, time, currentId)
 	currentId = currentId + 1
-	local dictName = ("ox_lib_dui_dict_%s"):format(id)
-	local txtName = ("ox_lib_dui_txt_%s"):format(id)
+	local dictName = ("%s_dui_dict_%s"):format(resource, id)
+	local txtName = ("%s_lib_dui_txt_%s"):format(resource, id)
 	local duiObject = CreateDui(data.url, data.width, data.height)
 	local duiHandle = GetDuiHandle(duiObject)
 	local runtimeTxd = CreateRuntimeTxd(dictName)
@@ -108,11 +110,11 @@ function xLib.dui:sendMouseWheel(deltaX, deltaY)
 end
 
 AddEventHandler("onResourceStop", function(resourceName)
-	if cache.resource ~= resourceName then return end
+	if resource ~= resourceName then return end
 
-	for _, dui in pairs(Duis) do
-		dui:remove()
-	end
+	for id in next, Duis do
+        Duis[id]:remove()
+    end
 end)
 
 return xLib.dui


### PR DESCRIPTION
### Description

Introduces a DUI (Drawing User Interface) class that makes it easy to create and manage in-game web browsers with full mouse interaction support.

---

### Motivation

Using FiveM’s built-in DUI functions can be tedious — you have to manually manage several objects like the DUI handle, texture dictionary, and runtime TXD, and remember to clean them up yourself.
This class wraps all of that into a simple, object-oriented system. It automatically handles creation, cleanup, and provides a clean, intuitive API for everyday tasks like changing URLs, sending messages, and handling mouse input.

---

### Implementation Details
- Added a new `xLib.dui` class that sets up the DUI object, texture dictionary, and runtime TXD automatically
- Added methods for:
   - Managing URLs (`setUrl`)
   - Sending data to the page (`sendMessage`)
   - Handling mouse actions (`sendMouseMove`, `sendMouseDown`, `sendMouseUp`, `sendMouseWheel`)
- Automatically cleans up DUI instances when the resource stops to prevent memory leaks
- Includes optional debug logging for easier development
- Keeps track of all DUI instances in a registry for better lifecycle control
---

### Usage Example

```lua
local myDui = nil
local showDui = false

local DUI_WIDTH<const> = 1920
local DUI_HEIGHT<const> = 1080

RegisterCommand('dui_test', function()
    myDui = xLib.dui:new({
        url = 'http://localhost:40120',
        width = DUI_WIDTH,
        height = DUI_HEIGHT,
        debug = true
    })

    showDui = true
    StartDuiRendering()
end, false)

RegisterCommand('dui_remove', function()
    if myDui then
        myDui:remove()
        myDui = nil
        showDui = false
    end
end, false)

function StartDuiRendering()
    CreateThread(function()
        while showDui and myDui do
            DrawSprite(myDui.dictName, myDui.txtName, 0.5, 0.5, 0.5, 0.5, 0.0, 255, 255, 255, 255)
            Wait(0)
        end
    end)
end
```

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.