### PR TITLE
fix(esx_inventory): let the quantity dialog accept a corrected amount

### DIFF
--- a/[core]/esx_inventory/client/main.lua
+++ b/[core]/esx_inventory/client/main.lua
@@ -146,7 +146,6 @@ local function openQuantityDialog(title, maxCount)
         local qty = tonumber(data.value)
         if not qty or qty <= 0 or qty > maxCount then
             ESX.ShowNotification(TranslateCap("amount_invalid"))
-            p:resolve(nil)
         else
             menu.close()
             p:resolve(qty)


### PR DESCRIPTION
The quantity dialog resolved its promise with `nil` on an invalid amount, so the give/remove had already aborted by the time the player typed a valid value. The dialog stayed open and a corrected amount did nothing.

Dropping the early resolve leaves the promise pending, so the same open dialog accepts the retry and drops/gives the item. Cancel still resolves nil.

Tested on artifact 25770: entered an over-count amount, got "invalid amount", corrected to a valid amount. Before, nothing happened; after, the item dropped. Most visible together with #1826, which is what lets the item action menu open in the first place.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.