### PR TITLE
fix(es_extended/server/modules/commands): stop console commands from throwing on a missing xPlayer

### DIFF
--- a/[core]/es_extended/server/modules/commands.lua
+++ b/[core]/es_extended/server/modules/commands.lua
@@ -178,9 +178,11 @@ ESX.RegisterCommand(
             return
         end
         xTarget.triggerEvent("esx:repairPedVehicle")
-        xPlayer.showNotification(TranslateCap("command_repair_success"), true, false, 140)
-        if xPlayer.source ~= xTarget.source then
-            xTarget.showNotification(TranslateCap("command_repair_success_target"), true, false, 140)
+        if xPlayer then
+            xPlayer.showNotification(TranslateCap("command_repair_success"))
+        end
+        if not xPlayer or xPlayer.source ~= xTarget.source then
+            xTarget.showNotification(TranslateCap("command_repair_success_target"))
         end
         if Config.AdminLogging then
             ESX.DiscordLogFields("UserActions", "Fix Vehicle /fix Triggered!", "pink", {
@@ -445,7 +447,11 @@ if not Config.CustomInventory then
     ESX.RegisterCommand("refreshitems", "admin", function(xPlayer)
         local itemCount = ESX.RefreshItems()
 
-        xPlayer.showNotification(Translate("command_refreshitems_success", itemCount), true, false, 140)
+        if xPlayer then
+            xPlayer.showNotification(Translate("command_refreshitems_success", itemCount))
+        else
+            print(("[^2INFO^7] %s^7"):format(Translate("command_refreshitems_success", itemCount)))
+        end
     end, true, { help = TranslateCap("command_refreshitems") })
 
     ESX.RegisterCommand(
@@ -558,7 +564,7 @@ end, true, { help = TranslateCap("command_saveall") })
 
 ESX.RegisterCommand("group", { "user", "admin" }, function(xPlayer, _, _)
     print(("%s, you are currently: ^5%s^0"):format(xPlayer.getName(), xPlayer.getGroup()))
-end, true)
+end, false)
 
 ESX.RegisterCommand("job", { "user", "admin" }, function(xPlayer, _, _)
 	local job = xPlayer.getJob()


### PR DESCRIPTION
### Description

Two separate defects, both in the same three lines of `commands.lua`.

`ESX.RegisterCommand` passes `xPlayer or false` to the callback, so a command that allows console use gets `false` when it runs from the server console. Three commands dereference it anyway and throw.

The same three lines also call `showNotification` with the old argument list, which breaks the notification for players as well.

---

### Motivation

**From the console.** `attempt to index a boolean value (local 'xPlayer')`, thrown from `functions.lua:179`:

| command | `allowConsole` | before | after |
| --- | --- | --- | --- |
| `group` | `true` | throws at `commands.lua:560` | refused, like its siblings |
| `refreshitems` | `true` | throws at `commands.lua:448` | `[INFO] Successfully reloaded 42 items.` |
| `fix` | `true` | repairs the vehicle, then throws at `commands.lua:181` | repairs, notifies the target, no error |
| `job`, `info`, `saveall`, `players`, `clearall` | | fine | unchanged |

`kill`, `freeze`, `unfreeze`, `clearall` and `setjob` already guard with `xPlayer and xPlayer.name`. These three were missed.

**In game.** `showNotification` takes `(msg, notifyType, length, title, position)`, but these three calls still pass the old `(msg, flash, saveToBrief, hudColorIndex)`:

```lua
xPlayer.showNotification(TranslateCap("command_repair_success"), true, false, 140)
```

So `title` ends up as `140` and `esx_notify` dies on it:

```
Uncaught TypeError: data.title.replace is not a function (@esx_notify/nui/js/script.js:125)
```

The player gets no confirmation at all. Every other `showNotification` in the core passes the message alone. These are the only three left on the old signature.

---

### Implementation Details

`group` prints "you are currently: X". There is no "you" on the console, and `job`, `info` and `playtime` are all already `allowConsole = false`, so it joins them.

`refreshitems` and `fix` keep console access, since reloading items and repairing someone else's vehicle are both reasonable from there. They just have to cope with there being no caller:

```lua
if xPlayer then
    xPlayer.showNotification(TranslateCap("command_repair_success"))
end

if not xPlayer or xPlayer.source ~= xTarget.source then
    xTarget.showNotification(TranslateCap("command_repair_success_target"))
end
```

From the console the target is never the caller, so it now gets the notification instead of nothing.

Checked on a v1.14.1 server, before and after, from the console and from chat: `/group` still works in game (`allowConsole` only ever compares against `playerId == 0`), `/fix 1` repairs and shows "Successfully repaired vehicle" with no NUI error, `/fix` without an argument still gives the argument error, and `/job`, `/saveall`, `/players` are unchanged.

---

### Usage Example

```
] group
before: SCRIPT ERROR: ... attempt to index a boolean value (local 'xPlayer')
after:  [WARNING] Command Cannot be executed from console

] refreshitems
before: SCRIPT ERROR: ... attempt to index a boolean value (local 'xPlayer')
after:  [INFO] Successfully reloaded 42 items.

] fix 1
before: vehicle repaired, then SCRIPT ERROR, and the target got no notification
after:  vehicle repaired, target notified
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
