### PR TITLE
fix(esx_lib): load imports from the correct resource name

### DIFF
--- a/[core]/esx_lib/resource/init.lua
+++ b/[core]/esx_lib/resource/init.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: lowercase-global
 xLib = setmetatable({
-    name = 'xLib',
+    name = 'esx_lib',
     side = IsDuplicityVersion() and 'server' or 'client'
 }, {
     __newindex = function(self, key, fn)


### PR DESCRIPTION
### Description

`xLib.name` was `"xLib"`, which is not a resource, so the import metatable fed it to `LoadResourceFile` and resolved nothing: silent on Legacy, a hard error on Enhanced. Points it at the real resource name. Boots clean on both.

### PR Checklist

-   [x] My commit messages and PR title follow the Conventional Commits standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does.
