### PR TITLE
refactor: remove unused esx:spawnVehicle server callback

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -740,22 +740,6 @@ ESX.RegisterServerCallback("esx:getPlayerNames", function(source, cb, players)
     cb(players)
 end)
 
-ESX.RegisterServerCallback("esx:spawnVehicle", function(source, cb, vehData)
-    local ped = GetPlayerPed(source)
-    ESX.OneSync.SpawnVehicle(vehData.model or `ADDER`, vehData.coords or GetEntityCoords(ped), vehData.coords.w or 0.0, vehData.props or {}, function(id)
-        if vehData.warp then
-            local vehicle = NetworkGetEntityFromNetworkId(id)
-            local timeout = 0
-            while GetVehiclePedIsIn(ped, false) ~= vehicle and timeout <= 15 do
-                Wait(0)
-                TaskWarpPedIntoVehicle(ped, vehicle, -1)
-                timeout += 1
-            end
-        end
-        cb(id)
-    end)
-end)
-
 AddEventHandler("txAdmin:events:scheduledRestart", function(eventData)
     if eventData.secondsRemaining == 60 then
         CreateThread(function()


### PR DESCRIPTION
The `esx:spawnVehicle` server callback has no caller anywhere in esx_core. The client spawns vehicles through the native `CreateVehicle` (`ESX.Game.SpawnVehicle`, es_extended/client/functions.lua). Verified by grepping the whole repository for `esx:spawnVehicle` — only the definition remained.

This removes dead code. `ESX.OneSync.SpawnVehicle` (used by `/car` and the vehicle class) is untouched, so there is no behavior change in core.

Note: this is a public server callback. Any external resource triggering `esx:spawnVehicle` directly would need to spawn client-side instead. Given it has no caller in core and isn't documented, the impact should be minimal.
