### PR TITLE
fix(nui): reset styled text with ~s~

### DIFF
--- a/[core]/esx_notify/nui/js/script.js
+++ b/[core]/esx_notify/nui/js/script.js
@@ -115,16 +115,6 @@ const notification = (data) => {
 		return;
 	}
 
-	if (data.message) {
-		// Remove any standalone ~s~ tags (not preceded by a color code)
-		data.message = data.message.replace(/~s~/g, "");
-	}
-
-	if (data.title) {
-		// Remove any standalone ~s~ tags (not preceded by a color code)
-		data.title = data.title.replace(/~s~/g, "");
-	}
-
 	let sanitizedTitle = data.title ? sanitizeHTML(data.title) : "";
 	let sanitizedMessage = data.message ? sanitizeHTML(data.message) : "";
 
@@ -137,6 +127,7 @@ const notification = (data) => {
 				sanitizedTitle = replaceColors(sanitizedTitle, objArr);
 			}
 		}
+		sanitizedTitle = sanitizedTitle.replace(/~s~/g, "");
 	}
 
 	for (const color in codes) {
@@ -147,6 +138,7 @@ const notification = (data) => {
 			sanitizedMessage = replaceColors(sanitizedMessage, objArr);
 		}
 	}
+	sanitizedMessage = sanitizedMessage.replace(/~s~/g, "");
 
 	sanitizedMessage = processLineBreaks(sanitizedMessage);
 	sanitizedTitle = processLineBreaks(sanitizedTitle);


### PR DESCRIPTION
### Description
Fix `~s~` so it closes colored text in NUI notifications (it was removed before parsing, so colors never reset).

---

### Motivation
Strings like `~b~$500~s~` should match GTA/ESX markup. They stayed the wrong color because `~s~` was stripped too early.

---

### Implementation Details
Stop stripping `~s~` before the color pass. Strip any leftover `~s~` only after replaceColors runs on title and message.

---

### Usage Example

```lua
ESX.ShowNotification('Paid ~b~$500~s~ deposit.', 'info', 5000)
```

Before:
<img width="437" height="131" alt="image" src="https://github.com/user-attachments/assets/01e5876d-55a4-4e3b-9c8d-28aae0e021a2" />


After:
<img width="435" height="141" alt="image" src="https://github.com/user-attachments/assets/77546e33-1f1e-4071-bc2b-c510761c51bd" />


---

### PR Checklist
-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
