### PR TITLE
fix(es_extended/server/functions): correct occured typo to occurred

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -591,7 +591,7 @@ function ESX.UseItem(source, item, ...)
 
             if not success then
                 return result and print(result) or
-                print(('[^3WARNING^7] An error occured when using item ^5"%s"^7! This was not caused by ESX.'):format(
+                print(('[^3WARNING^7] An error occurred when using item ^5"%s"^7! This was not caused by ESX.'):format(
                 item))
             end
         end


### PR DESCRIPTION
### Description

Fixes a spelling typo in the item-use error warning printed to the server console. The word "occured" was misspelled and is corrected to "occurred".

```diff
- print(('[^3WARNING^7] An error occured when using item ^5"%s"^7! This was not caused by ESX.'):format(item))
+ print(('[^3WARNING^7] An error occurred when using item ^5"%s"^7! This was not caused by ESX.'):format(item))
```

---

### Motivation

This message is shown directly in the server console whenever an item callback throws an error, so the misspelling is user-facing. Correcting it improves the polish of ESX's console output.

---

### Implementation Details

Single-word change to a string literal in `[core]/es_extended/server/functions.lua`. No logic, signatures, or behavior are affected.

---

### Usage Example

```lua
-- Not applicable — this is a text-only fix to an existing console warning.
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
