### PR TITLE
fix(esx_progressbar): honour the requested duration and ignore cancelled runs

### DIFF
--- a/[core]/esx_progressbar/Progress.lua
+++ b/[core]/esx_progressbar/Progress.lua
@@ -9,11 +9,12 @@
 ---@field public onFinish? function
 
 local CurrentProgress = nil
+local progressCount = 0
 
-local function startProcessing()
-    while (CurrentProgress ~= nil) do
-        if CurrentProgress.length > 0 then
-            CurrentProgress.length = CurrentProgress.length - 1000
+local function startProcessing(id)
+    while CurrentProgress ~= nil and CurrentProgress.id == id do
+        if GetGameTimer() < CurrentProgress.finishAt then
+            Wait(50)
         else
             ClearPedTasks(ESX.PlayerData.ped)
             if CurrentProgress.FreezePlayer then
@@ -24,7 +25,6 @@ local function startProcessing()
             end
             CurrentProgress = nil
         end
-        Wait(1000)
     end
 end
 
@@ -55,8 +55,15 @@ local function Progressbar(message, length, Options)
         length = length or 3000,
         message = message or "ESX-Framework",
     })
+    progressCount = progressCount + 1
+    CurrentProgress.id = progressCount
     CurrentProgress.length = length or 3000
-    CreateThread(startProcessing);
+    CurrentProgress.finishAt = GetGameTimer() + CurrentProgress.length
+
+    local id = progressCount
+    CreateThread(function()
+        startProcessing(id)
+    end)
     return true;
 end
 


### PR DESCRIPTION
The processing thread counted the remaining time down in 1000 ms steps and read the global `CurrentProgress` on every wake, which caused two problems.

**Durations are rounded up to the next whole second.** The thread only checks after another full second, so a 500 ms bar takes 1000 ms and a 4200 ms bar takes 5000 ms. The NUI bar runs on wall clock time, so it visibly completes and the player then stands frozen waiting for `onFinish`.

**Cancelling does not stop the thread.** `CancelProgressbar` clears `CurrentProgress`, but the sleeping thread only notices up to a second later. If a new bar was started in that window it sees a non-nil `CurrentProgress` and keeps decrementing the new one alongside its own thread, so the new bar finishes at roughly half its length and `onFinish` fires early — the reward lands before the animation is done.

The run now carries an id, so a thread stops as soon as its run is no longer the current one, and the end is an absolute timestamp instead of a countdown.

Measured in game on artifact 25770, requested vs actual `onFinish`:

```
before:  500 -> 1011 (+511)   4200 -> 5042 (+842)   cancel then 3000 -> 1427 (-1573)
after:   500 ->  519 (+19)    4200 -> 4222 (+22)    cancel then 3000 -> 3058 (+58)
```

The remaining few tens of ms are the 50 ms poll interval.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.