### PR TITLE
fix(es_extended/server): skip unspawned players in the bulk save

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -251,18 +251,24 @@ function Core.SavePlayers(cb)
     local parameters = {}
 
     for _, xPlayer in pairs(ESX.Players) do
-        updateHealthAndArmorInMetadata(xPlayer)
-        parameters[#parameters + 1] = {
-            json.encode(xPlayer.getAccounts(true)),
-            xPlayer.job.name,
-            xPlayer.job.grade,
-            xPlayer.group,
-            json.encode(xPlayer.getCoords(false, true)),
-            json.encode(xPlayer.getInventory(true)),
-            json.encode(xPlayer.getLoadout(true)),
-            json.encode(xPlayer.getMeta()),
-            xPlayer.identifier,
-        }
+        if xPlayer.spawned then
+            updateHealthAndArmorInMetadata(xPlayer)
+            parameters[#parameters + 1] = {
+                json.encode(xPlayer.getAccounts(true)),
+                xPlayer.job.name,
+                xPlayer.job.grade,
+                xPlayer.group,
+                json.encode(xPlayer.getCoords(false, true)),
+                json.encode(xPlayer.getInventory(true)),
+                json.encode(xPlayer.getLoadout(true)),
+                json.encode(xPlayer.getMeta()),
+                xPlayer.identifier,
+            }
+        end
+    end
+
+    if not parameters[1] then
+        return cb and cb()
     end
 
     MySQL.prepare(


### PR DESCRIPTION
`Core.SavePlayer` already refuses to save a player whose `spawned` flag is not set, because an unspawned player has no server-side ped and `getCoords`/health return 0,0,0 / 0. `Core.SavePlayers`, the bulk autosave that runs every few minutes and on restart/shutdown, had no such guard and saved every player in `ESX.Players`.

A player still in the load or character-selection window when the autosave fires gets their row overwritten with position 0,0,0 and health 0. On the next load the default-spawn fallback does not kick in, since a decoded `{"x":0.0,...}` is truthy, so they spawn at the world origin, and with `SaveDeathStatus` on, dead.

Same guard as the sibling function, and skip the query when no spawned player remains.

Tested on artifact 25770: forced a connected player to `spawned = false` and ran `saveall`. Before, the row was overwritten (the save ran); after, the row was left untouched and no save was issued.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.