### PR TITLE
fix(esx_multicharacter/client): act on the local player in HideHud

### DIFF
--- a/[core]/esx_multicharacter/client/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/client/modules/multicharacter.lua
@@ -59,9 +59,9 @@ local function HideComponents(hide)
 end
 
 function Multicharacter:HideHud(hide)
-    self.hidePlayers = true
+    self.hidePlayers = hide
 
-    MumbleSetVolumeOverride(ESX.PlayerId, 0.0)
+    MumbleSetVolumeOverride(ESX.playerId, hide and 0.0 or -1.0)
     HideComponents(hide)
 end
 
@@ -77,7 +77,7 @@ function Multicharacter:SetupCharacters()
     SetEntityCoords(self.playerPed, self.spawnCoords.x, self.spawnCoords.y, self.spawnCoords.z, true, false, false, false)
     SetEntityHeading(self.playerPed, self.spawnCoords.w)
 
-    SetPlayerControl(ESX.PlayerId, false, 0)
+    SetPlayerControl(ESX.playerId, false, 0)
     self:SetupCamera()
     self:HideHud(true)
 


### PR DESCRIPTION
`HideHud` uses `ESX.PlayerId`, which does not exist. The rest of the file correctly uses `ESX.playerId`.

Passing nil to a native that wants a player index makes it fall through to index 0, so `SetPlayerControl` and `MumbleSetVolumeOverride` act on whoever happens to be player 0 rather than on the local player. On top of that `HideHud` ignores its own `hide` argument and always sets `hidePlayers = true`, and the volume override is never released, so voice stays muted after the character is picked.

Fixed by using the existing `ESX.playerId`, honouring the argument, and restoring the override with -1.0 when unhiding.

Tested locally on artifact 25770, in game: with `ESX.PlayerId` the control state stayed on, with `ESX.playerId` movement is blocked during character selection and free again after spawning.

To be upfront about the limit: the voice part is not runtime tested, that would need a second connected player. It is included because -1.0 is the documented way to clear the override and the current code never clears it at all.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.