### PR TITLE
fix(es_extended): correct SQL insertion logic in ESX.AddItems

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -799,9 +799,21 @@ if not Config.CustomInventory then
         end
 
         if #toInsert > 0 then
-            MySQL.prepare.await(
-            "INSERT IGNORE INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES (?, ?, ?, ?, ?)",
-                toInsert)
+            local parameters = {}
+            for i = 1, #toInsert do
+                parameters[#parameters + 1] = {
+                    toInsert[i].name,
+                    toInsert[i].label,
+                    toInsert[i].weight,
+                    toInsert[i].rare,
+                    toInsert[i].canRemove
+                }
+            end
+
+            MySQL.insert.await(
+                "INSERT IGNORE INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES ?",
+                { parameters }
+            )
 
             for i = 1, #toInsert do
                 local row = toInsert[i]


### PR DESCRIPTION
Fixes a bug where items created with `ESX.AddItems` are not being persisted to the database because the previous oxmysql `prepare.await` implementation was receiving a list of objects instead of properly formatted primitives/arrays for bulk insertion.

Resolves #1768

### Changes
* Replaced the broken `MySQL.prepare.await` insertion with `MySQL.insert.await`, mapping the `toInsert` tables to an array of primitives for standard bulk insertion.