### PR TITLE
fix(esx_multicharacter/client): restore the stored height of hidden hud components

### DIFF
--- a/[core]/esx_multicharacter/client/modules/multicharacter.lua
+++ b/[core]/esx_multicharacter/client/modules/multicharacter.lua
@@ -50,7 +50,7 @@ local function HideComponents(hide)
         else
             if HiddenCompents[components[i]] then
                 local size = HiddenCompents[components[i]]
-                SetHudComponentSize(components[i], size.x, size.z)
+                SetHudComponentSize(components[i], size.x, size.y)
                 HiddenCompents[components[i]] = nil
             end
         end


### PR DESCRIPTION
Hud components hidden during character selection never come back.

`HideComponents` stores the size as `x` and `y` and checks both when hiding, but restores with `size.x, size.z`. A vector2 from `GetHudComponentSize` has no meaningful z, so the height is restored as 0 and the component stays invisible for the rest of the session.

Fixed by restoring `size.y`, the value that was stored.

Tested locally on artifact 25770, in game, components 11 and 12 measured right after character selection:
- before: `x=0.218 y=0.000`
- after: `x=0.218 y=0.389`

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.