### PR TITLE
Re-enabling the superadmin group

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -272,12 +272,8 @@ function loadESXPlayer(identifier, playerId, isNew)
 
     -- Group
     if result.group then
-        if result.group == "superadmin" then
-            userData.group = "admin"
-            print("[^3WARNING^7] ^5Superadmin^7 detected, setting group to ^5admin^7")
-        else
+       
             userData.group = result.group
-        end
     else
         userData.group = "user"
     end

--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -510,10 +510,6 @@ ESX.RegisterCommand(
         if not args.playerId then
             args.playerId = xPlayer.source
         end
-        if args.group == "superadmin" then
-            args.group = "admin"
-            print("[^3WARNING^7] ^5Superadmin^7 detected, setting group to ^5admin^7")
-        end
         args.playerId.setGroup(args.group)
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "/setgroup Triggered!", "pink", {


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
Restores the ability to setgroup players into the 'superadmin' group.
---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
Gives users the ability to freely use this group again, while restricting it is completely useless.
---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->
Just removed the conditions where the core would force the user back to the original admin group.
---

### PR Checklist

-   [ ✅] My changes have been tested locally and function as expected.
-   [✅ ] My PR does not introduce any breaking changes.
-   [ ✅] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
