### PR TITLE
fix(es_extended/server/main): use the identity sex for the default skin

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -307,7 +307,7 @@ function loadESXPlayer(identifier, playerId, isNew)
     userData.coords = json.decode(result.position) or Config.DefaultSpawns[ESX.Math.Random(1,#Config.DefaultSpawns)]
 
     -- Skin
-    userData.skin = (result.skin and result.skin ~= "") and json.decode(result.skin) or { sex = userData.sex == "f" and 1 or 0 }
+    userData.skin = (result.skin and result.skin ~= "") and json.decode(result.skin) or { sex = result.sex == "f" and 1 or 0 }
 
     -- Metadata
     userData.metadata = (result.metadata and result.metadata ~= "") and json.decode(result.metadata) or {}


### PR DESCRIPTION
A player without a saved skin always gets the male default, even when their identity says female.

The fallback reads `userData.sex`, but at that point `userData` is the table literal built a few lines above, which has no `sex` field. It is only assigned from `result.sex` further down, so the comparison is always `nil == "f"` and the sex ends up 0.

Fixed by reading `result.sex`, the same source the later assignment uses.

Tested locally on artifact 25770 with a user row whose identity sex is `f` and an empty skin column: before the change the default skin came out as sex 0, after it comes out as 1. A male identity stays at 0.

This replaces #1815, which was opened against `dev` before I got the answer on Discord that contributions should target the branch that becomes the next release.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.