### PR TITLE
perf(es_extended/client): only look up the closest player when the pickup prompt is used

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -372,7 +372,6 @@ if not Config.CustomInventory then
         while true do
             local Sleep = 1500
             local playerCoords = GetEntityCoords(ESX.PlayerData.ped)
-            local _, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
 
             for pickupId, pickup in pairs(pickups) do
                 local distance = #(playerCoords - pickup.coords)
@@ -383,6 +382,8 @@ if not Config.CustomInventory then
 
                     if distance < 1 then
                         if IsControlJustReleased(0, 38) then
+                            local _, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
+
                             if IsPedOnFoot(ESX.PlayerData.ped) and (closestDistance == -1 or closestDistance > 3) and not pickup.inRange then
                                 pickup.inRange = true
 


### PR DESCRIPTION
The pickup loop calls `ESX.Game.GetClosestPlayer` at the top of every iteration, but `closestDistance` is only read inside the nested check that runs when the player presses the pickup control right next to a drop. As soon as any pickup is within five metres the loop sets `Sleep` to 0, so that lookup runs every frame while standing near a drop.

`GetClosestPlayer` builds two tables and calls `GetPlayers` plus `GetPlayerPed`, `DoesEntityExist` and `GetEntityCoords` per player, so the cost grows with the number of players in scope, worst exactly when the server is busy.

Measured in game on artifact 25770 with a single player standing on a dropped pickup, reading `es_extended` in the resource monitor over about 20 seconds each:

| | es_extended |
|---|---|
| before | 0.16 - 0.18 ms, sitting around 0.17 |
| after | 0.13 - 0.15 ms, sitting around 0.14 |

The two ranges do not overlap. Idle, with no pickup within five metres, is 0.04 ms in both cases, as expected, since the loop sleeps 1500 ms then.

One player is the smallest saving this can ever show, because `GetClosestPlayer` scales with the number of players in scope. The larger saving on a populated server follows from that per player work and is **not** measured here, that would need several clients.

Behaviour is unchanged, the value is computed in the same frame it is used.

- [x] My commit messages and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally and function as expected.
- [x] My PR does not introduce any breaking changes.
- [x] I have provided a clear explanation of what my PR does.