### PR TITLE
fix(esx_lib): stop the table module from overwriting the stdlib

### DIFF
--- a/[core]/esx_lib/imports/table/shared.lua
+++ b/[core]/esx_lib/imports/table/shared.lua
@@ -1,5 +1,5 @@
----@class tablelib
-xLib.table = table
+---@class xtable : tablelib
+xLib.table = setmetatable({}, { __index = table })
 
 ---@param tbl table
 ---@return boolean


### PR DESCRIPTION
`xLib.table = table` aliases the stdlib instead of copying it, so every `function xLib.table.X()` overwrites the real `table.X`. sort, concat, wipe and clone collide.

sort is the one that bites: its body calls `table.sort(keys)`, which resolves to itself and recurses until the stack blows. Loading a player hits it at `es_extended/server/main.lua:266`.

Namespacing leaves the stdlib alone. `__index` still falls through for insert, remove and unpack.