### PR TITLE
fix(es_extended/locale): return a single value from TranslateCap

### DIFF
--- a/[core]/es_extended/locale.lua
+++ b/[core]/es_extended/locale.lua
@@ -33,7 +33,7 @@ function Translate(str, ...) -- Translate string
 end
 
 function TranslateCap(str, ...) -- Translate string first char uppercase
-    return _(str, ...):gsub("^%l", string.upper)
+    return (_(str, ...):gsub("^%l", string.upper))
 end
 
 _ = Translate


### PR DESCRIPTION
`TranslateCap` returns the result of `gsub` directly, and `gsub` returns the string **plus the number of substitutions**. Whenever `TranslateCap` is the last argument of a call, that count is passed along as an extra argument.

The common case is `showNotification(msg, notifyType, ...)`, called with just the message in ~49 places in the core. Those all pass `notifyType = 1` instead of `nil`, so the notification is rendered with a numeric type rather than the intended default. 71 call sites in total have `TranslateCap` in trailing position, e.g.

```lua
xPlayer.showNotification(TranslateCap("commanderror_invalidcommand", commandName))
```

Wrapping the call in parentheses truncates it to one value.

Verified in standalone Lua with the real function body:

```
select('#', TranslateCap("act_imp"))   before = 2      after = 1
showNotification(TranslateCap(...))    before -> notifyType=1   after -> notifyType=nil
TranslateCap(...) not in last position  unchanged in both
returned string identical               true
```

Nothing in the core reads the second value.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.