### PR TITLE
fix(esx_lib/streaming): give asset requests a timeout

### DIFF
--- a/[core]/esx_lib/imports/streaming/client.lua
+++ b/[core]/esx_lib/imports/streaming/client.lua
@@ -34,8 +34,9 @@ end
 
 ---@param modelHash number | string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return number | nil
-xLib.streaming.requestModel = function(modelHash, cb)
+xLib.streaming.requestModel = function(modelHash, cb, timeout)
     modelHash = type(modelHash) == "number" and modelHash or joaat(modelHash)
 
     if not IsModelInCdimage(modelHash) then return end
@@ -46,7 +47,7 @@ xLib.streaming.requestModel = function(modelHash, cb)
 
 	RequestModel(modelHash)
 
-	if not waitForLoaded(function() return HasModelLoaded(modelHash) end) then
+	if not waitForLoaded(function() return HasModelLoaded(modelHash) end, timeout) then
 		return
 	end
 
@@ -55,15 +56,16 @@ end
 
 ---@param textureDict string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | nil
-xLib.streaming.requestStreamedTextureDict = function(textureDict, cb)
+xLib.streaming.requestStreamedTextureDict = function(textureDict, cb, timeout)
 	if HasStreamedTextureDictLoaded(textureDict) then
 		return ret(cb, textureDict)
 	end
 
 	RequestStreamedTextureDict(textureDict, false)
 
-	if not waitForLoaded(function() return HasStreamedTextureDictLoaded(textureDict) end) then
+	if not waitForLoaded(function() return HasStreamedTextureDictLoaded(textureDict) end, timeout) then
 		return
 	end
 
@@ -72,15 +74,16 @@ end
 
 ---@param assetName string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | nil
-xLib.streaming.requestNamedPtfxAsset = function(assetName, cb)
+xLib.streaming.requestNamedPtfxAsset = function(assetName, cb, timeout)
 	if HasNamedPtfxAssetLoaded(assetName) then
 		return ret(cb, assetName)
 	end
 
 	RequestNamedPtfxAsset(assetName)
 
-	if not waitForLoaded(function() return HasNamedPtfxAssetLoaded(assetName) end) then
+	if not waitForLoaded(function() return HasNamedPtfxAssetLoaded(assetName) end, timeout) then
 		return
 	end
 
@@ -89,15 +92,16 @@ end
 
 ---@param animSet string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | nil
-xLib.streaming.requestAnimSet = function(animSet, cb)
+xLib.streaming.requestAnimSet = function(animSet, cb, timeout)
 	if HasAnimSetLoaded(animSet) then
 		return ret(cb, animSet)
 	end
 
 	RequestAnimSet(animSet)
 
-	if not waitForLoaded(function() return HasAnimSetLoaded(animSet) end) then
+	if not waitForLoaded(function() return HasAnimSetLoaded(animSet) end, timeout) then
 		return
 	end
 
@@ -106,15 +110,16 @@ end
 
 ---@param animDict string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | nil
-xLib.streaming.requestAnimDict = function(animDict, cb)
+xLib.streaming.requestAnimDict = function(animDict, cb, timeout)
 	if HasAnimDictLoaded(animDict) then
 		return ret(cb, animDict)
 	end
 
 	RequestAnimDict(animDict)
 
-	if not waitForLoaded(function() return HasAnimDictLoaded(animDict) end) then
+	if not waitForLoaded(function() return HasAnimDictLoaded(animDict) end, timeout) then
 		return
 	end
 
@@ -123,15 +128,16 @@ end
 
 ---@param weaponHash number | string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | number | nil
-xLib.streaming.requestWeaponAsset = function(weaponHash, cb)
+xLib.streaming.requestWeaponAsset = function(weaponHash, cb, timeout)
 	if HasWeaponAssetLoaded(weaponHash) then
 		return ret(cb, weaponHash)
 	end
 
 	RequestWeaponAsset(weaponHash, 31, 0)
 
-	if not waitForLoaded(function() return HasWeaponAssetLoaded(weaponHash) end) then
+	if not waitForLoaded(function() return HasWeaponAssetLoaded(weaponHash) end, timeout) then
 		return
 	end
 
@@ -140,11 +146,12 @@ end
 
 ---@param bankName string
 ---@param cb? function
+---@param timeout? number milliseconds to wait, defaults to 5000
 ---@return string | nil
-xLib.streaming.requestAudioBank = function(bankName, cb)
+xLib.streaming.requestAudioBank = function(bankName, cb, timeout)
     RequestAudioBank(bankName, false)
 
-    if not waitForLoaded(function() return RequestScriptAudioBank(bankName, false) end) then
+    if not waitForLoaded(function() return RequestScriptAudioBank(bankName, false) end, timeout) then
         return
     end
 

--- a/[core]/esx_lib/imports/streaming/client.lua
+++ b/[core]/esx_lib/imports/streaming/client.lua
@@ -1,6 +1,37 @@
 ---@class streaminglib
 xLib.streaming = {}
 
+local StreamTimeoutMs = 5000
+local StreamWaitStepMs = 50
+
+---@param cond fun():boolean
+---@param timeout? number
+---@param step? number
+---@return boolean loaded false on timeout
+local function waitForLoaded(cond, timeout, step)
+	local start = GetGameTimer()
+	local limit = timeout or StreamTimeoutMs
+	local step_ = step or StreamWaitStepMs
+
+	while not cond() do
+		if GetGameTimer() - start >= limit then
+			return false
+		end
+
+		Wait(step_)
+	end
+
+	return true
+end
+
+---@generic T
+---@param cb? fun(val: T): any
+---@param val T
+---@return T | any
+local function ret(cb, val)
+	return cb and cb(val) or val
+end
+
 ---@param modelHash number | string
 ---@param cb? function
 ---@return number | nil
@@ -9,76 +40,115 @@ xLib.streaming.requestModel = function(modelHash, cb)
 
     if not IsModelInCdimage(modelHash) then return end
 
-	RequestModel(modelHash)
-	while not HasModelLoaded(modelHash) do Wait(500) end
+	if HasModelLoaded(modelHash) then
+		return ret(cb, modelHash)
+	end
 
-	return cb and cb(modelHash) or modelHash
+	RequestModel(modelHash)
+
+	if not waitForLoaded(function() return HasModelLoaded(modelHash) end) then
+		return
+	end
+
+	return ret(cb, modelHash)
 end
 
 ---@param textureDict string
 ---@param cb? function
 ---@return string | nil
 xLib.streaming.requestStreamedTextureDict = function(textureDict, cb)
+	if HasStreamedTextureDictLoaded(textureDict) then
+		return ret(cb, textureDict)
+	end
+
 	RequestStreamedTextureDict(textureDict, false)
 
-	while not HasStreamedTextureDictLoaded(textureDict) do Wait(500) end
+	if not waitForLoaded(function() return HasStreamedTextureDictLoaded(textureDict) end) then
+		return
+	end
 
-	return cb and cb(textureDict) or textureDict
+	return ret(cb, textureDict)
 end
 
 ---@param assetName string
 ---@param cb? function
 ---@return string | nil
 xLib.streaming.requestNamedPtfxAsset = function(assetName, cb)
+	if HasNamedPtfxAssetLoaded(assetName) then
+		return ret(cb, assetName)
+	end
+
 	RequestNamedPtfxAsset(assetName)
 
-	while not HasNamedPtfxAssetLoaded(assetName) do Wait(500) end
+	if not waitForLoaded(function() return HasNamedPtfxAssetLoaded(assetName) end) then
+		return
+	end
 
-	return cb and cb(assetName) or assetName
+	return ret(cb, assetName)
 end
 
 ---@param animSet string
 ---@param cb? function
 ---@return string | nil
 xLib.streaming.requestAnimSet = function(animSet, cb)
+	if HasAnimSetLoaded(animSet) then
+		return ret(cb, animSet)
+	end
+
 	RequestAnimSet(animSet)
 
-	while not HasAnimSetLoaded(animSet) do Wait(500) end
+	if not waitForLoaded(function() return HasAnimSetLoaded(animSet) end) then
+		return
+	end
 
-	return cb and cb(animSet) or animSet
+	return ret(cb, animSet)
 end
 
 ---@param animDict string
 ---@param cb? function
 ---@return string | nil
 xLib.streaming.requestAnimDict = function(animDict, cb)
+	if HasAnimDictLoaded(animDict) then
+		return ret(cb, animDict)
+	end
+
 	RequestAnimDict(animDict)
 
-	while not HasAnimDictLoaded(animDict) do Wait(500) end
+	if not waitForLoaded(function() return HasAnimDictLoaded(animDict) end) then
+		return
+	end
 
-	return cb and cb(animDict) or animDict
+	return ret(cb, animDict)
 end
 
 ---@param weaponHash number | string
 ---@param cb? function
 ---@return string | number | nil
 xLib.streaming.requestWeaponAsset = function(weaponHash, cb)
+	if HasWeaponAssetLoaded(weaponHash) then
+		return ret(cb, weaponHash)
+	end
+
 	RequestWeaponAsset(weaponHash, 31, 0)
 
-	while not HasWeaponAssetLoaded(weaponHash) do Wait(500) end
+	if not waitForLoaded(function() return HasWeaponAssetLoaded(weaponHash) end) then
+		return
+	end
 
-	return cb and cb(weaponHash) or weaponHash
+	return ret(cb, weaponHash)
 end
 
 ---@param bankName string
 ---@param cb? function
 ---@return string | nil
 xLib.streaming.requestAudioBank = function(bankName, cb)
-    RequestAudioBank(bankName, false) 
+    RequestAudioBank(bankName, false)
 
-    while not RequestScriptAudioBank(bankName, false) do Wait(500) end
+    if not waitForLoaded(function() return RequestScriptAudioBank(bankName, false) end) then
+        return
+    end
 
-    return cb and cb(bankName) or bankName
+    return ret(cb, bankName)
 end
 
 


### PR DESCRIPTION
Every request function loops `while not HasXLoaded(...) do Wait(500) end` and never gives up. A misspelled or unavailable anim dict, texture dict or ptfx asset makes that loop run forever, so the calling coroutine never returns. `esx_progressbar` waits on `RequestAnimDict`, so a bad dict there leaves the player stuck. A not yet loaded asset also costs at least 500 ms, since the first check always fails.

`dev` fixed this in 0f5f6a6b with a `waitForLoaded` helper: 5000 ms timeout, 50 ms step, and a shortcut when the asset is already loaded. It was not carried over when the module moved into `esx_lib`, so `v1.14.1` and `main` still run the old code. This ports it and does the same for `requestAudioBank`, which `dev` does not have.

Callers already deal with nil. `requestModel` could always return nil through the `IsModelInCdimage` guard, and `esx_multicharacter` and `spawnVehicle` both check for it.

Measured in game on artifact 25770 with a dict name that does not exist:

```
before:  never returned, still hanging after 8 seconds
after:   returns nil after 5026 ms
```

A valid dict still returns immediately.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.