### PR TITLE
fix(esx_lib): make the uint check work and remove an unread table

### DIFF
--- a/[core]/esx_lib/imports/interactions/client.lua
+++ b/[core]/esx_lib/imports/interactions/client.lua
@@ -2,7 +2,6 @@
 xLib.interactions = {}
 
 local interactions = {}
-local pressedInteractions = {}
 
 ---@param name string
 function xLib.interactions.remove(name)
@@ -36,7 +35,6 @@ xLib.addKeybind({
         for _, interaction in pairs(interactions) do
             local success, result = pcall(interaction.condition)
             if success and result then
-                pressedInteractions[#pressedInteractions + 1] = interaction
                 interaction.onPress()
             end
         end

--- a/[core]/esx_lib/imports/verify/shared.lua
+++ b/[core]/esx_lib/imports/verify/shared.lua
@@ -81,7 +81,7 @@ local function verifyType(value, valid_type)
     elseif valid_type == 'float' then
         return math.type(value) == 'float'
     elseif valid_type == 'uint' then
-        return math.type(value) == 'int' and value >= 0    
+        return math.type(value) == 'integer' and value >= 0
     elseif valid_type == 'char' then 
         return type(value) == 'string' and #value == 1
     elseif valid_type == 'ped' then 


### PR DESCRIPTION
### Description

Two small defects in `esx_lib`, both in ESX's own code rather than anything inherited from ox_lib.

`xLib.verify(value, 'uint')` can never be true. `math.type` only ever returns `'integer'`, `'float'` or `nil`, and the `'uint'` branch compares against `'int'`. The `'int'` branch two lines above gets it right.

`xLib.interactions` appends every triggered interaction to a `pressedInteractions` table that nothing ever reads.

---

### Motivation

`'uint'` is part of the documented `CustomType` alias, so it shows up in autocomplete for anyone using the library. It matches nothing, and with `throw_error` set it throws on every value, including the ones it is supposed to accept:

```
[xLib] Couldn't match 5 to type uint
```

Loaded the real file under Lua 5.4 and ran 21 assertions. Before: 18/21, the three failures being `verify(5, 'uint')`, `verify(0, 'uint')` and the throwing variant. After: 21/21, with `-3`, `2.5` and `'7'` still rejected and every other type unchanged.

`pressedInteractions` is declared once, written once and read nowhere. A grep over the repo finds those two lines and nothing else. It grows for the lifetime of the session and holds on to the interaction tables, so removed interactions and their callbacks stay reachable.

---

### Implementation Details

```lua
-return math.type(value) == 'int' and value >= 0
+return math.type(value) == 'integer' and value >= 0
```

and the two `pressedInteractions` lines are gone.

Two things I looked at and left alone: `xLib.Raycast:Stop()` and `:IsActive()` share a guard that reads `not self and not self.active`, which would index nil in exactly the case it is written for. But `ESX.Game.StopRaycasting` and `ESX.Game.IsRaycastActive` in `es_extended/client/compat.lua` already check `raycast and raycast.active` before calling through, so that branch cannot be reached from the core and I have no failing case to show. The `event` global in `imports/callback/server.lua` is missing its `local` (the client twin has it), but that file carries the ox_lib licence header and I would rather not touch inherited code in a PR about ESX's own.

---

### Usage Example

```lua
xLib.verify(5, 'uint')        -- false before, true after
xLib.verify(0, 'uint')        -- false before, true after
xLib.verify(-3, 'uint')       -- false either way
xLib.verify(5, 'uint', true)  -- threw before, passes after
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
