### PR TITLE
fix(cron): keep the scheduler alive when a job errors

### DIFF
--- a/[core]/cron/server/main.lua
+++ b/[core]/cron/server/main.lua
@@ -38,7 +38,10 @@ function OnTime(timestamp)
 
         if timestamp >= scheduledTimestamp and (not lastTimestamp or lastTimestamp < scheduledTimestamp) then
             local d = os.date('*t', scheduledTimestamp).wday
-            cronJobs[i].cb(d, cronJobs[i].h, cronJobs[i].m)
+
+            if not pcall(cronJobs[i].cb, d, cronJobs[i].h, cronJobs[i].m) then
+                print(("[^1ERROR^7] cron job at ^5%02d:%02d^7 errored, skipping it"):format(cronJobs[i].h, cronJobs[i].m))
+            end
         end
     end
 end


### PR DESCRIPTION
Registered jobs are third party callbacks and were invoked bare:

```lua
cronJobs[i].cb(d, cronJobs[i].h, cronJobs[i].m)
```

An error inside one propagates out of `OnTime` into `Tick`, so `Tick` never reaches its `SetTimeout(60000, Tick)` at the end and nothing reschedules it. From that moment **cron is dead for every resource on the server** — paychecks, cleanups, anything registered through `cron:runAt` — until a restart. The operator sees one stack trace and then silence.

Wrapping the callback keeps the loop and the reschedule intact, and names the job that failed.

Simulated the scheduler chain in standalone Lua with three jobs where the first raises:

```
before:  tick died -> SetTimeout never reached | later jobs fired: NONE
after:   job 01:01 errored (caught)            | later jobs fired: 01:02, 01:03
```

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.