### PR TITLE
fix(esx_inventory/client): stop overloading the menu usable flag

### DIFF
--- a/[core]/esx_inventory/client/main.lua
+++ b/[core]/esx_inventory/client/main.lua
@@ -4,7 +4,8 @@
 ---@field icon string
 ---@field count number
 ---@field value string
----@field usable boolean
+---@field canUse boolean?
+---@field usable boolean?
 ---@field rare boolean
 ---@field canRemove boolean
 ---@field unselectable boolean?
@@ -34,7 +35,6 @@ local function appendAccounts(elements)
                 icon = "fas fa-money-bill-wave",
                 count = account.money,
                 value = account.name,
-                usable = false,
                 rare = false,
                 canRemove = canDrop
             }
@@ -56,7 +56,7 @@ local function appendItems(elements)
                 icon = "fas fa-box",
                 count = item.count,
                 value = item.name,
-                usable = item.usable,
+                canUse = item.usable,
                 rare = item.rare,
                 canRemove = item.canRemove
             }
@@ -83,7 +83,6 @@ local function appendLoadout(elements)
             icon = "fas fa-gun",
             count = 1,
             value = weapon.name,
-            usable = false,
             rare = false,
             ammo = ammo,
             canGiveAmmo = (weapon.ammo ~= nil),
@@ -119,7 +118,7 @@ end
 ---@return table
 local function buildItemActionMenu(selected, playerNearby)
     local elements2 = {}
-    if selected.usable then
+    if selected.canUse then
         elements2[#elements2 + 1] = { action = "use", label = TranslateCap("use"), icon = "fas fa-utensils", type = selected.type, value = selected.value }
     end
     if selected.canRemove then


### PR DESCRIPTION
The default inventory does not react to Enter on any row.

`esx_menu_default` uses `usable` to mean "this row can be confirmed", alongside `unselectable` which skips the row while navigating. `esx_inventory` fills the same field with a different meaning, "this item has a use callback", and sets it to false for accounts, weapons and every non consumable item. The menu then refuses to open the action submenu for those rows, so money, weapons and most items do nothing at all.

Fixed on the Lua side by moving the item flag to its own name, `canUse`, and leaving `usable` alone. No change to the menu bundle. The weight row keeps `usable = false` on purpose, that one really is not meant to be confirmable.

Tested locally on artifact 25770, in game:
- before: Enter on cash and on bread did nothing
- after: cash offers Throw and Return, bank offers only Return since it cannot be dropped, bread offers Throw and Return without Use, and the Current Weight row is still not selectable

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.