### PR TITLE
fix(es_extended/server/functions): drop leading space from merge command arguments

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -136,7 +136,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
                                 end
                                 local merge = table.concat(args, " ")
 
-                                newArgs[v.name] = string.sub(merge, length)
+                                newArgs[v.name] = string.sub(merge, length + 1)
                             elseif v.type == "coordinate" then
                                 local coord = tonumber(args[k]:match("(-?%d+%.?%d*)"))
                                 if not coord then


### PR DESCRIPTION
Commands registered through `ESX.RegisterCommand` with an argument of type `merge` receive the merged text with a leading space.

`length` is built up as the character count of the preceding arguments plus one space each, so it equals the number of characters consumed before the merged part. Lua strings are 1-indexed, so the merged text starts at `length + 1` — passing `length` to `string.sub` returns the separating space as well.

Anything that consumes such an argument gets the stray space: ban and kick reasons, chat messages, and any comparison or `tonumber()` on the value.

Tested locally on artifact 25770 with a command whose `merge` argument sits at position 1, 2 and 3:

| merge at | before | after |
| --- | --- | --- |
| position 1 | `hello big world` | `hello big world` |
| position 2 | ` def ghi` | `def ghi` |
| position 3 | ` ccc ddd` | `ccc ddd` |

Position 1 is unchanged because `string.sub` clamps index 0 to 1, so it already returned the whole string.

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.