### PR TITLE
fix(es_extended/server/main): skip unknown weapons when loading a loadout

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -288,9 +288,9 @@ function loadESXPlayer(identifier, playerId, isNew)
 
             local loadout = json.decode(result.loadout)
             for name, weapon in pairs(loadout) do
-                local label = ESX.GetWeaponLabel(name)
+                local found, label = pcall(ESX.GetWeaponLabel, name)
 
-                if label then
+                if found and label then
                     userData.loadout[#userData.loadout + 1] = {
                         name = name,
                         ammo = weapon.ammo,


### PR DESCRIPTION
A weapon name in the saved loadout that is no longer in the weapons config stops the player from loading at all.

`ESX.GetWeaponLabel` does not return nil for an unknown name, it calls `error("Invalid weapon name!")`. `loadESXPlayer` runs that in a plain call, so the whole load path aborts. The player is left hanging on the loading screen and stays stuck on every reconnect, because the bad row is still in the database.

This is reachable without anything exotic: renaming or removing a weapon from the config, or a downgrade after a weapon was added.

Fixed by calling it through pcall and skipping entries that do not resolve, which is what the `if label then` check clearly meant to do.

Tested locally on artifact 25770 with `{"WEAPON_NOTAREALGUN":{"ammo":50}}` in the loadout column: before the change the server logged `Invalid weapon name!` and the player never finished loading, after it the unknown entry is skipped and the remaining weapons load normally.

This replaces #1816, which was opened against `dev` before I got the answer on Discord that contributions should target the branch that becomes the next release.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.