### PR TITLE
fix(es_extended/modules/callback): compare the promise state against its numeric value

### DIFF
--- a/[core]/es_extended/client/modules/callback.lua
+++ b/[core]/es_extended/client/modules/callback.lua
@@ -102,7 +102,7 @@ function ESX.AwaitServerCallback(eventName, ...)
 
     -- if the server callback takes longer than 15 seconds to respond, reject the promise
     SetTimeout(15000, function()
-        if p.state == "pending" then
+        if p.state == 0 then
             p:reject("Server Callback Timed Out")
         end
     end)

--- a/[core]/es_extended/server/modules/callback.lua
+++ b/[core]/es_extended/server/modules/callback.lua
@@ -107,7 +107,7 @@ function ESX.AwaitClientCallback(player, eventName, ...)
     if not p then return end
 
     SetTimeout(15000, function()
-        if p.state == "pending" then
+        if p.state == 0 then
             p:reject("Server Callback Timed Out")
         end
     end)


### PR DESCRIPTION
The 15 second timeout in `ESX.AwaitServerCallback` and `ESX.AwaitClientCallback` can never fire.

```lua
SetTimeout(15000, function()
    if p.state == "pending" then
        p:reject("Server Callback Timed Out")
    end
end)
```

`promise.state` is a number, not a string. The runtime defines `PENDING = 0` (through `REJECTED = 4`) and `Citizen.Await` tests `state == 0` itself, so the string comparison is always false. If the other side never answers — handler not registered, an error thrown before `cb()`, a resource restarted mid-call — `Citizen.Await` blocks the calling coroutine permanently instead of rejecting after 15 seconds as the comment above it describes.

Measured on artifact 25770 with the real 15 second delay:

| case | guard | state at 15s | rejected | result of the await |
| --- | --- | --- | --- | --- |
| never answers | current | 0 (pending) | no | never returns |
| never answers | fixed | 0 (pending) | yes | returns "Server Callback Timed Out" |
| answers after 1s | fixed | 3 (resolved) | no | returns normally |

The third row is the regression case: an already resolved promise is left alone, so callbacks that answer in time behave exactly as before.

Worth stating explicitly: after this change a callback that never answers surfaces as a rejection after 15 seconds instead of hanging forever, since `Citizen.Await` re-raises it. That is what the existing comment intends, and nothing can meaningfully depend on the hang. Nothing inside `esx_core` calls either function, so no core behaviour changes.

- [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.