### PR TITLE
feat(es_extended): grant StartingInventoryItems under ox_inventory

### DIFF
--- a/[core]/es_extended/server/bridge/inventory/oxinventory.lua
+++ b/[core]/es_extended/server/bridge/inventory/oxinventory.lua
@@ -32,5 +32,11 @@ function setPlayerInventory(playerId, xPlayer, inventory, isNew)
                 exports.ox_inventory:AddItem(playerId, name, account)
             end
         end
+
+        if Config.StartingInventoryItems then
+            for name, count in pairs(Config.StartingInventoryItems) do
+                exports.ox_inventory:AddItem(playerId, name, count)
+            end
+        end
     end
 end


### PR DESCRIPTION
The ox bridge only seeded StartingAccountMoney, so StartingInventoryItems was ignored under ox. Now granted via ox_inventory:AddItem on new characters, for parity with the default inventory.

Guarded against the false default (pairs(false) would crash).

Not tested at runtime — validation = create a character with StartingInventoryItems set.
