### PR TITLE
fix(es_extended/server/functions): drop leading space from merge command arguments

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -136,7 +136,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
                                 end
                                 local merge = table.concat(args, " ")
 
-                                newArgs[v.name] = string.sub(merge, length)
+                                newArgs[v.name] = string.sub(merge, length + 1)
                             elseif v.type == "coordinate" then
                                 local coord = tonumber(args[k]:match("(-?%d+%.?%d*)"))
                                 if not coord then


### PR DESCRIPTION
A command argument of type `merge` comes back with a leading space whenever it is not the first argument.

`length` is built as the sum of the preceding arguments plus one separator each, so it already points at the space in front of the merged part. `string.sub` is 1-based and inclusive, so starting there keeps that space.

Tested locally on artifact 25770 against this branch, with a command whose second argument is a merge:
- before: `probe_merge aaa bbb ccc ddd` gave `[ bbb ccc ddd]`
- after: the same input gives `[bbb ccc ddd]`, and `probe_merge xx yy` gives `[yy]`

A merge argument in first position is unaffected, `length` is 0 there and `string.sub(merge, 1)` is the whole string either way.

This replaces #1814, which was opened against `dev` before I got the answer on Discord that contributions should target the branch that becomes the next release.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.