### PR TITLE
fix(es_extended/shared): return false instead of raising on invalid utf8

### DIFF
--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -186,6 +186,10 @@ function ESX.IsValidLocaleString(str, allowDigits)
         return false
     end
 
+    if not utf8.len(str) then
+        return false
+    end
+
     local locale = string.lower(Config.Locale)
 
     local defaultRanges ={


### PR DESCRIPTION
`ESX.IsValidLocaleString` is annotated `@return boolean` but raises on invalid UTF-8 input.

`utf8.codes` throws when it hits a malformed byte sequence, and the loop calls it without any guard. Callers that treat the function as a predicate get an error instead of false. Through `esx_identity:registerIdentity` this is reachable from a modified client: the callback aborts and the player is left sitting in the identity screen.

Fixed with an early `utf8.len` check, which returns nil for malformed input instead of raising.

Tested locally on artifact 25770 against this branch:
- before: a string with a lone `\xAD` byte gave `pcall ok=false`, server log `SCRIPT ERROR: @es_extended/shared/functions.lua:237: invalid UTF-8 code`
- after: the same string returns false

Regression cases, unchanged in both runs: `John` true, `Jo!hn` false, `Jo3hn` with allowDigits true.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.