### PR TITLE
fix(esx_lib): correct the shared table and string helpers

### DIFF
--- a/[core]/esx_lib/imports/string/shared.lua
+++ b/[core]/esx_lib/imports/string/shared.lua
@@ -47,7 +47,7 @@ end
 function xLib.string.toPascal(s)
     xLib.verify(s, 'string', true)
 
-    local res = s:gsub("(%a)([%w_]*)", function(first, rest)
+    local res = s:gsub("(%a)([%w]*)", function(first, rest)
         return first:upper() .. rest:lower()
     end):gsub("_", "")
 
@@ -113,6 +113,10 @@ end
 ---@return string
 function xLib.string.replace(s, old, new)
     xLib.verify(s, 'string', true)
+
+    if type(new) == "string" then
+        new = new:gsub("%%", "%%%%")
+    end
 
     local result = s:gsub(xLib.string.escapePattern(old), new)
 

--- a/[core]/esx_lib/imports/table/shared.lua
+++ b/[core]/esx_lib/imports/table/shared.lua
@@ -14,13 +14,9 @@ function xLib.table.isArray(tbl)
         end
 
         count, maxIndex = count + 1, math.max(maxIndex, k)
-
-        if count > maxIndex then
-            return false
-        end
     end
 
-    return true
+    return count == maxIndex
 end
 
 ---@param tbl table

--- a/[core]/esx_lib/imports/table/shared.lua
+++ b/[core]/esx_lib/imports/table/shared.lua
@@ -35,13 +35,6 @@ function xLib.table.searchForKey(tbl, item)
 end
 
 ---@param tbl table
----@param item any
----@return boolean
-function xLib.table.contains(tbl, item)
-    return xLib.table.searchForKey(tbl, item) ~= nil
-end
-
----@param tbl table
 ---@param filter fun(value:any, key:any):boolean
 ---@return table
 function xLib.table.filter(tbl, filter)
@@ -118,7 +111,7 @@ function xLib.table.dump(tbl)
         local s = '{ '
         for k,v in pairs(tbl) do
            if type(k) ~= 'number' then k = '"'..k..'"' end
-           s = s .. '['..k..'] = ' .. tbl(v) .. ','
+           s = s .. '['..k..'] = ' .. xLib.table.dump(v) .. ','
         end
         return s .. '} '
      else


### PR DESCRIPTION
Small logic bugs in the `esx_lib` shared helpers, each verified with a standalone Lua run against the shipped files.

**`table.isArray`** returned `true` for sparse tables like `{[1]=1,[3]=3}`. The in-loop `count > maxIndex` check can never fire (with positive integer keys `count` is always `<= maxIndex`), so it was dead code. Dropped it and `return count == maxIndex`, which is false for gaps and still true for a dense sequence or an empty table.

**`table.dump`** called its own table argument as a function:

```lua
s = s .. '['..k..'] = ' .. tbl(v) .. ','
```

So it threw `attempt to call a table value (local 'tbl')` for any table with at least one entry. An empty table still returned `"{ } "` and a non-table still returned `tostring`, which is why it looks fine until you dump something with contents in it. Recursing into `xLib.table.dump(v)` is what the surrounding code expects, and it also gets nested tables right.

**`table.contains`** was defined twice in the same file, once with annotations delegating to `searchForKey` and once further down without. Lua keeps the second one, so the first was unreachable. Removed the unreachable one. The table-argument branch that only the live version has is how I confirmed which of the two was actually in use, and behaviour before and after is identical.

**`string.toPascal`** lowercased the letters after an underscore: `[%w_]*` swallowed the underscore and the next word into the part that gets lowercased, so `"hello_world"` became `"Helloworld"`. Excluding the underscore leaves each word to be capitalised, then the trailing gsub removes the underscores → `"HelloWorld"` (sibling `toCamel` already behaves this way).

**`string.replace`** escaped the pattern but not the replacement, so a `%` in the replacement raised `invalid use of '%' in replacement string` and `%1`-style sequences expanded captures. Escape `%` in a string replacement; a function/table replacement is left untouched.

Verified under standalone Lua 5.4, loading the shipped files rather than retyping them:

- `isArray({[1]=1,[3]=3})` false (was true), dense and empty unchanged
- `dump({a=1})` → `{ ["a"] = 1,}`, `dump({a={b=1}})` → `{ ["a"] = { ["b"] = 1,} ,}` (both were errors), empty table and non-table unchanged
- `contains` returns true/false/true for `2`, `9` and `{3}` against `{1,2,3}` before and after removing the duplicate
- `toPascal("hello_world")` → `"HelloWorld"` (was `"Helloworld"`)
- `replace("price a","a","50%")` → `"price 50%"` (was an error)

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.
