### PR TITLE
fix SQL parameter passing in setProps to save complex modifications

### DIFF
--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -167,7 +167,7 @@ Core.vehicleClass = {
 		assert(type(newProps) == "table", "Expected 'props' to be a table")
 
 		local vehicleData = Core.vehicles[self.plate]
-		local affectedRows = MySQL.update.await("UPDATE owned_vehicles SET vehicle = ? WHERE plate = ? AND owner = ?",{ json.encode(newProps), vehicleData.plate, vehicleData.owner })
+		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", { json.encode(newProps), vehicleData.plate, vehicleData.owner })
 		if affectedRows <= 0 then
 			self:delete()
 			return false

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -167,7 +167,7 @@ Core.vehicleClass = {
 		assert(type(newProps) == "table", "Expected 'props' to be a table")
 
 		local vehicleData = Core.vehicles[self.plate]
-		local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(newProps), vehicleData.plate, vehicleData.owner)
+		local affectedRows = MySQL.update.await("UPDATE owned_vehicles SET vehicle = ? WHERE plate = ? AND owner = ?",{ json.encode(newProps), vehicleData.plate, vehicleData.owner })
 		if affectedRows <= 0 then
 			self:delete()
 			return false


### PR DESCRIPTION
### Description
改进了sql语句 使其更难出现问题
---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
使用复杂改装时常常无法保存我的改装 一路排查到这 为避免后续的人们遇到问题 所以我决定贡献
---

### Implementation Details
MySQL.update.await 期望第二个参数是一个数组
但 setProps() 方法将它们作为单独的参数传递，导致 UPDATE 查询静默失败 在第170行给参数加上大括号就能解决
---

### Usage Example

```lua
原来:
local affectedRows = MySQL.update.await("UPDATE `owned_vehicles` SET `vehicle` = ? WHERE `plate` = ? AND `owner` = ?", json.encode(newProps), vehicleData.plate, vehicleData.owner)
现在:
local affectedRows = MySQL.update.await("UPDATE owned_vehicles SET vehicle = ? WHERE plate = ? AND owner = ?",{ json.encode(newProps), vehicleData.plate, vehicleData.owner })
```

---

### PR Checklist

-   [ y] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ y] My changes have been tested locally and function as expected.
-   [ y] My PR does not introduce any breaking changes.
-   [ y] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
