### PR TITLE
feat: integrate Medal.tv globally

### DIFF
--- a/[core]/esx_lib/config.lua
+++ b/[core]/esx_lib/config.lua
@@ -1,0 +1,24 @@
+Config = {}
+
+---@class MedalClipOptions
+---@field duration integer
+---@field captureDelayMs integer
+---@field alertType 'Default'|'Disabled'|'SoundOnly'|'OverlayOnly'
+
+---@class MedalConfig
+---@field enabled boolean
+---@field publicKey string
+---@field eventName string
+---@field clipOptions MedalClipOptions
+
+---@type MedalConfig
+Config.Medal = {
+	enabled = true,
+	publicKey = 'pub_82qkpMKV77AkpqLSgWsxLlDyfzpPI7Vw',
+	eventName = 'Death',
+	clipOptions = {
+		duration = 30,
+		captureDelayMs = 0,
+		alertType = 'Default'
+	}
+}

--- a/[core]/esx_lib/fxmanifest.lua
+++ b/[core]/esx_lib/fxmanifest.lua
@@ -8,13 +8,18 @@ author 'ESX Team'
 version '0.01'
 description 'Official ESX library'
 
+ui_page 'html/medal.html'
+
 files {
     'imports.lua',
     'imports/**/client.lua',
     'imports/**/shared.lua',
+    'html/medal.html',
+    'html/medal.js',
 }
 
 shared_scripts {
+    'config.lua',
     'resource/init.lua',
     'resource/**/shared.lua',
 }

--- a/[core]/esx_lib/html/medal.html
+++ b/[core]/esx_lib/html/medal.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src http://localhost:12665 http://127.0.0.1:12665">
+</head>
+<body>
+    <script src="medal.js"></script>
+</body>
+</html>

--- a/[core]/esx_lib/html/medal.js
+++ b/[core]/esx_lib/html/medal.js
@@ -1,0 +1,13 @@
+window.addEventListener('message', function (event) {
+    var data = event.data;
+    if (!data || data.action !== 'medalClip') return;
+
+    fetch('http://localhost:12665/api/v1/event/invoke', {
+        method: 'POST',
+        headers: {
+            'publicKey': data.publicKey,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data.payload)
+    }).catch(function () {});
+});

--- a/[core]/esx_lib/imports/medal/client.lua
+++ b/[core]/esx_lib/imports/medal/client.lua
@@ -1,0 +1,18 @@
+local medal = {}
+
+function medal.getConfig()
+    return exports['esx_lib']:getMedalConfig()
+end
+
+function medal.triggerClip(publicKey, eventName, clipOptions)
+    local cfg = medal.getConfig()
+    if not cfg or not cfg.enabled then return end
+
+    exports['esx_lib']:triggerMedalClip(
+        publicKey or cfg.publicKey,
+        eventName or cfg.eventName,
+        clipOptions or cfg.clipOptions
+    )
+end
+
+return medal

--- a/[core]/esx_lib/resource/medal/client.lua
+++ b/[core]/esx_lib/resource/medal/client.lua
@@ -1,0 +1,22 @@
+xLib.getMedalConfig = function()
+    return Config.Medal
+end
+
+xLib.triggerMedalClip = function(publicKey, eventName, clipOptions)
+    if not publicKey or publicKey == '' then return end
+
+    SendNUIMessage({
+        action = 'medalClip',
+        publicKey = publicKey,
+        payload = {
+            eventId = ('esx-clip-%s-%s'):format(GetPlayerServerId(PlayerId()), GetGameTimer()),
+            eventName = eventName or 'Event',
+            triggerActions = { 'SaveClip' },
+            clipOptions = clipOptions or {
+                duration = 30,
+                captureDelayMs = 0,
+                alertType = 'Default'
+            }
+        }
+    })
+end


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Centralizes the Medal.tv auto-clipping feature into the esx_lib core library, moving it out of esx_ambulancejob and making it available globally for all resources on the server. It exposes a simple xLib.medal module for triggering clips and managing configuration.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Previously, Medal.tv auto-clipping was coupled with esx_ambulancejob. If other scripts wanted to trigger Medal clips (e.g., on kills, heist completions, or custom events), developers had to duplicate NUI pages, script handlers, and configurations across multiple resources. Centralizing this feature inside the core esx_lib library eliminates code duplication and allows any script to easily trigger clips via a standardized global interface.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- NUI Migration: Moved ``medal.html`` and ``medal.js`` into ``esx_lib/html/`` and registered the NUI iframe using the ``ui_page`` entry in ``esx_lib/fxmanifest.lua``.

- Centralized Configuration: Created ``esx_lib/config.lua`` to define ``Config.Medal`` globally.

- Export Registry: Implemented ``triggerMedalClip`` and ``getMedalConfig`` exports in ``esx_lib/resource/medal/client.lua``.

- Lazy-Loaded Module: Developed ``esx_lib/imports/medal/client.lua`` to wrap the exports under the ``xLib.medal`` table. Added fallback logic so that calls to ``xLib.medal.triggerClip()`` without arguments automatically query and use the centralized configuration values.

---

### Usage Example
To use this feature in any resource, first import ``@esx_lib/imports.lua`` in your ``fxmanifest.lua``:
```lua
shared_scripts {
    '@esx_lib/imports.lua',
}
```
```lua
-- Trigger clip using default configuration values set in esx_lib/config.lua
xLib.medal.triggerClip()
-- Or override specific properties (e.g., custom event name)
xLib.medal.triggerClip(nil, "Heist Complete")
-- Or override all properties manually
xLib.medal.triggerClip("pub_customPublicKey", "Deathmatch Kill", {
    duration = 45,
    captureDelayMs = 0,
    alertType = 'SoundOnly'
})
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
