### PR TITLE
fix(esx_lib/game): keep the secondary colour when the primary is custom

### DIFF
--- a/[core]/esx_lib/imports/game/client.lua
+++ b/[core]/esx_lib/imports/game/client.lua
@@ -462,7 +462,7 @@ function xLib.game.setVehicleProperties(vehicle, props)
         if type(props.color2) == "table" then
             SetVehicleCustomSecondaryColour(vehicle, props.color2[1], props.color2[2], props.color2[3])
         else
-            SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
+            SetVehicleColours(vehicle, type(props.color1) == "number" and props.color1 or colorPrimary, props.color2)
         end
     end
     if props.pearlescentColor ~= nil then


### PR DESCRIPTION
`setVehicleProperties` passes `props.color1` straight into `SetVehicleColours` when the secondary colour comes from the palette:

```lua
SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2)
```

If the primary is a custom RGB colour, the getter stored it as a table, so a table reaches a native that wants a paint index and the call does nothing. The secondary colour is silently lost. Any car sprayed with a custom primary and a palette secondary comes back from storage with the wrong secondary colour.

Falling back to the vehicle's current primary when `props.color1` is not a paint index fixes it. The custom primary was already applied by the block above, so nothing is lost.

Measured in game on artifact 25770, reading properties off a car with a custom red primary and palette secondary 12, then applying them to a second car:

```
before:  color2 came back 0
after:   color2 came back 12
```

The custom primary survives either way, mods and wheels are untouched.

- [x] Conventional Commits.
- [x] Tested locally.
- [x] No breaking changes.
- [x] Clear explanation.