### PR TITLE
fix(es_extended/shared): stop reseeding the random generator on every call

### DIFF
--- a/[core]/es_extended/shared/functions.lua
+++ b/[core]/es_extended/shared/functions.lua
@@ -23,8 +23,6 @@ end)
 ---@param length number
 ---@return string
 function ESX.GetRandomString(length)
-    math.randomseed(GetGameTimer())
-
     return length > 0 and ESX.GetRandomString(length - 1) .. Charset[math.random(1, #Charset)] or ""
 end
 

--- a/[core]/es_extended/shared/modules/math.lua
+++ b/[core]/es_extended/shared/modules/math.lua
@@ -32,7 +32,6 @@ end
 ---@param maxRange number
 ---@return number
 function ESX.Math.Random(minRange, maxRange)
-    math.randomseed(GetGameTimer())
     return math.random(minRange or 1, maxRange or 10)
 end
 


### PR DESCRIPTION
`ESX.Math.Random` and `ESX.GetRandomString` reseed with `GetGameTimer()` on every call, which makes them return the same value repeatedly.

The game timer only advances once per frame, so every call within the same tick reseeds to the identical value and gets the identical result back. It also resets the global Lua generator, so any other resource drawing a random number in that tick is affected too.

Fixed by removing both reseed calls. The runtime already seeds the generator at startup.

Tested locally on artifact 25770 against this branch, six numbers and two strings drawn in one command:
- before: `1,1,1,1,1,1` and the same string twice, `0JhFxxPm` / `0JhFxxPm`
- after, first run: `66,2,73,62,6,62`, strings `ZfMPR8mv` / `C0lumUTy`
- after, second run: `26,24,68,12,61,60`, strings `wj5EfPCG` / `a0gdCVrg`

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.