### PR TITLE
fix(es_extended): guard getMoney and player load against missing data

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -114,7 +114,8 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
     end
 
     function self.getMoney()
-        return self.getAccount("money").money
+        local account = self.getAccount("money")
+        return account and account.money or 0
     end
 
     function self.addMoney(money, reason)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -200,6 +200,11 @@ function loadESXPlayer(identifier, playerId, isNew)
 
     local result = MySQL.prepare.await(loadPlayer, { identifier })
 
+    if not result then
+        print(("[^1ERROR^7] esx_core could not load data for identifier ^5%s^7"):format(identifier))
+        return DropPlayer(playerId --[[@as string]], "There was an error loading your character!\nError code: data-load-failed\n\nYour character data could not be retrieved. Please reconnect, and contact the server administration team if this keeps happening.")
+    end
+
     -- Accounts
     local accounts = result.accounts
     accounts = (accounts and accounts ~= "") and json.decode(accounts) or {}


### PR DESCRIPTION
Two small defensive guards in the server core:

- `getMoney()` returns 0 when the player has no `money` account instead of indexing nil. It is called unconditionally during player load.
- `loadESXPlayer` now drops the player with a clear message (and logs the error) when the data query returns no row, instead of indexing a nil result and leaving them stuck at loading.

No change on the happy path, these only affect edge cases that previously threw.
