### PR TITLE
fix(esx_lib/points): start the points loop only once

### DIFF
--- a/[core]/esx_lib/imports/points/client.lua
+++ b/[core]/esx_lib/imports/points/client.lua
@@ -4,6 +4,7 @@ xLib.points = {}
 local points = {}
 local insidePoints = {}
 local handleCount = 0
+local loopStarted = false
 
 ---@param coords vector3
 ---@param distance number
@@ -44,6 +45,12 @@ function xLib.points.hide(handle, hidden)
 end
 
 function xLib.points.startLoop()
+    if loopStarted then
+        return
+    end
+
+    loopStarted = true
+
     CreateThread(function()
         local lastScan = 0
 


### PR DESCRIPTION
`startLoop` is called from the `esx:playerLoaded` handler in es_extended, which fires again on every character switch, and the loop it creates runs `while true` with no exit. Each relog therefore leaves another points thread running: they all scan the same table, fire the same enter and leave callbacks, and none of them ever stop.

A guard makes a second call a no-op. The loop is meant to live for the resource lifetime, so starting it twice is never right.

Measured in game on artifact 25770, counting scans over four seconds:

```
before:  1.0 -> 2.0 -> 3.0 loops across two relogs
after:   1.0 -> 1.0 -> 1.0
```

Points keep working, the surviving loop is unaffected.

Same root cause as #1844, which fixes the equivalent leak in `Adjustments`. This touches the same file as #1831, but a different part of it, so the two are independent.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.