### PR TITLE
fix(es_extended/server/functions): reject invalid weapon arguments instead of raising

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -122,8 +122,10 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
                                     err = TranslateCap("commanderror_invaliditem")
                                 end
                             elseif v.type == "weapon" then
-                                if pcall(ESX.GetWeapon, args[k]) then
-                                    newArgs[v.name] = string.upper(args[k])
+                                local weapon = ESX.GetWeaponFromHash(args[k])
+
+                                if weapon then
+                                    newArgs[v.name] = weapon.name
                                 else
                                     err = TranslateCap("commanderror_invalidweapon")
                                 end

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -122,7 +122,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
                                     err = TranslateCap("commanderror_invaliditem")
                                 end
                             elseif v.type == "weapon" then
-                                if ESX.GetWeapon(args[k]) then
+                                if pcall(ESX.GetWeapon, args[k]) then
                                     newArgs[v.name] = string.upper(args[k])
                                 else
                                     err = TranslateCap("commanderror_invalidweapon")


### PR DESCRIPTION
The `weapon` argument type checks a command argument with `ESX.GetWeapon`, but that function asserts on an unknown name and upper-cases its argument before doing anything else. It can never return a falsy value, so the `else` branch that sets `commanderror_invalidweapon` is dead code, and a typo raises a Lua error in the console instead of telling the admin what was wrong.

Commands registered with `validate = false`, such as `/giveammo`, skip the argument count check and reach `string.upper(nil)`, which raises as well.

Calling it through `pcall` makes both cases take the error branch that was already written for them. Valid names, including lower case, behave as before.

Measured on artifact 25770 over RCON:

```
before:  giveweapon 1 WEAPON_PISTOI 50 -> SCRIPT ERROR ... Invalid weapon name!
         giveammo 1                    -> SCRIPT ERROR ... bad argument #1 to 'upper'
after:   neither errors, both rejected with the invalid weapon message
         giveweapon 1 WEAPON_PISTOL 50 works in both
```

Affects `/giveweapon`, `/giveammo` and `/giveweaponcomponent`.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.