### PR TITLE
fix(es_extended/shared/config): reset the female move speed multiplier to normal

### DIFF
--- a/[core]/es_extended/shared/config/adjustments.lua
+++ b/[core]/es_extended/shared/config/adjustments.lua
@@ -71,7 +71,7 @@ Config.PlayerStatsByGender = {
         stamina = 1.15,
         strength = 0.85,
         swimSpeed = 1.25,
-        moveSpeed = 7.00,
+        moveSpeed = 1.0,
     }
 }
 


### PR DESCRIPTION
`Config.PlayerStatsByGender.female.moveSpeed` is `7.00`, while `male.moveSpeed` is `1.0` and the legend in the same block defines the scale as `1.0 = normal, 1.5 = +50%, 0.5 = -50%`.

The value is applied directly as a ped move rate override in a per frame loop (`client/modules/adjustments.lua`, `SetPedMoveRateOverride`), and `PlayerStatsByGender.enabled` and `useCharacterData` are both true out of the box. So on a stock install every character registered as female moves at seven times the normal rate — fast enough to outrun traffic, and enough to trip the speed checks in most anticheats.

Looks like a leftover test value; `1.0` matches the male entry and the documented scale.

Tested locally on artifact 25770 with a female character: unplayably fast before the change, normal after. A male character behaves the same before and after.

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.