### PR TITLE
fix(es_extended/client/modules/adjustments): escape placeholder values before substitution

### DIFF
--- a/[core]/es_extended/client/modules/adjustments.lua
+++ b/[core]/es_extended/client/modules/adjustments.lua
@@ -175,11 +175,11 @@ function Adjustments:ReplacePlaceholders(text)
         local success, result = pcall(cb)
 
         if not success then
-            error(("Failed to execute placeholder: ^5%s^7\n%s"):format(placeholder, result))
+            print(("[^1ERROR^7] Failed to execute placeholder: ^5%s^7\n%s"):format(placeholder, result))
             result = "Unknown"
         end
 
-        text = text:gsub(("{%s}"):format(placeholder), tostring(result))
+        text = text:gsub(("{%s}"):format(placeholder), (tostring(result):gsub("%%", "%%%%")))
     end
     return text
 end


### PR DESCRIPTION
### Description

`Adjustments:ReplacePlaceholders` feeds the placeholder result straight into `gsub` as the replacement string. A `%` in that value is not literal there, so a player whose name contains one either kills the Discord presence thread or gets a mangled string.

The `result = "Unknown"` fallback right above it can never run, because the `error()` on the line before always propagates.

---

### Motivation

`player_name` is `GetPlayerName(ESX.playerId)`, so the value is whatever the player called themselves. `DiscordPresence` calls this inside `while true` with no `pcall`, so a throw ends the thread for good.

Three different outcomes, none of them the intended one:

| player name | before | after |
| --- | --- | --- |
| `Sniper` | `Playing as Sniper` | unchanged |
| `50%Sniper` | throws `invalid use of '%' in replacement string` | `Playing as 50%Sniper` |
| `100%` | throws | `Playing as 100%` |
| `%d` | throws | `Playing as %d` |
| `a%%b` | `Playing as a%b`, silently mangled | `Playing as a%%b` |
| `x%1y` | `Playing as x{player_name}y`, the placeholder token itself gets inserted | `Playing as x%1y` |

The last two are the quieter half: `%%` collapses to one `%`, and `%1` is a capture reference, so the matched text lands in the output.

The fallback is a separate matter. `9f8432f7` deliberately changed `return "Unknown"` to `result = "Unknown"`, so a failing placeholder was meant to fall back and carry on. The `error()` above it makes that impossible, and every later commit kept both lines.

Only applies with `Config.DiscordActivity.appId ~= 0`.

---

### Implementation Details

```lua
-error(("Failed to execute placeholder: ^5%s^7\n%s"):format(placeholder, result))
+print(("[^1ERROR^7] Failed to execute placeholder: ^5%s^7\n%s"):format(placeholder, result))
```

```lua
-text = text:gsub(("{%s}"):format(placeholder), tostring(result))
+text = text:gsub(("{%s}"):format(placeholder), (tostring(result):gsub("%%", "%%%%")))
```

The outer parentheses keep `gsub`'s second return value out of the argument list. `[^1ERROR^7]` matches the existing warning in `client/modules/callback.lua`.

I loaded the real file under Lua 5.4 with stubbed natives and stubbed `GetPlayerName` so the value goes through the actual placeholder path. Eight cases: six names and two control strings with several placeholders and none. 3/8 before, 8/8 after, and the two controls give the same output either way.

Not verified against a live client with `appId` set, since that needs a real Discord application.

---

### Usage Example

```lua
Config.DiscordActivity.presence = "Playing as {player_name}"
```

```
player joins as "50%Sniper"
before: SCRIPT ERROR: invalid use of '%' in replacement string, presence stops updating
after:  Playing as 50%Sniper
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
