### PR TITLE
Fix<esx_identity>: esx_identity:completedRegistration event trigger

### DIFF
--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -296,6 +296,7 @@ ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb,
 
         TriggerClientEvent("esx_identity:setPlayerData", xPlayer.src, currentIdentity)
         saveIdentityToDatabase(identifier, currentIdentity)
+        TriggerEvent("esx_identity:completedRegistration", source, data)
         alreadyRegistered[identifier] = true
         playerIdentity[identifier] = nil
         return cb(true)


### PR DESCRIPTION
Not triggering esx_identity:completedRegistration correctly
### Description

Added esx_identity:completedRegistration inside xPlayer condition.
The original event isn't being triggered if xPlayer exists which renders this event unusable.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Documentation does include this event but doesn't get triggered properly.
Adding this would allow people to make a listener after the registration.

### PR Checklist

-   [✅] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [✅] My changes have been tested locally and function as expected.
-   [✅] My PR does not introduce any breaking changes.
-   [✅] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
