### PR TITLE
fix(es_extended/modules/callback): compare the promise state against its numeric value

### DIFF
--- a/[core]/es_extended/client/modules/callback.lua
+++ b/[core]/es_extended/client/modules/callback.lua
@@ -102,7 +102,7 @@ function ESX.AwaitServerCallback(eventName, ...)
 
     -- if the server callback takes longer than 15 seconds to respond, reject the promise
     SetTimeout(15000, function()
-        if p.state == "pending" then
+        if p.state == 0 then
             p:reject("Server Callback Timed Out")
         end
     end)

--- a/[core]/es_extended/server/modules/callback.lua
+++ b/[core]/es_extended/server/modules/callback.lua
@@ -107,7 +107,7 @@ function ESX.AwaitClientCallback(player, eventName, ...)
     if not p then return end
 
     SetTimeout(15000, function()
-        if p.state == "pending" then
+        if p.state == 0 then
             p:reject("Server Callback Timed Out")
         end
     end)


### PR DESCRIPTION
The 15 second timeout in `AwaitServerCallback` and `AwaitClientCallback` never fires.

`promise.state` is a number, not a string. The constants are PENDING = 0, RESOLVING = 1, REJECTING = 2, RESOLVED = 3, REJECTED = 4, so `p.state == "pending"` is always false and the promise is never rejected. A callback that never answers leaves `Citizen.Await` waiting forever instead of erroring after 15 seconds.

Tested locally on artifact 25770 against this branch. Printed straight from a fresh promise on the running server:

```
promise pending state -> 0 (number)
promise == 'pending'  -> false
promise == 0          -> true
```

Regression case measured as well: a promise that is answered in time reaches state 3, and the corrected guard leaves it alone.

This replaces #1818, which was opened against `dev` before I got the answer on Discord that contributions should target the branch that becomes the next release.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.