### PR TITLE
fix(es_extended/server/functions): persist items added via AddItems

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -799,9 +799,15 @@ if not Config.CustomInventory then
         end
 
         if #toInsert > 0 then
+            local parameters = {}
+            for i = 1, #toInsert do
+                local row = toInsert[i]
+                parameters[i] = { row.name, row.label, row.weight, row.rare, row.canRemove }
+            end
+
             MySQL.prepare.await(
             "INSERT IGNORE INTO `items` (`name`, `label`, `weight`, `rare`, `can_remove`) VALUES (?, ?, ?, ?, ?)",
-                toInsert)
+                parameters)
 
             for i = 1, #toInsert do
                 local row = toInsert[i]


### PR DESCRIPTION
ESX.AddItems adds the items to ESX.Items but they never end up in the database.

MySQL.prepare batch mode wants an array of positional parameter arrays, but toInsert is a list of keyed tables, so the ? placeholders get nothing and the INSERT does nothing. In-game it looks fine because ESX.Items is filled from the same keyed tables, but after a restart the items are gone since they were never saved.

Fixed by building a positional parameters array before the prepared insert.

Tested locally on artifact 25770 with MariaDB, against this branch: before the change the items table had 0 rows after AddItems, after it the two rows are there with the right label and weight.

Closes #1768

This replaces #1813, which was opened against `dev` before I got the answer on Discord that contributions should target the branch that becomes the next release.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.