### PR TITLE
fix(es_extended/server/classes/vehicle): keep xVehicle usable after setPlate

### DIFF
--- a/[core]/es_extended/server/classes/vehicle.lua
+++ b/[core]/es_extended/server/classes/vehicle.lua
@@ -154,6 +154,7 @@ Core.vehicleClass = {
 		vehicleData.plate = newPlate
 		Core.vehicles[newPlate] = table.clone(vehicleData)
 		Core.vehicles[oldPlate] = nil
+		self.plate = newPlate
 
 		TriggerEvent("esx:changedExtendedVehiclePlate", vehicleData.plate, oldPlate)
 		Wait(0)


### PR DESCRIPTION
### Description

`setPlate` re-keys `Core.vehicles` from the old plate to the new one, but leaves `self.plate` pointing at the old key. That key was just removed, so `isValid()` fails from then on and the object you called it on is dead, even though `setPlate` returned `true`.

---

### Motivation

Every accessor goes through `isValid()`, so after a successful `setPlate` the whole object stops working:

| after `setPlate("NEW") == true` | before | after |
| --- | --- | --- |
| `self.plate` | `OLDPLATE` | `NEWPLATE` |
| `getEntity()` / `getNetId()` / `getPlate()` / `getOwner()` | `nil` | correct |
| `setProps()` / `setOwner()` / another `setPlate()` | `false` | `true` |
| `delete()` removes the entity | no | yes |
| `delete()` sets `owned_vehicles.stored` | stays `false` | `true` |
| `delete()` clears the `Core.vehicles` entry | no | yes |
| `esx:deletedExtendedVehicle` | never fires | fires |

`delete()` is the worst of it. It bails out early on `Core.vehicles[self.plate] == nil`, so the vehicle is never despawned and `stored` stays `false`. The car is gone from the garage and only SQL brings it back, and the `Core.vehicles` entry leaks on top.

The stored state itself is fine, only the handle is stale. `getFromPlate(newPlate)` right after gives a working object. So a resource that re-plates a vehicle and keeps using the same handle silently loses it, with nothing in the return value to hint at that.

---

### Implementation Details

One line, right after the re-key:

```lua
Core.vehicles[oldPlate] = nil
self.plate = newPlate
```

I checked the class with a harness that loads the shipped file and stubs the natives. 22 assertions over six cases: `delete()` without a prior `setPlate`, every getter and setter, a `setPlate` that fails on the database, a `setPlate` on an already invalid object, `getFromPlate` after a rename, and two handles on the same vehicle. Unpatched it is 21/22 and the one failure is this bug. Patched it is 22/22 with every other path unchanged.

Also ran it in game on the same server: spawned a real vehicle through `ESX.CreateExtendedVehicle`, renamed it, then deleted it.

| after `setPlate("SETPL002") == true` | before | after |
| --- | --- | --- |
| `self.plate` | `SETPL001` | `SETPL002` |
| `isValid()` | `false` | `true` |
| `getEntity()` | returns nothing at all | `144386` |
| `getNetId()` / `getPlate()` / `getOwner()` | nothing | correct |
| `setProps({})` | `false` | `true` |
| `delete()`, vehicle in world | stays | gone |
| `delete()`, `owned_vehicles.stored` | `0` | `1` |
| `delete()`, `Core.vehicles` | entry stays | empty |

The plate on the car changes either way, and so does the database row, which is what makes this easy to miss. `getEntity()` not returning even `nil` is the bare `return` behind `if not self:isValid()`.

---

### Usage Example

```lua
local xVehicle = ESX.GetExtendedVehicleFromPlate("OLDPLATE")

xVehicle:setPlate("NEWPLATE") -- true

xVehicle:getEntity() -- nil before, entity handle after
xVehicle:delete()    -- did nothing before, stores the vehicle after
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
