### PR TITLE
fix(es_extended/server/functions): persist ESX.AddItems to database

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -799,9 +799,15 @@ if not Config.CustomInventory then
         end
 
         if #toInsert > 0 then
+            local parameters = {}
+            for i = 1, #toInsert do
+                local row = toInsert[i]
+                parameters[i] = { row.name, row.label, row.weight, row.rare, row.canRemove }
+            end
+
             MySQL.prepare.await(
             "INSERT IGNORE INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES (?, ?, ?, ?, ?)",
-                toInsert)
+                parameters)
 
             for i = 1, #toInsert do
                 local row = toInsert[i]


### PR DESCRIPTION
## What this PR does

`ESX.AddItems` updated in-game state but never persisted new items to the database.

### Root cause
`MySQL.prepare.await` batch mode expects the parameters argument to be an array of **positional** parameter arrays (e.g. `{ {a, b}, {c, d} }`). The code passed `toInsert`, which is an array of **keyed** tables (`{ name = ..., label = ... }`). The `?` placeholders therefore received no values and the `INSERT IGNORE` silently failed.

Because `ESX.Items[...]` is populated separately from the same keyed tables, items still showed up in-game — but nothing was ever written to the `items` table. This matches the reported symptom exactly.

### Fix
Build a positional `parameters` array before the prepared insert, leaving the keyed tables intact for the `ESX.Items` population loop.

Closes #1768

## Checklist
- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.