### PR TITLE
fix(es_extended/server/main): skip unknown weapons when loading a loadout

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -293,9 +293,9 @@ function loadESXPlayer(identifier, playerId, isNew)
 
             local loadout = json.decode(result.loadout)
             for name, weapon in pairs(loadout) do
-                local label = ESX.GetWeaponLabel(name)
+                local found, label = pcall(ESX.GetWeaponLabel, name)
 
-                if label then
+                if found and label then
                     userData.loadout[#userData.loadout + 1] = {
                         name = name,
                         ammo = weapon.ammo,


### PR DESCRIPTION
A player whose saved loadout contains a weapon that is not in `Config.Weapons` can never log in again.

`loadESXPlayer` walks the stored loadout like this:

```lua
local label = ESX.GetWeaponLabel(name)

if label then
```

`ESX.GetWeaponLabel` asserts when the name is unknown, so it never returns a falsy value and the `if label then` check can never skip anything. The assert propagates out of `loadESXPlayer`, so `CreateExtendedPlayer` is never reached, `ESX.Players[playerId]` stays empty and `esx:playerLoaded` never fires. The player sits on the loading screen and hits the same error on every reconnect, with no way out other than editing the database.

This is reachable whenever the weapon list changes underneath saved data — changing `sv_enforceGameBuild`, removing or renaming an entry in `shared/weapons.lua`, or removing a resource that had added weapons to the config.

Wrapping the lookup leaves `ESX.GetWeaponLabel` untouched and lets the existing check do what it was written for.

Tested locally on artifact 25770 with MariaDB by storing `{"WEAPON_NOTAREALGUN":{"ammo":50}}` in a character's loadout column:

- before: the client hangs after character selection, server logs `Invalid weapon name!` with a stack trace through `GetWeaponLabel` and `loadESXPlayer`
- after: the character loads normally, the unknown weapon is skipped and no error is logged

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.