### PR TITLE
feat(es_extended/server): store extended vehicles on shutdown

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -283,6 +283,32 @@ function Core.SavePlayers(cb)
     )
 end
 
+function Core.StoreVehicles(cb)
+    if not next(Core.vehicles) then
+        return type(cb) == "function" and cb()
+    end
+
+    local parameters = {}
+
+    for plate, vehicleData in pairs(Core.vehicles) do
+        parameters[#parameters + 1] = { plate, vehicleData.owner }
+    end
+
+    MySQL.prepare("UPDATE `owned_vehicles` SET `stored` = true WHERE `plate` = ? AND `owner` = ?", parameters,
+        function(results)
+            if not results then
+                return
+            end
+
+            if type(cb) == "function" then
+                return cb()
+            end
+
+            print(("[^2INFO^7] Stored ^5%s^7 %s"):format(#parameters, #parameters > 1 and "vehicles" or "vehicle"))
+        end
+    )
+end
+
 ESX.GetPlayers = GetPlayers
 
 local function checkTable(key, val, xPlayer, xPlayers, minimal)

--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -745,12 +745,14 @@ AddEventHandler("txAdmin:events:scheduledRestart", function(eventData)
         CreateThread(function()
             Wait(50000)
             Core.SavePlayers()
+            Core.StoreVehicles()
         end)
     end
 end)
 
 AddEventHandler("txAdmin:events:serverShuttingDown", function()
     Core.SavePlayers()
+    Core.StoreVehicles()
 end)
 
 local DoNotUse = {


### PR DESCRIPTION
### Description

`ESX.CreateExtendedVehicle` writes `owned_vehicles.stored = false` when a vehicle is spawned, and only `xVehicle:delete()` ever writes it back to `true`. Nothing calls `delete()` on shutdown, so a restart leaves every extended vehicle at `stored = false`.

That row is then unreachable: `Core.vehicleClass.new` selects `WHERE stored = true`, so the vehicle can never be spawned again. The entity is long gone with the restart, and the owner has to fix it with SQL.

---

### Motivation

ESX already has a shutdown path. `txAdmin:events:serverShuttingDown` and `txAdmin:events:scheduledRestart` both call `Core.SavePlayers()`. Vehicles were simply never added to it, even though the flag they depend on is written by ESX itself.

Measured on a local v1.14.1 server with a row in `owned_vehicles` and a matching entry in `Core.vehicles`, firing `txAdmin:events:serverShuttingDown`:

| | `stored` after shutdown |
| --- | --- |
| before | `0` |
| after | `1` |

---

### Implementation Details

`Core.StoreVehicles` mirrors `Core.SavePlayers`: same early return, same batched `MySQL.prepare`, same optional callback and log line. It is called next to `Core.SavePlayers()` in both txAdmin handlers.

The `WHERE plate = ? AND owner = ?` pair means only rows that belong to a vehicle ESX itself spawned get touched. Nothing else in `owned_vehicles` is affected, which matters because third party garage scripts own most of that table on a typical server.

Three regression cases on the same server:

- empty `Core.vehicles` — early return, no query, no error, table untouched
- two vehicles — both go to `stored = 1`
- entry whose owner does not match the row — row stays at `stored = 0` and keeps its owner

This does not cover a crash or a hard kill, where no event fires at all. A startup sweep would, but it cannot tell an ESX row from a third party one, so it would have to touch rows ESX never wrote. Covering the graceful path is the part that can be done safely.

---

### Usage Example

```lua
local xVehicle = ESX.CreateExtendedVehicle(owner, "ABC123", coords)
-- owned_vehicles.stored is now false

-- server restarts via txAdmin
-- before: stored stays false, the vehicle is gone from the garage for good
-- after:  stored is true again and it spawns like normal
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
