### PR TITLE
feat(es_extended): add Config.EnablePickup to disable/enable this feature

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -250,7 +250,7 @@ ESX.SecureNetEvent("esx:setGroup", function(group)
     ESX.SetPlayerData("group", group)
 end)
 
-if not Config.CustomInventory then
+if not Config.CustomInventory and Config.EnablePickup then
     ESX.SecureNetEvent("esx:createPickup", function(pickupId, label, coords, itemType, name, components, tintIndex)
         local function setObjectProperties(object)
             SetEntityAsMissionEntity(object, true, false)
@@ -300,7 +300,7 @@ ESX.SecureNetEvent("esx:registerSuggestions", function(registeredCommands)
     end
 end)
 
-if not Config.CustomInventory then
+if not Config.CustomInventory and Config.EnablePickup then
     ESX.SecureNetEvent("esx:removePickup", function(pickupId)
         if pickups[pickupId] and pickups[pickupId].obj then
             ESX.Game.DeleteObject(pickups[pickupId].obj)
@@ -367,7 +367,7 @@ function StartServerSyncLoops()
     end)
 end
 
-if not Config.CustomInventory then
+if not Config.CustomInventory and Config.EnablePickup then
     CreateThread(function()
         while true do
             local Sleep = 1500
@@ -602,7 +602,7 @@ local function noclipThread()
             local currentTime = GetGameTimer()
 
             DisableAllControlActions(0)
-            
+
             for i = 1, #allowedKeys do
                 local key = allowedKeys[i]
                 EnableControlAction(key[1], key[2], true)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -356,7 +356,7 @@ function loadESXPlayer(identifier, playerId, isNew)
     userData.variables = xPlayer.variables or {}
     xPlayer.triggerEvent("esx:playerLoaded", userData, isNew, userData.skin)
 
-    if not Config.CustomInventory then
+    if not Config.CustomInventory and Config.EnablePickup then
         xPlayer.triggerEvent("esx:createMissingPickups", Core.Pickups)
     elseif setPlayerInventory then
         -- Wait for identity to be set before loading inventory (for non-multichar)
@@ -570,9 +570,12 @@ if not Config.CustomInventory then
             end
 
             xPlayer.removeInventoryItem(itemName, itemCount)
-            local pickupLabel = ("%s [%s]"):format(xItem.label, itemCount)
-            ESX.CreatePickup("item_standard", itemName, itemCount, pickupLabel, playerId)
-            xPlayer.showNotification(TranslateCap("threw_standard", itemCount, xItem.label))
+
+            if Config.EnablePickup then
+                local pickupLabel = ("%s [%s]"):format(xItem.label, itemCount)
+                ESX.CreatePickup("item_standard", itemName, itemCount, pickupLabel, playerId)
+                xPlayer.showNotification(TranslateCap("threw_standard", itemCount, xItem.label))
+            end
         elseif itemType == "item_account" then
             if itemCount == nil or itemCount < 1 then
                 return xPlayer.showNotification(TranslateCap("imp_invalid_amount"))
@@ -588,9 +591,12 @@ if not Config.CustomInventory then
             end
 
             xPlayer.removeAccountMoney(itemName, itemCount, "Threw away")
-            local pickupLabel = ("%s [%s]"):format(account.label, TranslateCap("locale_currency", ESX.Math.GroupDigits(itemCount)))
-            ESX.CreatePickup("item_account", itemName, itemCount, pickupLabel, playerId)
-            xPlayer.showNotification(TranslateCap("threw_account", ESX.Math.GroupDigits(itemCount), string.lower(account.label)))
+
+            if Config.EnablePickup then
+                local pickupLabel = ("%s [%s]"):format(account.label, TranslateCap("locale_currency", ESX.Math.GroupDigits(itemCount)))
+                ESX.CreatePickup("item_account", itemName, itemCount, pickupLabel, playerId)
+                xPlayer.showNotification(TranslateCap("threw_account", ESX.Math.GroupDigits(itemCount), string.lower(account.label)))
+            end
         elseif itemType == "item_weapon" then
             itemName = string.upper(itemName)
 
@@ -607,16 +613,18 @@ if not Config.CustomInventory then
             local components = ESX.Table.Clone(weapon.components)
             xPlayer.removeWeapon(itemName)
 
-            if weaponObject.ammo and weapon.ammo > 0 then
-                local ammoLabel = weaponObject.ammo.label
-                weaponPickupLabel = ("%s [%s %s]"):format(weapon.label, weapon.ammo, ammoLabel)
-                xPlayer.showNotification(TranslateCap("threw_weapon_ammo", weapon.label, weapon.ammo, ammoLabel))
-            else
-                weaponPickupLabel = ("%s"):format(weapon.label)
-                xPlayer.showNotification(TranslateCap("threw_weapon", weapon.label))
-            end
+            if Config.EnablePickup then
+                if weaponObject.ammo and weapon.ammo > 0 then
+                    local ammoLabel = weaponObject.ammo.label
+                    weaponPickupLabel = ("%s [%s %s]"):format(weapon.label, weapon.ammo, ammoLabel)
+                    xPlayer.showNotification(TranslateCap("threw_weapon_ammo", weapon.label, weapon.ammo, ammoLabel))
+                else
+                    weaponPickupLabel = ("%s"):format(weapon.label)
+                    xPlayer.showNotification(TranslateCap("threw_weapon", weapon.label))
+                end
 
-            ESX.CreatePickup("item_weapon", itemName, weapon.ammo, weaponPickupLabel, playerId, components, weapon.tintIndex)
+                ESX.CreatePickup("item_weapon", itemName, weapon.ammo, weaponPickupLabel, playerId, components, weapon.tintIndex)
+            end
         end
     end)
 
@@ -637,50 +645,52 @@ if not Config.CustomInventory then
         ESX.UseItem(source, itemName)
     end)
 
-    RegisterNetEvent("esx:onPickup", function(pickupId)
-        local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)
+    if Config.EnablePickup then
+        RegisterNetEvent("esx:onPickup", function(pickupId)
+            local pickup, xPlayer, success = Core.Pickups[pickupId], ESX.GetPlayerFromId(source)
 
-        if not xPlayer then
-            return
-        end
-
-        if not pickup then return end
-
-        local playerPickupDistance = #(pickup.coords - xPlayer.getCoords(true))
-        if playerPickupDistance > 5.0 then
-            print(("[^3WARNING^7] Player Detected Cheating (Out of range pickup): ^5%s^7"):format(xPlayer.getIdentifier()))
-            return
-        end
-
-        if pickup.type == "item_standard" then
-            if not xPlayer.canCarryItem(pickup.name, pickup.count) then
-                return xPlayer.showNotification(TranslateCap("threw_cannot_pickup"))
+            if not xPlayer then
+                return
             end
 
-            xPlayer.addInventoryItem(pickup.name, pickup.count)
-            success = true
-        elseif pickup.type == "item_account" then
-            success = true
-            xPlayer.addAccountMoney(pickup.name, pickup.count, "Picked up")
-        elseif pickup.type == "item_weapon" then
-            if xPlayer.hasWeapon(pickup.name) then
-                return xPlayer.showNotification(TranslateCap("threw_weapon_already"))
+            if not pickup then return end
+
+            local playerPickupDistance = #(pickup.coords - xPlayer.getCoords(true))
+            if playerPickupDistance > 5.0 then
+                print(("[^3WARNING^7] Player Detected Cheating (Out of range pickup): ^5%s^7"):format(xPlayer.getIdentifier()))
+                return
             end
 
-            success = true
-            xPlayer.addWeapon(pickup.name, pickup.count)
-            xPlayer.setWeaponTint(pickup.name, pickup.tintIndex)
+            if pickup.type == "item_standard" then
+                if not xPlayer.canCarryItem(pickup.name, pickup.count) then
+                    return xPlayer.showNotification(TranslateCap("threw_cannot_pickup"))
+                end
 
-            for _, v in ipairs(pickup.components) do
-                xPlayer.addWeaponComponent(pickup.name, v)
+                xPlayer.addInventoryItem(pickup.name, pickup.count)
+                success = true
+            elseif pickup.type == "item_account" then
+                success = true
+                xPlayer.addAccountMoney(pickup.name, pickup.count, "Picked up")
+            elseif pickup.type == "item_weapon" then
+                if xPlayer.hasWeapon(pickup.name) then
+                    return xPlayer.showNotification(TranslateCap("threw_weapon_already"))
+                end
+
+                success = true
+                xPlayer.addWeapon(pickup.name, pickup.count)
+                xPlayer.setWeaponTint(pickup.name, pickup.tintIndex)
+
+                for _, v in ipairs(pickup.components) do
+                    xPlayer.addWeaponComponent(pickup.name, v)
+                end
             end
-        end
 
-        if success then
-            Core.Pickups[pickupId] = nil
-            TriggerClientEvent("esx:removePickup", -1, pickupId)
-        end
-    end)
+            if success then
+                Core.Pickups[pickupId] = nil
+                TriggerClientEvent("esx:removePickup", -1, pickupId)
+            end
+        end)
+    end
 end
 
 ESX.RegisterServerCallback("esx:getPlayerData", function(source, cb)

--- a/[core]/es_extended/shared/config/main.lua
+++ b/[core]/es_extended/shared/config/main.lua
@@ -53,6 +53,7 @@ Config.EnableSocietyPayouts = false    -- pay from the society account that the 
 Config.MaxWeight = 24                  -- the max inventory weight without a backpack
 Config.PaycheckInterval = 7 * 60000    -- how often to receive paychecks in milliseconds
 Config.SaveDeathStatus = true          -- Save the death status of a player
+Config.EnablePickup = true             -- Enable the pickup system for items and weapons
 Config.EnableDebug = false             -- Use Debug options?
 
 Config.DefaultJobDuty = true           -- A players default duty status when changing jobs


### PR DESCRIPTION
### Description

This PR introduces a new configuration option, `Config.EnablePickup`, to `es_extended`. This toggle gives server owners the flexibility to choose whether a physical pickup object drops on the ground when an item or weapon is removed from a player's inventory.

---

### Motivation

Currently, removing an item or a weapon automatically forces a ground pickup to spawn. While this fits some server styles, many developers prefer to delete items silently (e.g., for clean-up scripts, custom inventory wipes, or specific roleplay scenarios) without cluttering the map or allowing players to immediately scoop the item back up. This change solves that issue by putting the control directly in the config.

---

### Implementation Details

* Added `Config.EnablePickup` to `config.lua` (defaulting to `true` to preserve original framework behavior).
* Wrapped the pickup spawning logic inside the item/weapon removal functions with a simple conditional check. If set to `false`, the item is removed cleanly without executing the object creation code.

---

### Usage Example

In your `config.lua`:

```lua
-- Set to true to drop a pickup on the ground when items/weapons are removed (Default)
-- Set to false to silently delete them without spawning a ground pickup
Config.EnablePickup = false 

```

---

### PR Checklist

* [x] My commit messages and PR title follow the [[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) standard.
* [x] My changes have been tested locally and function as expected.
* [x] My PR does not introduce any breaking changes.
* [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.