### PR TITLE
feat(es_extended): auto-detect Legacy vs Enhanced edition

### DIFF
--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -14,6 +14,7 @@ shared_scripts {
     'shared/config/adjustments.lua',
 
     'shared/main.lua',
+    'shared/enhanced.lua',
     'shared/functions.lua',
     'shared/modules/*.lua',
 	'shared/compat.lua'

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -151,7 +151,7 @@ if not Config.Multichar then
             return deferrals.done(("[ESX] ESX Requires a minimum Artifact version of 10188, Please update your server."))
         end
 
-        if oneSyncState == "off" or oneSyncState == "legacy" then
+        if not ESX.IsEnhanced and (oneSyncState == "off" or oneSyncState == "legacy") then
             return deferrals.done(("[ESX] ESX Requires Onesync Infinity to work. This server currently has Onesync set to: %s"):format(oneSyncState))
         end
 

--- a/[core]/es_extended/shared/enhanced.lua
+++ b/[core]/es_extended/shared/enhanced.lua
@@ -1,0 +1,17 @@
+local ENHANCED_GAME_NAMES <const> = {
+    ["gta5enhanced"] = true,
+    ["gta5_enhanced"] = true
+}
+
+local isEnhanced
+
+if IsDuplicityVersion() then
+    isEnhanced = ENHANCED_GAME_NAMES[GetConvar("gamename", "gta5")] == true
+    SetConvarReplicated("esx:enhanced", isEnhanced and "true" or "false")
+    print(("[ESX] Edition detected: ^5%s^7"):format(isEnhanced and "Enhanced" or "Legacy"))
+else
+    isEnhanced = type(IsGameEnhancedVersion) == "function" and IsGameEnhancedVersion() == true
+end
+
+---@type boolean
+ESX.IsEnhanced = isEnhanced


### PR DESCRIPTION
### Description

Adds `ESX.IsEnhanced` so one codebase runs on both Legacy and GTA V Enhanced (server: `gamename` convar, client: `IsGameEnhancedVersion`, mirrored to a replicated `esx:enhanced` convar). OneSync Infinity is enforced on Legacy only.

### PR Checklist

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.
