### PR TITLE
fix(es_extended/server): harden player save against invalid ped state

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -152,7 +152,9 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
     local self = {} ---@type xPlayer
 
     self.accounts = accounts
-    self.coords = coords
+    -- Fix: normalise the cached position to a canonical, mutable {x, y, z, heading} table once,
+    -- so getCoords can refresh it in-place (no per-call allocation) and fall back to it when a live read isn't available.
+    self.coords = { x = coords.x, y = coords.y, z = coords.z, heading = coords.heading or coords.w or 0.0 }
     self.group = group
     self.identifier = identifier
     self.ssn = ssn
@@ -218,17 +220,45 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
 
     function self.getCoords(vector, heading)
         local ped <const> = GetPlayerPed(self.source)
-        local entityCoords <const> = GetEntityCoords(ped)
-        local entityHeading <const> = GetEntityHeading(ped)
 
-        local coordinates = { x = entityCoords.x, y = entityCoords.y, z = entityCoords.z }
+        if ped ~= 0 and DoesEntityExist(ped) then
+            local entityCoords <const> = GetEntityCoords(ped)
+            local entityHeading <const> = GetEntityHeading(ped)
 
-        if vector then
-            coordinates = (heading and vector4(entityCoords.x, entityCoords.y, entityCoords.z, entityHeading) or entityCoords)
-        else
-            if heading then
-                coordinates.heading = entityHeading
+            -- Fix: refresh the cached position in-place (no allocation on this hot path).
+            -- type() guard self-heals if external code reassigned coords to a vector (non-mutable).
+            if type(self.coords) ~= "table" then
+                self.coords = { x = entityCoords.x, y = entityCoords.y, z = entityCoords.z, heading = entityHeading }
+            else
+                self.coords.x, self.coords.y, self.coords.z, self.coords.heading =
+                    entityCoords.x, entityCoords.y, entityCoords.z, entityHeading
             end
+
+            local coordinates = { x = entityCoords.x, y = entityCoords.y, z = entityCoords.z }
+
+            if vector then
+                coordinates = (heading and vector4(entityCoords.x, entityCoords.y, entityCoords.z, entityHeading) or entityCoords)
+            else
+                if heading then
+                    coordinates.heading = entityHeading
+                end
+            end
+
+            return coordinates
+        end
+
+        -- Fix: no valid ped -> fall back to the last cached position instead of reading a null entity.
+        local c <const> = self.coords
+        local ch <const> = c.heading or c.w or 0.0
+
+        -- Mirror of the ped-valid return shapes above: both branches must stay in sync.
+        if vector then
+            return heading and vector4(c.x, c.y, c.z, ch) or vector3(c.x, c.y, c.z)
+        end
+
+        local coordinates = { x = c.x, y = c.y, z = c.z }
+        if heading then
+            coordinates.heading = ch
         end
 
         return coordinates

--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -270,7 +270,7 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
 
     function self.getPlayTime()
         -- luacheck: ignore
-        return self.lastPlaytime + GetPlayerTimeOnline(self.source --[[@as string]])
+        return (self.lastPlaytime or 0) + (GetPlayerTimeOnline(self.source --[[@as string]]) or 0)
     end
 
     function self.setMoney(money)

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -190,8 +190,11 @@ end
 
 local function updateHealthAndArmorInMetadata(xPlayer)
     local ped = GetPlayerPed(xPlayer.source)
-    xPlayer.setMeta("health", GetEntityHealth(ped))
-    xPlayer.setMeta("armor", GetPedArmour(ped))
+    -- Fix: only read health/armor from a valid ped; otherwise keep the last saved metadata.
+    if ped ~= 0 and DoesEntityExist(ped) then
+        xPlayer.setMeta("health", GetEntityHealth(ped))
+        xPlayer.setMeta("armor", GetPedArmour(ped))
+    end
     xPlayer.setMeta("lastPlaytime", xPlayer.getPlayTime())
 end
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -190,8 +190,8 @@ end
 
 local function updateHealthAndArmorInMetadata(xPlayer)
     local ped = GetPlayerPed(xPlayer.source)
-    -- Fix: only read health/armor from a valid ped; otherwise keep the last saved metadata.
-    if ped ~= 0 and DoesEntityExist(ped) then
+    -- Fix: only read health/armor from a valid ped, and skip while the player is dead so a persisted health of 0 isn't overwritten with the live ped's HP.
+    if ped ~= 0 and DoesEntityExist(ped) and not Player(xPlayer.source).state.isDead then
         xPlayer.setMeta("health", GetEntityHealth(ped))
         xPlayer.setMeta("armor", GetPedArmour(ped))
     end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -202,10 +202,6 @@ end
 ---@param cb? function
 ---@return nil
 function Core.SavePlayer(xPlayer, cb)
-    if not xPlayer.spawned then
-        return cb and cb()
-    end
-
     updateHealthAndArmorInMetadata(xPlayer)
     local parameters <const> = {
         json.encode(xPlayer.getAccounts(true)),


### PR DESCRIPTION
## Summary

Harden server-side player persistence so coordinates and health/armor survive
every save context (disconnect, periodic autosave, resource restart, `/save`,
shutdown) instead of being corrupted to `0,0,0` / `0` when no valid ped is
available at save time (e.g. a player crashing out).

## Changes (server-side only)

- **Coordinates** — `getCoords` (server/classes/player.lua) keeps a canonical
  cached position refreshed on every live read, and returns the last known
  position instead of `0,0,0` when a fresh ped read isn't available.
- **Health / armor** — `updateHealthAndArmorInMetadata` (server/functions.lua)
  reads from a valid ped only, otherwise preserves the last persisted values
  instead of overwriting them with `0`.
- **Save flow** — `Core.SavePlayer` no longer early-returns on `not spawned`,
  so a not-yet-spawned player is saved against cached/loaded values.

## Scope

This PR persists the **position** of a dead player (death location is no longer
lost to `0,0,0`). It does **not** persist or restore the death **state** itself —
es_extended has no server-side notion of death (that lives in the death resource),
so staying dead across reconnect is out of scope here.

## Testing (local ESX server)

- Disconnect → reconnect, alive: respawns at the last persisted position with
  the last persisted HP/armor. Values are the last persisted snapshot, not the
  exact instant of disconnect.
- Disconnect → reconnect, dead: respawns at the last persisted position (death
  location preserved). Death-state restoration is out of scope and unchanged.

## Checklist

- [x] Tested locally
- [x] Conventional commits
- [x] No breaking changes (nominal save path unchanged)