### PR TITLE
fix(esx_lib/points): keep the points loop alive when a callback errors

### DIFF
--- a/[core]/esx_lib/imports/points/client.lua
+++ b/[core]/esx_lib/imports/points/client.lua
@@ -50,8 +50,11 @@ function xLib.points.startLoop()
         while true do
             local coords = GetEntityCoords(PlayerPedId())
 
-            for _, point in pairs(insidePoints) do
-                point.inside(#(coords - point.coords))
+            for handle, point in pairs(insidePoints) do
+                if not pcall(point.inside, #(coords - point.coords)) then
+                    insidePoints[handle] = nil
+                    print(("[^1ERROR^7] point ^5%s^7 from ^5%s^7 errored on inside"):format(handle, point.resource))
+                end
             end
 
             local now = GetGameTimer()
@@ -63,8 +66,8 @@ function xLib.points.startLoop()
                         if not point.nearby then
                             point.nearby = true
 
-                            if point.enter then
-                                point.enter()
+                            if point.enter and not pcall(point.enter) then
+                                print(("[^1ERROR^7] point ^5%s^7 from ^5%s^7 errored on enter"):format(handle, point.resource))
                             end
 
                             if point.inside then
@@ -74,8 +77,8 @@ function xLib.points.startLoop()
                     elseif point.nearby then
                         point.nearby = false
 
-                        if point.leave then
-                            point.leave()
+                        if point.leave and not pcall(point.leave) then
+                            print(("[^1ERROR^7] point ^5%s^7 from ^5%s^7 errored on leave"):format(handle, point.resource))
                         end
 
                         insidePoints[handle] = nil


### PR DESCRIPTION
Every point from every resource is served by one shared thread, and `enter`, `leave` and `inside` are all invoked bare. A Lua error in any one of them terminates that coroutine, and nothing restarts it, `startLoop` only runs once from the spawn handler in es_extended.

So one faulty third party resource takes down point detection for the whole client. Shops, garages and job markers stop reacting, with no hint beyond a single stack trace, until the player reconnects.

`inside` is the worst of the three because it runs every frame while the player stands in the point, so a broken one is also dropped from `insidePoints`. Without that the guard would turn a dead thread into a console flood at framerate. `enter` and `leave` only fire on a transition, so they stay registered.

Tested in game on artifact 25770 with three points created while standing on them: one healthy, one whose `enter` raises, one whose `inside` raises.

Before:

```
[TEST] GESUND enter
SCRIPT ERROR: attempt to index a nil value (local 't')
> fn (@esx_lib/imports/points/client.lua:67)
```

and then nothing at all. No `leave` when walking away, and points created afterwards never fired `enter` either.

After:

```
[TEST] GESUND enter
[ERROR] point 2 from pointdrop_test errored on enter
[TEST] INSIDE-PUNKT enter
[ERROR] point 3 from pointdrop_test errored on inside
[TEST] GESUND leave
[TEST] KAPUTT leave
[TEST] INSIDE-PUNKT leave
```

All three fired `leave`, points created afterwards worked normally, and the `inside` failure printed once rather than every frame.

The runtime already prints the error and its stack, so the added line only names the point and the resource it came from.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.