### PR TITLE
Fix(esx_identity/server/main.lua): Added esx_identity:completedRegistration event within if statement xPlayer

### DIFF
--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -296,6 +296,8 @@ ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb,
 
         TriggerClientEvent("esx_identity:setPlayerData", xPlayer.src, currentIdentity)
         saveIdentityToDatabase(identifier, currentIdentity)
+        TriggerEvent("esx_identity:completedRegistration", source, data)
+
         alreadyRegistered[identifier] = true
         playerIdentity[identifier] = nil
         return cb(true)


### PR DESCRIPTION
### Description

This fix ensures that the esx_identity:completedRegistration according to the official documentations gets triggered after a player completed their registration.

---

### Motivation

This would help players to identify if the player has completed their registration and be able to integrate their own scripts to the framework regarding registration.

---

### Implementation Details

Added the event trigger inside the if statement which was not being triggered due to returning early if xPlayer exists.

---

### PR Checklist

-   [✅] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [✅] My changes have been tested locally and function as expected.
-   [✅] My PR does not introduce any breaking changes.
-   [✅] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
