### PR TITLE
fix(es_extended/server/main): add the weapon before restoring its tint and components

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -474,6 +474,9 @@ if not Config.CustomInventory then
             local weaponComponents = ESX.Table.Clone(weapon.components)
             local weaponTint = weapon.tintIndex
 
+            sourceXPlayer.removeWeapon(itemName)
+            targetXPlayer.addWeapon(itemName, itemCount)
+
             if weaponTint then
                 targetXPlayer.setWeaponTint(itemName, weaponTint)
             end
@@ -483,9 +486,6 @@ if not Config.CustomInventory then
                     targetXPlayer.addWeaponComponent(itemName, v)
                 end
             end
-
-            sourceXPlayer.removeWeapon(itemName)
-            targetXPlayer.addWeapon(itemName, itemCount)
 
             if weaponObject.ammo and itemCount > 0 then
                 local ammoLabel = weaponObject.ammo.label


### PR DESCRIPTION
Giving a weapon to another player loses its tint and its attachments.

`esx:giveInventoryItem` calls `setWeaponTint` and `addWeaponComponent` on the target before `addWeapon`. Both of those look the weapon up on the target through `getWeapon` and return early when it is not there, and the handler has already bailed out earlier if the target did have the weapon. So at the moment they run, the target never has it, and both are guaranteed no-ops. The weapon arrives clean and the source player's tint and attachments are gone with it.

The pickup path in the same file already does it the other way around, add first and then restore, which is where the correct order comes from.

Tested locally on artifact 25770 by logging the return of both calls:
- give order: both calls false, result `tint=0 components=[]`
- pickup order: both calls true, result `tint=1 components=[clip_extended]`

To be upfront about the limit: this was measured on the mechanism, not with two connected clients, so the end to end hand-over between two real players is not part of the evidence.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.