### PR TITLE
fix(es_extended/server/main): use the identity sex for the default skin

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -312,7 +312,7 @@ function loadESXPlayer(identifier, playerId, isNew)
     userData.coords = json.decode(result.position) or Config.DefaultSpawns[ESX.Math.Random(1,#Config.DefaultSpawns)]
 
     -- Skin
-    userData.skin = (result.skin and result.skin ~= "") and json.decode(result.skin) or { sex = userData.sex == "f" and 1 or 0 }
+    userData.skin = (result.skin and result.skin ~= "") and json.decode(result.skin) or { sex = result.sex == "f" and 1 or 0 }
 
     -- Metadata
     userData.metadata = (result.metadata and result.metadata ~= "") and json.decode(result.metadata) or {}


### PR DESCRIPTION
A character that has no saved skin always falls back to the male model, even when the identity was registered as female.

`loadESXPlayer` builds the fallback skin from `userData.sex`:

```lua
userData.skin = (result.skin and result.skin ~= "") and json.decode(result.skin) or { sex = userData.sex == "f" and 1 or 0 }
```

`userData` is created earlier in the function without a `sex` field, and `userData.sex` is only assigned about thirty lines further down while reading the identity data off the result row. At this point it is still nil, so the comparison is always false and the fallback is always `{ sex = 0 }`.

`result.sex` already holds the value here — it is selected alongside the other identity columns and used a few lines later — so reading it directly is enough.

In practice the character shows up correctly during identity registration, then switches to the male model once the skin data arrives from the server.

Tested locally on artifact 25770 with MariaDB, using a character whose `skin` column is empty:

| identity sex | skin.sex before | skin.sex after |
| --- | --- | --- |
| `f` | 0 (male model) | 1 (female model) |
| `m` | 0 | 0 |

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.