### PR TITLE
fix: refactor robustness fixes across core modules

### DIFF
--- a/[core]/cron/server/main.lua
+++ b/[core]/cron/server/main.lua
@@ -38,7 +38,11 @@ function OnTime(timestamp)
 
         if timestamp >= scheduledTimestamp and (not lastTimestamp or lastTimestamp < scheduledTimestamp) then
             local d = os.date('*t', scheduledTimestamp).wday
-            cronJobs[i].cb(d, cronJobs[i].h, cronJobs[i].m)
+            -- Fix: wrap the callback in pcall so one failing job does not interrupt the remaining ones.
+            local ok, err = pcall(cronJobs[i].cb, d, cronJobs[i].h, cronJobs[i].m)
+            if not ok then
+                print(("[^1ERROR^7] cron job (%02d:%02d) raised an error: %s"):format(cronJobs[i].h, cronJobs[i].m, tostring(err)))
+            end
         end
     end
 end

--- a/[core]/es_extended/client/modules/actions.lua
+++ b/[core]/es_extended/client/modules/actions.lua
@@ -226,6 +226,13 @@ function Actions:PedLoop()
 end
 
 function Actions:Init()
+    -- Fix: guard against the double Init() (module load + esx:playerLoaded) that spawned
+    -- a redundant TrackPedCoordsOnce thread and duplicate loops. Init is now idempotent.
+    if self.initialized then
+        return
+    end
+    self.initialized = true
+
     self:SlowLoop()
     self:PedLoop()
     self:TrackPedCoordsOnce()

--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -130,6 +130,11 @@ AddStateBagChangeHandler("VehicleProperties", nil, function(bagName, _, value)
         return
     end
 
+    -- Fix: validate the state bag payload type before use to avoid acting on malformed data
+    if type(value) ~= "table" then
+        return
+    end
+
     bagName = bagName:gsub("entity:", "")
     local netId = tonumber(bagName)
     if not netId then
@@ -371,10 +376,13 @@ if not Config.CustomInventory then
     CreateThread(function()
         while true do
             local Sleep = 1500
-            local playerCoords = GetEntityCoords(ESX.PlayerData.ped)
-            local _, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
 
-            for pickupId, pickup in pairs(pickups) do
+            -- Fix: skip the per-tick work (incl. GetClosestPlayer) when there are no active pickups
+            if next(pickups) then
+                local playerCoords = GetEntityCoords(ESX.PlayerData.ped)
+                local _, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
+
+                for pickupId, pickup in pairs(pickups) do
                 local distance = #(playerCoords - pickup.coords)
 
                 if distance < 5 then
@@ -404,6 +412,7 @@ if not Config.CustomInventory then
                     ESX.Game.Utils.DrawText3D(textCoords, label, 1.2, 1)
                 elseif pickup.inRange then
                     pickup.inRange = false
+                end
                 end
             end
             Wait(Sleep)
@@ -662,6 +671,10 @@ end)
 RegisterNetEvent("esx:repairPedVehicle", function()
     local ped = ESX.PlayerData.ped
     local vehicle = GetVehiclePedIsIn(ped, false)
+    -- Fix: only act when the player is actually in a vehicle (defensive guard)
+    if not vehicle or vehicle == 0 then
+        return
+    end
     SetVehicleEngineHealth(vehicle, 1000)
     SetVehicleEngineOn(vehicle, true, true, false)
     SetVehicleFixed(vehicle)
@@ -669,6 +682,10 @@ RegisterNetEvent("esx:repairPedVehicle", function()
 end)
 
 RegisterNetEvent("esx:freezePlayer", function(input)
+    -- Fix: validate argument type for this server->client event
+    if type(input) ~= "string" then
+        return
+    end
     if input == "freeze" then
         SetEntityCollision(ESX.PlayerData.ped, false, false)
         FreezeEntityPosition(ESX.PlayerData.ped, true)
@@ -690,6 +707,10 @@ end)
 
 ---@param command string
 ESX.SecureNetEvent("esx:executeCommand", function(command)
+    -- Fix: only execute when the argument is a non-empty string (defensive validation)
+    if type(command) ~= "string" or command == "" then
+        return
+    end
     ExecuteCommand(command)
 end)
 

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -307,7 +307,8 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
 
             if account then
                 money = account.round and ESX.Math.Round(money) or money
-                if self.accounts[account.index].money - money > self.accounts[account.index].money then
+                -- Fix: previous guard `balance - money > balance` was always false for money > 0, allowing negative balances. Refuse withdrawals when funds are insufficient.
+                if money > self.accounts[account.index].money then
                     error(("Tried To Underflow Account ^5%s^1 For Player ^5%s^1!"):format(accountName, self.playerId))
                     return
                 end
@@ -335,7 +336,9 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
     function self.addInventoryItem(itemName, count)
         local item = self.getInventoryItem(itemName)
 
-        if item then
+        -- Fix: validate count is a positive number before mutating inventory/weight
+        count = tonumber(count)
+        if item and count and count > 0 then
             count = ESX.Math.Round(count)
             item.count = item.count + count
             self.weight = self.weight + (item.weight * count)
@@ -369,7 +372,9 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
     function self.setInventoryItem(itemName, count)
         local item = self.getInventoryItem(itemName)
 
-        if item and count >= 0 then
+        -- Fix: coerce count to a number and reject negative/invalid values
+        count = tonumber(count)
+        if item and count and count >= 0 then
             count = ESX.Math.Round(count)
 
             if count > item.count then
@@ -426,6 +431,11 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
     end
 
     function self.setMaxWeight(newWeight)
+        -- Fix: validate newWeight is a non-negative number before applying
+        newWeight = tonumber(newWeight)
+        if not newWeight or newWeight < 0 then
+            return print(("[ESX] [^3WARNING^7] Ignoring invalid ^5.setMaxWeight()^7 usage for ID: ^5%s^7, Weight: ^5%s^7"):format(self.source, tostring(newWeight)))
+        end
         self.maxWeight = newWeight
         self.triggerEvent("esx:setMaxWeight", self.maxWeight)
     end

--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -192,8 +192,9 @@ Core.vehicleClass = {
 		end
 
 		local entity = NetworkGetEntityFromNetworkId(vehicleData.netId)
-		if entity >= 0 and Entity(entity).state.owner == vehicleData.owner then
-			DeleteEntity(vehicleData.entity)
+		-- Fix: `entity >= 0` accepts 0 (no entity); require the entity to actually exist and be a vehicle before deleting, and delete the resolved entity.
+		if entity and entity > 0 and DoesEntityExist(entity) and GetEntityType(entity) == 2 and Entity(entity).state.owner == vehicleData.owner then
+			DeleteEntity(entity)
 		end
 
 		local query = "UPDATE `owned_vehicles` SET `stored` = true WHERE `plate` = ? AND `owner` = ?"

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -247,7 +247,8 @@ function Core.SavePlayers(cb)
         return
     end
 
-    local startTime <const> = os.time()
+    -- Fix: use GetGameTimer() (millisecond resolution) instead of os.time() (seconds), which made the duration log always read ~0.00
+    local startTime <const> = GetGameTimer()
     local parameters = {}
 
     for _, xPlayer in pairs(ESX.Players) do
@@ -278,7 +279,7 @@ function Core.SavePlayers(cb)
             end
 
             print(("[^2INFO^7] Saved ^5%s^7 %s over ^5%s^7 ms"):format(#parameters,
-                #parameters > 1 and "players" or "player", ESX.Math.Round((os.time() - startTime) / 1000000, 2)))
+                #parameters > 1 and "players" or "player", ESX.Math.Round(GetGameTimer() - startTime, 2)))
         end
     )
 end
@@ -560,11 +561,12 @@ function ESX.RefreshJobs()
         end
     end
 
-    if not Jobs then
-        -- Fallback data, if no jobs exist
+    ESX.Jobs = Jobs
+
+    -- Fix: `Jobs` is always a table, so the previous `if not Jobs` fallback was unreachable; ensure an 'unemployed' job always exists (player loading depends on it) when missing or invalid.
+    if not ESX.Jobs["unemployed"] then
+        print('[^3WARNING^7] No valid ^5"unemployed"^0 job found, inserting default fallback')
         ESX.Jobs["unemployed"] = { name = "unemployed", label = "Unemployed", type = "civ", whitelisted = false, grades = { ["0"] = { grade = 0, name = "unemployed", label = "Unemployed", salary = 200, skin_male = {}, skin_female = {} } } }
-    else
-        ESX.Jobs = Jobs
     end
 
     TriggerEvent("esx:jobsRefreshed")

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -738,14 +738,14 @@ ESX.RegisterServerCallback("esx:getOtherPlayerData", function(source, cb, target
         return
     end
 
-    -- Fix: server-side proximity guard to block mass remote exfiltration of other players' data (IDOR).
-    -- The target is client-controlled, so verify source and target peds are valid and close (~10.0 units) before disclosing data.
+    -- Only disclose another player's data when the requester is near the target; the target id is not trusted.
+    -- Range is bounded by Config.DistanceGetOtherPlayerData (default 10.0); out of range returns nil.
     local sourcePed = GetPlayerPed(source)
     local targetPed = GetPlayerPed(target)
     if sourcePed == 0 or targetPed == 0 then
         return cb(nil)
     end
-    if #(GetEntityCoords(sourcePed) - GetEntityCoords(targetPed)) > 10.0 then
+    if #(GetEntityCoords(sourcePed) - GetEntityCoords(targetPed)) > (Config.DistanceGetOtherPlayerData or 10.0) then
         return cb(nil)
     end
 

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -423,8 +423,16 @@ if not Config.CustomInventory then
     RegisterNetEvent("esx:updateWeaponAmmo", function(weaponName, ammoCount)
         local xPlayer = ESX.GetPlayerFromId(source)
 
-        if xPlayer then
-            xPlayer.updateWeaponAmmo(weaponName, ammoCount)
+        -- Fix: validate and clamp client-supplied ammo before persisting (>= 0 and within a sane bound).
+        ammoCount = tonumber(ammoCount)
+        if ammoCount then
+            ammoCount = math.floor(ammoCount)
+            if ammoCount < 0 then ammoCount = 0 end
+            if ammoCount > 9999 then ammoCount = 9999 end
+
+            if xPlayer then
+                xPlayer.updateWeaponAmmo(weaponName, ammoCount)
+            end
         end
     end)
 
@@ -459,7 +467,13 @@ if not Config.CustomInventory then
             sourceXPlayer.showNotification(TranslateCap("gave_item", itemCount, sourceItem.label, targetXPlayer.name))
             targetXPlayer.showNotification(TranslateCap("received_item", itemCount, sourceItem.label, sourceXPlayer.name))
         elseif itemType == "item_account" then
-            if itemCount < 1 or sourceXPlayer.getAccount(itemName).money < itemCount then
+            -- Fix: nil-guard the account name and verify the account actually exists for the player before dereferencing (itemName is client-controlled).
+            local sourceAccount = itemName and sourceXPlayer.getAccount(itemName)
+            if not sourceAccount or not Config.Accounts[itemName] then
+                return
+            end
+
+            if itemCount < 1 or sourceAccount.money < itemCount then
                 return sourceXPlayer.showNotification(TranslateCap("imp_invalid_amount"))
             end
 
@@ -623,9 +637,13 @@ if not Config.CustomInventory then
             return
         end
 
-        local count = xPlayer.getInventoryItem(itemName).count
+        -- Fix: nil-guard the inventory item before dereferencing .count (itemName is client-controlled).
+        local item = xPlayer.getInventoryItem(itemName)
+        if not item then
+            return
+        end
 
-        if count < 1 then
+        if item.count < 1 then
             return xPlayer.showNotification(TranslateCap("act_imp"))
         end
 
@@ -705,11 +723,22 @@ ESX.RegisterServerCallback("esx:getGameBuild", function(_, cb)
     cb(tonumber(GetConvar("sv_enforceGameBuild", "1604")))
 end)
 
-ESX.RegisterServerCallback("esx:getOtherPlayerData", function(_, cb, target)
+ESX.RegisterServerCallback("esx:getOtherPlayerData", function(source, cb, target)
     local xPlayer = ESX.GetPlayerFromId(target)
 
     if not xPlayer then
         return
+    end
+
+    -- Fix: server-side proximity guard to block mass remote exfiltration of other players' data (IDOR).
+    -- The target is client-controlled, so verify source and target peds are valid and close (~10.0 units) before disclosing data.
+    local sourcePed = GetPlayerPed(source)
+    local targetPed = GetPlayerPed(target)
+    if sourcePed == 0 or targetPed == 0 then
+        return cb(nil)
+    end
+    if #(GetEntityCoords(sourcePed) - GetEntityCoords(targetPed)) > 10.0 then
+        return cb(nil)
     end
 
     cb({
@@ -741,8 +770,24 @@ ESX.RegisterServerCallback("esx:getPlayerNames", function(source, cb, players)
 end)
 
 ESX.RegisterServerCallback("esx:spawnVehicle", function(source, cb, vehData)
+    -- Fix: defensive validation of client-supplied arguments (no permission gate, to avoid breaking legitimate resource usage).
+    vehData = type(vehData) == "table" and vehData or {}
     local ped = GetPlayerPed(source)
-    ESX.OneSync.SpawnVehicle(vehData.model or `ADDER`, vehData.coords or GetEntityCoords(ped), vehData.coords.w or 0.0, vehData.props or {}, function(id)
+
+    local model = vehData.model
+    if type(model) ~= "string" and type(model) ~= "number" then
+        model = `ADDER`
+    end
+
+    local coords = vehData.coords
+    if type(coords) ~= "table" and type(coords) ~= "vector3" and type(coords) ~= "vector4" then
+        coords = GetEntityCoords(ped)
+    end
+
+    local heading = tonumber(coords.w) or 0.0
+    local props = type(vehData.props) == "table" and vehData.props or {}
+
+    ESX.OneSync.SpawnVehicle(model, coords, heading, props, function(id)
         if vehData.warp then
             local vehicle = NetworkGetEntityFromNetworkId(id)
             local timeout = 0

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -446,6 +446,14 @@ if not Config.CustomInventory then
             return
         end
 
+        if itemType ~= "item_weapon" then
+            itemCount = tonumber(itemCount)
+            if not itemCount or itemCount < 1 then
+                return sourceXPlayer.showNotification(TranslateCap("imp_invalid_quantity"))
+            end
+            itemCount = math.floor(itemCount)
+        end
+
         if itemType == "item_standard" then
             local sourceItem = sourceXPlayer.getInventoryItem(itemName)
 

--- a/[core]/es_extended/server/modules/paycheck.lua
+++ b/[core]/es_extended/server/modules/paycheck.lua
@@ -2,32 +2,40 @@ function StartPayCheck()
     CreateThread(function()
         while true do
             Wait(Config.PaycheckInterval)
+
+            -- Fix: hoist constant config/translation lookups out of the per-player loop to avoid redundant work/allocation each interval.
+            local logPaycheck = Config.LogPaycheck
+            local enableSocietyPayouts = Config.EnableSocietyPayouts
+            local offDutyMultiplier = Config.OffDutyPaycheckMultiplier
+            local bankTitle = TranslateCap("bank")
+            local receivedPaycheck = TranslateCap("received_paycheck")
+
             for player, xPlayer in pairs(ESX.Players) do
                 local jobLabel = xPlayer.job.label
                 local job = xPlayer.job.grade_name
                 local onDuty = xPlayer.job.onDuty
-                local salary = (job == "unemployed" or onDuty) and xPlayer.job.grade_salary or ESX.Math.Round(xPlayer.job.grade_salary * Config.OffDutyPaycheckMultiplier)
+                local salary = (job == "unemployed" or onDuty) and xPlayer.job.grade_salary or ESX.Math.Round(xPlayer.job.grade_salary * offDutyMultiplier)
 
                 if xPlayer.paycheckEnabled then
                     if salary > 0 then
                         if job == "unemployed" then -- unemployed
                             xPlayer.addAccountMoney("bank", salary, "Welfare Check")
-                            TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)
-                            if Config.LogPaycheck then
+                            TriggerClientEvent("esx:showAdvancedNotification", player, bankTitle, receivedPaycheck, TranslateCap("received_help", salary), "CHAR_BANK_MAZE", 9)
+                            if logPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Unemployment Benefits", "green", {
                                     { name = "Player", value = xPlayer.name, inline = true },
                                     { name = "ID", value = xPlayer.source, inline = true },
                                     { name = "Amount", value = salary, inline = true },
                                 })
                             end
-                        elseif Config.EnableSocietyPayouts then -- possibly a society
+                        elseif enableSocietyPayouts then -- possibly a society
                             TriggerEvent("esx_society:getSociety", xPlayer.job.name, function(society)
                                 if society ~= nil then -- verified society
                                     TriggerEvent("esx_addonaccount:getSharedAccount", society.account, function(account)
                                         if account.money >= salary then -- does the society money to pay its employees?
                                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
                                             account.removeMoney(salary)
-                                            if Config.LogPaycheck then
+                                            if logPaycheck then
                                                 ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
                                                     { name = "Player", value = xPlayer.name, inline = true },
                                                     { name = "ID", value = xPlayer.source, inline = true },
@@ -35,33 +43,33 @@ function StartPayCheck()
                                                 })
                                             end
 
-                                            TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
+                                            TriggerClientEvent("esx:showAdvancedNotification", player, bankTitle, receivedPaycheck, TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
                                         else
-                                            TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), "", TranslateCap("company_nomoney"), "CHAR_BANK_MAZE", 1)
+                                            TriggerClientEvent("esx:showAdvancedNotification", player, bankTitle, "", TranslateCap("company_nomoney"), "CHAR_BANK_MAZE", 1)
                                         end
                                     end)
                                 else -- not a society
                                     xPlayer.addAccountMoney("bank", salary, "Paycheck")
-                                    if Config.LogPaycheck then
+                                    if logPaycheck then
                                         ESX.DiscordLogFields("Paycheck", "Paycheck - " .. jobLabel, "green", {
                                             { name = "Player", value = xPlayer.name, inline = true },
                                             { name = "ID", value = xPlayer.source, inline = true },
                                             { name = "Amount", value = salary, inline = true },
                                         })
                                     end
-                                    TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
+                                    TriggerClientEvent("esx:showAdvancedNotification", player, bankTitle, receivedPaycheck, TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
                                 end
                             end)
                         else -- generic job
                             xPlayer.addAccountMoney("bank", salary, "Paycheck")
-                            if Config.LogPaycheck then
+                            if logPaycheck then
                                 ESX.DiscordLogFields("Paycheck", "Paycheck - Generic", "green", {
                                     { name = "Player", value = xPlayer.name, inline = true },
                                     { name = "ID", value = xPlayer.source, inline = true },
                                     { name = "Amount", value = salary, inline = true },
                                 })
                             end
-                            TriggerClientEvent("esx:showAdvancedNotification", player, TranslateCap("bank"), TranslateCap("received_paycheck"), TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
+                            TriggerClientEvent("esx:showAdvancedNotification", player, bankTitle, receivedPaycheck, TranslateCap("received_salary", salary), "CHAR_BANK_MAZE", 9)
                         end
                     end
                 end

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -61,6 +61,7 @@ Config.OffDutyPaycheckMultiplier = 0.5 -- The multiplier for off duty paychecks.
 Config.Multichar = GetResourceState("esx_multicharacter") ~= "missing"
 Config.Identity = true      -- Select a character identity data before they have loaded in (this happens by default with multichar)
 Config.DistanceGive = 4.0   -- Max distance when giving items, weapons etc.
+Config.DistanceGetOtherPlayerData = 10.0 -- Max distance (units) a player must be within to read another player's data
 
 Config.AdminLogging = false -- Logs the usage of certain commands by those with group.admin ace permissions (default is false)
 

--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -10,6 +10,10 @@ for i = 97, 122 do
     table.insert(Charset, string.char(i))
 end
 
+-- Fix: seed the PRNG once at module load instead of on every call/character,
+-- which produced poorly-randomized output (reseeding with GetGameTimer() reset the sequence).
+math.randomseed(GetGameTimer())
+
 local weaponsByName = {}
 local weaponsByHash = {}
 
@@ -23,8 +27,7 @@ end)
 ---@param length number
 ---@return string
 function ESX.GetRandomString(length)
-    math.randomseed(GetGameTimer())
-
+    -- Fix: removed per-call/per-character math.randomseed; the PRNG is now seeded once at module load
     return length > 0 and ESX.GetRandomString(length - 1) .. Charset[math.random(1, #Charset)] or ""
 end
 

--- a/[core]/es_extended/shared/modules/math.lua
+++ b/[core]/es_extended/shared/modules/math.lua
@@ -1,5 +1,9 @@
 ESX.Math = {}
 
+-- Fix: seed the PRNG once at module load instead of on every ESX.Math.Random call,
+-- which reset the sequence and produced poorly-randomized output.
+math.randomseed(GetGameTimer())
+
 ---@param value number
 ---@param numDecimalPlaces? number
 ---@return number
@@ -32,7 +36,7 @@ end
 ---@param maxRange number
 ---@return number
 function ESX.Math.Random(minRange, maxRange)
-    math.randomseed(GetGameTimer())
+    -- Fix: removed per-call math.randomseed; the PRNG is now seeded once at module load
     return math.random(minRange or 1, maxRange or 10)
 end
 

--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -254,6 +254,11 @@ end
 ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb, data)
     local xPlayer = ESX.Player(source)
 
+    -- Fix: data comes from the client; guard its type before indexing fields.
+    if type(data) ~= "table" then
+        return cb(false)
+    end
+
     if not checkNameFormat(data.firstname) then
         TriggerClientEvent("esx:showNotification", source, TranslateCap("invalid_firstname_format"), "error")
         return cb(false)
@@ -286,7 +291,8 @@ ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb,
             firstName = formatName(data.firstname),
             lastName = formatName(data.lastname),
             dateOfBirth = formatDate(data.dateofbirth),
-            sex = data.sex,
+            -- Fix: normalise case and restrict to 'm'/'f' so downstream comparisons stay consistent.
+            sex = string.lower(data.sex) == "f" and "f" or "m",
             height = data.height,
         }
 
@@ -310,14 +316,18 @@ ESX.RegisterServerCallback("esx_identity:registerIdentity", function(source, cb,
     local formattedLastName = formatName(data.lastname)
     local formattedDate = formatDate(data.dateofbirth)
 
+    -- Fix: normalise sex to 'm'/'f' (same as the single-character path) before it is persisted.
+    local normalizedSex = string.lower(data.sex) == "f" and "f" or "m"
+
     data.firstname = formattedFirstName
     data.lastname = formattedLastName
     data.dateofbirth = formattedDate
+    data.sex = normalizedSex
     local Identity = {
         firstName = formattedFirstName,
         lastName = formattedLastName,
         dateOfBirth = formattedDate,
-        sex = data.sex,
+        sex = normalizedSex,
         height = data.height,
     }
 

--- a/[core]/esx_multicharacter/server/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/server/modules/multicharacter.lua
@@ -3,6 +3,8 @@
 Multicharacter = {}
 Multicharacter._index = Multicharacter
 Multicharacter.awaitingRegistration = {}
+Multicharacter.ownedSlots = {}
+Multicharacter.selecting = {}
 
 function Multicharacter:SetupCharacters(source)
     SetPlayerRoutingBucket(source, source)
@@ -12,6 +14,9 @@ function Multicharacter:SetupCharacters(source)
 
     local identifier = ESX.GetIdentifier(source)
     ESX.Players[identifier] = source
+
+    self.selecting[source] = nil
+    self.ownedSlots[source] = {}
 
     local slots = Database:GetPlayerSlots(identifier)
     identifier = Server.prefix .. "%:" .. identifier
@@ -40,6 +45,7 @@ function Multicharacter:SetupCharacters(source)
             local idString = string.sub(v.identifier, #Server.prefix + 1, string.find(v.identifier, ":") - 1)
             local id = tonumber(idString)
             if id then
+                self.ownedSlots[source][id] = { disabled = v.disabled == 1 or v.disabled == true }
                 characters[id] = {
                     id = id,
                     bank = accounts.bank,
@@ -68,33 +74,32 @@ function Multicharacter:CharacterChosen(source, charid, isNew)
     if isNew then
         self.awaitingRegistration[source] = charid
     else
+        if self.selecting[source] then
+            return
+        end
+
+        local ownedSlots = self.ownedSlots[source]
+        local slot = ownedSlots and ownedSlots[charid]
+        if not slot or slot.disabled then
+            return
+        end
+
+        local token = {}
+        self.selecting[source] = token
+
+        SetTimeout(30000, function()
+            if self.selecting[source] == token then
+                self.selecting[source] = nil
+            end
+        end)
+
         local license = ESX.GetIdentifier(source)
-
-        -- Fix (IDOR): the chosen charid comes from the client. Validate it is within the player's
-        -- own slot count and that the matching character actually exists for this license and is
-        -- not disabled, before loading it. Without this a client could load an arbitrary slot or a
-        -- character disabled via `disablechar`.
-        local slots = Database:GetPlayerSlots(("%s%%:%s"):format(Server.prefix, license))
-        if charid < 1 or charid > slots then
-            return
-        end
-
         local fullIdentifier = ("%s%s:%s"):format(Server.prefix, charid, license)
-        local character = MySQL.single.await("SELECT `disabled` FROM `users` WHERE `identifier` = ?", { fullIdentifier })
-        if not character then
-            return
-        end
-
-        if character.disabled == 1 or character.disabled == true then
-            return
-        end
 
         SetPlayerRoutingBucket(source, 0)
         if not ESX.GetConfig().EnableDebug then
-            local identifier = fullIdentifier
-
-            if ESX.GetPlayerFromIdentifier(identifier) then
-                DropPlayer(source, "[ESX Multicharacter] Your identifier " .. identifier .. " is already on the server!")
+            if ESX.GetPlayerFromIdentifier(fullIdentifier) then
+                DropPlayer(source, "[ESX Multicharacter] Your identifier " .. fullIdentifier .. " is already on the server!")
                 return
             end
         end
@@ -102,6 +107,8 @@ function Multicharacter:CharacterChosen(source, charid, isNew)
         local charIdentifier = ("%s%s"):format(Server.prefix, charid)
         TriggerEvent("esx:onPlayerJoined", source, charIdentifier)
         ESX.Players[ESX.GetIdentifier(source)] = charIdentifier
+
+        self.selecting[source] = nil
     end
 end
 
@@ -117,5 +124,7 @@ end
 
 function Multicharacter:PlayerDropped(player)
     self.awaitingRegistration[player] = nil
+    self.ownedSlots[player] = nil
+    self.selecting[player] = nil
     ESX.Players[ESX.GetIdentifier(player)] = nil
 end

--- a/[core]/esx_multicharacter/server/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/server/modules/multicharacter.lua
@@ -68,9 +68,30 @@ function Multicharacter:CharacterChosen(source, charid, isNew)
     if isNew then
         self.awaitingRegistration[source] = charid
     else
+        local license = ESX.GetIdentifier(source)
+
+        -- Fix (IDOR): the chosen charid comes from the client. Validate it is within the player's
+        -- own slot count and that the matching character actually exists for this license and is
+        -- not disabled, before loading it. Without this a client could load an arbitrary slot or a
+        -- character disabled via `disablechar`.
+        local slots = Database:GetPlayerSlots(("%s%%:%s"):format(Server.prefix, license))
+        if charid < 1 or charid > slots then
+            return
+        end
+
+        local fullIdentifier = ("%s%s:%s"):format(Server.prefix, charid, license)
+        local character = MySQL.single.await("SELECT `disabled` FROM `users` WHERE `identifier` = ?", { fullIdentifier })
+        if not character then
+            return
+        end
+
+        if character.disabled == 1 or character.disabled == true then
+            return
+        end
+
         SetPlayerRoutingBucket(source, 0)
         if not ESX.GetConfig().EnableDebug then
-            local identifier = ("%s%s:%s"):format(Server.prefix, charid, ESX.GetIdentifier(source))
+            local identifier = fullIdentifier
 
             if ESX.GetPlayerFromIdentifier(identifier) then
                 DropPlayer(source, "[ESX Multicharacter] Your identifier " .. identifier .. " is already on the server!")

--- a/[core]/esx_notify/Notify.lua
+++ b/[core]/esx_notify/Notify.lua
@@ -20,7 +20,7 @@ local function Notify(notificatonType, length, message, title, position)
     if Debug then
         print("1 ".. tostring(notificatonType))
         print("2 "..tostring(length))
-        print("3 "..message)
+        print("3 "..tostring(message)) -- Fix: guard nil/non-string message to avoid a concat error.
         print("4 "..tostring(title))
         print("5 "..tostring(position))
     end
@@ -40,7 +40,7 @@ local function Notify(notificatonType, length, message, title, position)
     if Debug then
         print("6 ".. tostring(notificatonType))
         print("7 "..tostring(length))
-        print("8 "..message)
+        print("8 "..tostring(message)) -- Fix: guard nil/non-string message to avoid a concat error.
         print("9 "..tostring(title))
         print("10 "..tostring(position))
     end

--- a/[core]/esx_skin/server/main.lua
+++ b/[core]/esx_skin/server/main.lua
@@ -1,3 +1,12 @@
+-- Fix: precompute the highest configured backpack modifier so client-supplied bags_1 can never
+-- raise the player's max weight beyond what the server config actually permits.
+local MaxBackpackModifier = 0
+for _, modifier in pairs(Config.BackpackWeight) do
+    if type(modifier) == "number" and modifier > MaxBackpackModifier then
+        MaxBackpackModifier = modifier
+    end
+end
+
 RegisterNetEvent("esx_skin:save", function(skin)
     if not skin or type(skin) ~= "table" then
         return
@@ -6,10 +15,13 @@ RegisterNetEvent("esx_skin:save", function(skin)
 
     if not ESX.GetConfig().CustomInventory then
         local defaultMaxWeight = ESX.GetConfig().MaxWeight
-        local backpackModifier = Config.BackpackWeight[skin.bags_1]
+        -- Fix: the skin (and bags_1) come from the client; only accept a numeric key that maps to a
+        -- configured backpack and bound the modifier to the highest configured value so a crafted
+        -- value can never inflate the player's max weight beyond what the config allows.
+        local backpackModifier = type(skin.bags_1) == "number" and Config.BackpackWeight[skin.bags_1] or nil
 
         if backpackModifier then
-            xPlayer.setMaxWeight(defaultMaxWeight + backpackModifier)
+            xPlayer.setMaxWeight(defaultMaxWeight + math.min(backpackModifier, MaxBackpackModifier))
         else
             xPlayer.setMaxWeight(defaultMaxWeight)
         end
@@ -22,14 +34,21 @@ RegisterNetEvent("esx_skin:save", function(skin)
 end)
 
 RegisterNetEvent("esx_skin:setWeight", function(skin)
+    -- Fix: guard against a missing/invalid skin payload (this handler lacked the type check the
+    -- save handler already has) before indexing it.
+    if type(skin) ~= "table" then
+        return
+    end
     local xPlayer = ESX.Player(source)
 
     if not ESX.GetConfig().CustomInventory then
         local defaultMaxWeight = ESX.GetConfig().MaxWeight
-        local backpackModifier = Config.BackpackWeight[skin.bags_1]
+        -- Fix: do not trust the client bags_1 value for max weight; require a numeric key and bound
+        -- the resulting modifier to the highest configured backpack value.
+        local backpackModifier = type(skin.bags_1) == "number" and Config.BackpackWeight[skin.bags_1] or nil
 
         if backpackModifier then
-            xPlayer.setMaxWeight(defaultMaxWeight + backpackModifier)
+            xPlayer.setMaxWeight(defaultMaxWeight + math.min(backpackModifier, MaxBackpackModifier))
         else
             xPlayer.setMaxWeight(defaultMaxWeight)
         end

--- a/[core]/esx_textui/nui/js/script.js
+++ b/[core]/esx_textui/nui/js/script.js
@@ -69,7 +69,16 @@ const replaceColors = (str, obj) => {
     return strToReplace;
 };
 
+// Fix: escape HTML special chars so player-supplied text cannot inject markup/scripts.
+// The color codes (~r~ ... ~s~) are applied AFTER escaping, so intentional color
+// formatting still renders while raw HTML in the message is neutralised.
+const escapeHtml = (str) =>
+    String(str).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
 notification = (data) => {
+    // Fix: neutralise any HTML in the message before color codes are turned into <span> markup.
+    data["message"] = escapeHtml(data["message"]);
+
     for (color in codes) {
         if (data["message"].includes(color)) {
             let objArr = {};


### PR DESCRIPTION
## What

A batch of **security and robustness fixes** found during an audit of `esx_core` 1.13.5 (still present on `main`). Each change carries an inline `-- Fix:` / `// Fix:` comment. All changes are intentionally **minimal and aim to be non-breaking**; debatable design changes were deliberately left out (see *Not changed* below).

This is a broad PR touching several modules — happy to **split it into per-module PRs** if you prefer to cherry-pick.

## Security

- **`es_extended` — `esx:getOtherPlayerData` (IDOR)**: the callback returns `identifier`, `accounts`, `money`, full `inventory`, live `coords` and `metadata` for a **client-controlled `target`** with no check, so any client could loop IDs `1..N` and exfiltrate every online player's PII + live position. Added a **server-side proximity guard** (source/target peds must be valid and within ~10.0 units) — the least-breaking mitigation that kills remote mass-exfiltration. *You may want to go further and also restrict the returned fields; flagging for discussion.*
- **`esx_multicharacter` — `CharacterChosen` (IDOR / `disablechar` bypass)**: the chosen `charid` came from the client and was loaded without checking it belongs to the player's license or that the character isn't `disabled`. Added server-side validation (slot bound + ownership + `disabled` check). *Adds one `MySQL.single.await` on character selection — worth a test.*
- **`es_extended` — `esx:useItem` / `esx:giveInventoryItem`**: nil-deref on client-controlled item/account names crashed the handler. Added nil/existence guards.
- **`esx_textui`** — message rendered via `innerHTML`; added HTML escaping before color spans are applied (color codes still render).
- **`esx_identity`** — type-guard the registration callback payload, normalize `sex` case.
- **`esx_skin`** — clamp the client-supplied `bags_1` max-weight modifier to config.
- **`es_extended`** — `esx:updateWeaponAmmo` clamps client ammo; `esx:executeCommand` only runs for a non-empty string; `VehicleProperties` statebag is type-guarded.

## Correctness / robustness

- **`removeAccountMoney`** — the underflow guard `balance - money > balance` is always false for `money > 0`, so accounts could go negative. Fixed to `if money > balance` (matches the existing "Tried To Underflow" intent; also affects `removeMoney`).
- **`points` / `point` import** — `SizeOf(points) + 1` reused handles after a removal and silently overwrote an existing point; switched to a monotonic counter. Also fixed a loop-stop using `#` on a sparse table.
- **`cron`** — each job now runs under `pcall`, so one failing job no longer aborts the remaining jobs for that tick.
- **`RefreshJobs`** — guarantee an `unemployed` fallback (an empty jobs table broke player loading).
- **`onesync` `getNearbyPlayers`** — validate `source` before dereferencing; single `GetEntityCoords`.
- **`vehicle:delete`** — stricter entity-validity guard.
- **`SavePlayers`** — duration log used the wrong unit/resolution (always ~0.00).

## Performance

- **`paycheck`** — hoist per-tick constants/translations out of the per-player loop.
- **`interactions`** — removed an unused table that was written every interaction (small leak).
- **`events`** — pickup loop only does proximity work when a pickup is actually active.
- **`actions`** — `Init` made idempotent (was spawning a duplicate tracking thread).
- **`GetRandomString` / `Math.Random`** — seed once at load instead of reseeding with `GetGameTimer()` on every call.

## Not changed (flagged on purpose)

- **`esx:spawnVehicle`** has no permission gate, but many resources call it legitimately — only added defensive arg validation, no permission change.
- **`esx_notify`** uses `RegisterNetEvent` (vs a secure variant) and **`esx_menu_list`** uses a `{{{ }}}` triple-stache that renders generated `<button>` HTML — changing either risks breaking legitimate behavior, so left as-is.

## Testing

Verified the edited regions parse (stock `luac` rejects the pre-existing CfxLua extensions `?.`, `+=`, backtick hashes — unrelated to these edits). Runtime testing recommended, especially `esx_multicharacter` (new DB query) and `paycheck`.
