### PR TITLE
chore: bump manifest version to 1.14.0

### DIFF
--- a/[core]/cron/fxmanifest.lua
+++ b/[core]/cron/fxmanifest.lua
@@ -4,6 +4,6 @@ game 'gta5'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 server_script 'server/main.lua'

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'The Core resource that provides the functionalities for all other resources.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 shared_scripts {
 	'@esx_lib/imports.lua',

--- a/[core]/esx_chat_theme/fxmanifest.lua
+++ b/[core]/esx_chat_theme/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.13.5'
+version '1.14.0'
 author 'ESX-Framework'
 description 'A ESX Stylised theme for the chat resource.'
 

--- a/[core]/esx_context/fxmanifest.lua
+++ b/[core]/esx_context/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'gta5'
 author 'ESX-Framework & Brayden'
 description 'A simplistic context menu for ESX.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 ui_page 'index.html'
 

--- a/[core]/esx_identity/fxmanifest.lua
+++ b/[core]/esx_identity/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'Allows the player to Pick their characters: Name, Gender, Height and Date-of-birth.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 shared_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_inventory/fxmanifest.lua
+++ b/[core]/esx_inventory/fxmanifest.lua
@@ -4,7 +4,7 @@ game "gta5"
 description "Inventory for the ESX framework"
 lua54 "yes"
 use_fxv2_oal "yes"
-version '1.13.5'
+version '1.14.0'
 
 shared_scripts {
     "/config/main.lua",

--- a/[core]/esx_loadingscreen/fxmanifest.lua
+++ b/[core]/esx_loadingscreen/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'common'
 fx_version 'cerulean'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 loadscreen 'index.html'

--- a/[core]/esx_menu_default/fxmanifest.lua
+++ b/[core]/esx_menu_default/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'A basic menu system for ESX Legacy.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 client_scripts { '@es_extended/imports.lua', 'client/main.lua' }
 

--- a/[core]/esx_menu_dialog/fxmanifest.lua
+++ b/[core]/esx_menu_dialog/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic input dialog for ESX Legacy.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 client_scripts {
 	'@es_extended/imports.lua',

--- a/[core]/esx_menu_list/fxmanifest.lua
+++ b/[core]/esx_menu_list/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic table-based menu system for ESX Legacy.'
 lua54 'yes'
-version '1.13.5'
+version '1.14.0'
 
 
 client_scripts {

--- a/[core]/esx_multicharacter/fxmanifest.lua
+++ b/[core]/esx_multicharacter/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 author 'ESX-Framework - Linden - KASH'
 description 'Allows players to have multiple characters on the same account.'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 dependencies { 'es_extended', 'esx_context', 'esx_identity', 'esx_skin' }

--- a/[core]/esx_notify/fxmanifest.lua
+++ b/[core]/esx_notify/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 lua54 'yes'
 game 'gta5'
-version '1.13.5'
+version '1.14.0'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI notification system for ESX'
 

--- a/[core]/esx_progressbar/fxmanifest.lua
+++ b/[core]/esx_progressbar/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI progress bar for ESX'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 client_scripts { 'Progress.lua' }

--- a/[core]/esx_skin/fxmanifest.lua
+++ b/[core]/esx_skin/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Allows players to customise their character\'s appearance'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 shared_scripts {

--- a/[core]/esx_textui/fxmanifest.lua
+++ b/[core]/esx_textui/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple Persistent Notification system for ESX.'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 client_scripts { 'TextUI.lua' }

--- a/[core]/skinchanger/fxmanifest.lua
+++ b/[core]/skinchanger/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Saves/loads character appearances for ESX Legacy.'
-version '1.13.5'
+version '1.14.0'
 lua54 'yes'
 
 client_scripts {


### PR DESCRIPTION
Bumps the 16 core fxmanifest versions from 1.13.5 to 1.14.0 to match the published release (esx_lib keeps its own versioning). The release was created outside the release workflow, so the automatic bump never ran.

Closes #1806