### PR TITLE
feat(esx_lib): add isEnhanced game edition detection

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -2,6 +2,7 @@ SetMapName("San Andreas")
 SetGameType("ESX Legacy")
 
 local oneSyncState = GetConvar("onesync", "off")
+local isEnhanced = xLib.isEnhanced()
 local newPlayer = "INSERT INTO `users` SET `accounts` = ?, `identifier` = ?, `ssn` = ?, `group` = ?"
 local loadPlayer = "SELECT `accounts`, `ssn`, `job`, `job_grade`, `group`, `position`, `inventory`, `skin`, `loadout`, `metadata`"
 
@@ -151,7 +152,7 @@ if not Config.Multichar then
             return deferrals.done(("[ESX] ESX Requires a minimum Artifact version of 10188, Please update your server."))
         end
 
-        if oneSyncState == "off" or oneSyncState == "legacy" then
+        if not isEnhanced and (oneSyncState == "off" or oneSyncState == "legacy") then
             return deferrals.done(("[ESX] ESX Requires Onesync Infinity to work. This server currently has Onesync set to: %s"):format(oneSyncState))
         end
 

--- a/[core]/esx_lib/imports/isEnhanced/shared.lua
+++ b/[core]/esx_lib/imports/isEnhanced/shared.lua
@@ -1,0 +1,17 @@
+local ENHANCED_GAME_NAMES <const> = {
+    ["gta5enhanced"] = true,
+    ["gta5_enhanced"] = true
+}
+
+local isEnhanced
+
+if IsDuplicityVersion() then
+    isEnhanced = ENHANCED_GAME_NAMES[GetConvar("gamename", "gta5")] == true
+else
+    isEnhanced = type(IsGameEnhancedVersion) == "function" and IsGameEnhancedVersion() == true
+end
+
+---@return boolean
+return function()
+    return isEnhanced
+end


### PR DESCRIPTION
### Description

`xLib.isEnhanced()` returns whether the game runs GTA V Enhanced (server: `gamename` convar, client: `IsGameEnhancedVersion` native). es_extended uses it to require OneSync Infinity on Legacy only, since Enhanced runs OneSync natively.

### PR Checklist

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.
