### PR TITLE
fix: mysql.ready called before functions.lua is loaded

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -21,12 +21,13 @@ server_scripts {
 	'@oxmysql/lib/MySQL.lua',
     'shared/config/logs.lua',
 
+	'server/core.lua',
+	'server/functions.lua',
 	'server/common.lua',
 	'server/modules/callback.lua',
 	'server/classes/player.lua',
 	'server/classes/vehicle.lua',
 	'server/classes/overrides/*.lua',
-	'server/functions.lua',
 	'server/modules/onesync.lua',
 	'server/modules/paycheck.lua',
 

--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -1,20 +1,6 @@
 ESX.Players = {}
 ESX.Jobs = {}
 ESX.Items = {}
-Core = {}
-Core.JobsPlayerCount = {}
-Core.UsableItemsCallbacks = {}
-Core.RegisteredCommands = {}
-Core.Pickups = {}
-Core.PickupId = 0
-Core.PlayerFunctionOverrides = {}
-Core.DatabaseConnected = false
-Core.playersByIdentifier = {}
-Core.JobsLoaded = false
-
----@type table<string, CVehicleData>
-Core.vehicles = {}
-Core.vehicleTypesByModel = {}
 
 RegisterNetEvent("esx:onPlayerSpawn", function()
     ESX.Players[source].spawned = true

--- a/[core]/es_extended/server/core.lua
+++ b/[core]/es_extended/server/core.lua
@@ -1,0 +1,14 @@
+Core = {}
+Core.JobsPlayerCount = {}
+Core.UsableItemsCallbacks = {}
+Core.RegisteredCommands = {}
+Core.Pickups = {}
+Core.PickupId = 0
+Core.PlayerFunctionOverrides = {}
+Core.DatabaseConnected = false
+Core.playersByIdentifier = {}
+Core.JobsLoaded = false
+
+---@type table<string, CVehicleData>
+Core.vehicles = {}
+Core.vehicleTypesByModel = {}


### PR DESCRIPTION
### Description

The code inside `common.lua` is awaiting mysql to be ready. When its ready it is executing RefreshJobs. This function is loaded from inside functions.lua which is below the common.lua inside the manifest. This change fixes the load order and makes sure RefreshJobs is always loaded before common.lua is executed.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
