### PR TITLE
fix(esx_menu_dialog, esx_menu_list): do not grab NUI focus after the menu closed

### DIFF
--- a/[core]/esx_menu_dialog/client/main.lua
+++ b/[core]/esx_menu_dialog/client/main.lua
@@ -1,10 +1,6 @@
-local Timeouts, OpenedMenus, MenuType = {}, {}, "dialog"
+local OpenedMenus, MenuType = {}, "dialog"
 
 local function openMenu(namespace, name, data)
-    for i = 1, #Timeouts, 1 do
-        ESX.ClearTimeout(Timeouts[i])
-    end
-
     OpenedMenus[namespace .. "_" .. name] = true
 
     SendNUIMessage({
@@ -14,13 +10,11 @@ local function openMenu(namespace, name, data)
         data = data,
     })
 
-    local timeoutId = ESX.SetTimeout(200, function()
+    ESX.SetTimeout(200, function()
         if next(OpenedMenus) then
             SetNuiFocus(true, true)
         end
     end)
-
-    table.insert(Timeouts, timeoutId)
 end
 
 local function closeMenu(namespace, name)

--- a/[core]/esx_menu_dialog/client/main.lua
+++ b/[core]/esx_menu_dialog/client/main.lua
@@ -15,7 +15,9 @@ local function openMenu(namespace, name, data)
     })
 
     local timeoutId = ESX.SetTimeout(200, function()
-        SetNuiFocus(true, true)
+        if next(OpenedMenus) then
+            SetNuiFocus(true, true)
+        end
     end)
 
     table.insert(Timeouts, timeoutId)

--- a/[core]/esx_menu_list/client/main.lua
+++ b/[core]/esx_menu_list/client/main.lua
@@ -12,7 +12,9 @@ CreateThread(function()
             data = data,
         })
         SetTimeout(200, function()
-            SetNuiFocus(true, true)
+            if next(OpenedMenus) then
+                SetNuiFocus(true, true)
+            end
         end)
     end
 


### PR DESCRIPTION
Opening a menu schedules `SetNuiFocus(true, true)` 200 ms later so the NUI has time to render. Closing sets the focus off but does not cancel that timer, so a menu closed within those 200 ms leaves the timer to fire afterwards and turn the focus back on with nothing open: the player gets a cursor and loses movement and input until another menu is opened and closed. `esx_menu_list` never stored the timer id at all, so it could not be cancelled in any case.

Checking inside the callback whether a menu is still open fixes both, and also covers a quick open-close-open where cancelling by id would drop a focus that is still wanted. `esx_menu_default` is unaffected, it has no timer.

Tested on artifact 25770 with a dialog closed 50 ms after opening, reading `IsNuiFocused()` 600 ms later:

```
before:  false, 1, 1     (focus stuck, cursor on screen, input blocked)
after:   false, false, false
```

With the callback guarding itself, the id bookkeeping in `esx_menu_dialog` has nothing left to do, so it is gone too. It was leaking anyway. The table holding the ids was never emptied, so every open walked every id ever created:

```lua
for i = 1, #Timeouts, 1 do
    ESX.ClearTimeout(Timeouts[i])
end
```

`clearTimeout` only writes into xLib's `CancelledTimeouts`, and that entry is removed when the timer fires and sees it. Ids that had already fired never fire again, so their entries stay for the rest of the session, in a table every resource using `ESX.SetTimeout` shares.

Measured by driving the shipped `openMenu` against the shipped `xLib.timeout`, opening and closing a dialog 60 times:

| opens | ClearTimeout calls | ids kept | CancelledTimeouts |
|---|---|---|---|
| 10 | 45 | 10 | 9 |
| 30 | 435 | 30 | 29 |
| 60 | 1770 | 60 | 59 |

All three are zero afterwards, at any number of opens. The three focus cases above still behave the same: closed inside 200 ms leaves the focus alone, a menu left open gets it, and open-close-open gets it.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.
