### PR TITLE
fix(es_extended/server/modules/createJob): let CreateJob add grades to an existing job

### DIFF
--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -52,14 +52,17 @@ function ESX.CreateJob(name, label, grades, jobType)
         jobType = "civ"
     end
 
-    local jobExists = MySQL.scalar.await('SELECT 1 FROM `jobs` WHERE `name` = ?', { name }) ~= nil
+    local existingJob = MySQL.single.await('SELECT `label`, `type` FROM `jobs` WHERE `name` = ?', { name })
+    local jobExists = existingJob ~= nil
     local existingGrades = {}
 
     if jobExists then
+        label, jobType = existingJob.label, existingJob.type
+
         local rows = MySQL.query.await('SELECT `grade` FROM `job_grades` WHERE `job_name` = ?', { name })
 
         for i = 1, #(rows or {}) do
-            existingGrades[rows[i].grade] = true
+            existingGrades[tostring(rows[i].grade)] = true
         end
     end
 
@@ -72,8 +75,11 @@ function ESX.CreateJob(name, label, grades, jobType)
         }
     end
 
+    local newGrades = {}
+
     for _, grade in pairs(grades) do
-        if not existingGrades[grade.grade] then
+        if not existingGrades[tostring(grade.grade)] then
+            newGrades[#newGrades + 1] = grade
             queries[#queries + 1] = {
                 query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
                 values = { name, grade.grade, grade.name, grade.label, grade.salary, grade.skin_male and json.encode(grade.skin_male) or '{}', grade.skin_female and json.encode(grade.skin_female) or '{}' }
@@ -93,7 +99,7 @@ function ESX.CreateJob(name, label, grades, jobType)
         return success
     end
 
-    ESX.Jobs[name] = generateNewJobTable(name, label, grades, jobType)
+    ESX.Jobs[name] = generateNewJobTable(name, label, newGrades, jobType)
 
     notify("SUCCESS", currentResourceName, 'Job created successfully: `%s`', name)
 

--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -8,7 +8,7 @@ local NOTIFY_TYPES = {
 local function generateNewJobTable(name, label, grades, jobType)
     local job = ESX.Jobs[name] or { name = name, label = label, type = jobType, grades = {} }
     for _, v in pairs(grades) do
-        job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = v.skin_male or '{}', skin_female = v.skin_female or '{}' }
+        job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = v.skin_male, skin_female = v.skin_female }
     end
 
     return job
@@ -79,10 +79,13 @@ function ESX.CreateJob(name, label, grades, jobType)
 
     for _, grade in pairs(grades) do
         if not existingGrades[tostring(grade.grade)] then
-            newGrades[#newGrades + 1] = grade
+            local skinMale = grade.skin_male and json.encode(grade.skin_male) or '{}'
+            local skinFemale = grade.skin_female and json.encode(grade.skin_female) or '{}'
+
+            newGrades[#newGrades + 1] = { grade = grade.grade, name = grade.name, label = grade.label, salary = grade.salary, skin_male = skinMale, skin_female = skinFemale }
             queries[#queries + 1] = {
                 query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
-                values = { name, grade.grade, grade.name, grade.label, grade.salary, grade.skin_male and json.encode(grade.skin_male) or '{}', grade.skin_female and json.encode(grade.skin_female) or '{}' }
+                values = { name, grade.grade, grade.name, grade.label, grade.salary, skinMale, skinFemale }
             }
         end
     end

--- a/[core]/es_extended/server/modules/createJob.lua
+++ b/[core]/es_extended/server/modules/createJob.lua
@@ -5,22 +5,8 @@ local NOTIFY_TYPES = {
     ERROR = "^5[%s]^7-^1[ERROR]^7 %s"
 }
 
-local function doesJobAndGradesExist(name, grades)
-    if not ESX.Jobs[name] then
-       return false
-    end
-
-   for _, grade in ipairs(grades) do
-       if not ESX.DoesJobExist(name, grade.grade) then
-           return false
-       end
-   end
-
-   return true
-end
-
 local function generateNewJobTable(name, label, grades, jobType)
-    local job = { name = name, label = label, type = jobType, grades = {} }
+    local job = ESX.Jobs[name] or { name = name, label = label, type = jobType, grades = {} }
     for _, v in pairs(grades) do
         job.grades[tostring(v.grade)] = { job_name = name, grade = v.grade, name = v.name, label = v.label, salary = v.salary, skin_male = v.skin_male or '{}', skin_female = v.skin_female or '{}' }
     end
@@ -66,22 +52,38 @@ function ESX.CreateJob(name, label, grades, jobType)
         jobType = "civ"
     end
 
-    local currentJobExist = doesJobAndGradesExist(name, grades)
+    local jobExists = MySQL.scalar.await('SELECT 1 FROM `jobs` WHERE `name` = ?', { name }) ~= nil
+    local existingGrades = {}
 
-    if currentJobExist then
-        notify("ERROR",currentResourceName, 'Job or grades already exists: `%s`', name)
-        return success
+    if jobExists then
+        local rows = MySQL.query.await('SELECT `grade` FROM `job_grades` WHERE `job_name` = ?', { name })
+
+        for i = 1, #(rows or {}) do
+            existingGrades[rows[i].grade] = true
+        end
     end
 
-    local queries = {
-        { query = 'INSERT INTO `jobs` (`name`, `label`, `type`) VALUES (?, ?, ?)', values = { name, label, jobType } }
-    }
+    local queries = {}
+
+    if not jobExists then
+        queries[#queries + 1] = {
+            query = 'INSERT INTO `jobs` (`name`, `label`, `type`) VALUES (?, ?, ?)',
+            values = { name, label, jobType }
+        }
+    end
 
     for _, grade in pairs(grades) do
-        queries[#queries + 1] = {
-            query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
-            values = { name, grade.grade, grade.name, grade.label, grade.salary, grade.skin_male and json.encode(grade.skin_male) or '{}', grade.skin_female and json.encode(grade.skin_female) or '{}' }
-        }
+        if not existingGrades[grade.grade] then
+            queries[#queries + 1] = {
+                query = 'INSERT INTO job_grades (job_name, grade, name, label, salary, skin_male, skin_female) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                values = { name, grade.grade, grade.name, grade.label, grade.salary, grade.skin_male and json.encode(grade.skin_male) or '{}', grade.skin_female and json.encode(grade.skin_female) or '{}' }
+            }
+        end
+    end
+
+    if not queries[1] then
+        notify("ERROR",currentResourceName, 'Job or grades already exists: `%s`', name)
+        return success
     end
 
     success = exports.oxmysql:transaction_async(queries)


### PR DESCRIPTION
### Description

`ESX.CreateJob` always builds an `INSERT INTO jobs` regardless of whether the job is already there. `jobs` has its primary key on `name`, so as soon as the row exists the transaction fails on a duplicate key and rolls back, and nothing gets written at all.

The guard above it does not stop that. It only returns early when the job **and every** grade you passed already exist, which is exactly the case where you have nothing to add.

---

### Motivation

Adding a grade to an existing job is the obvious use for this function and it cannot work today:

| | before | after |
| --- | --- | --- |
| `police` has grades 0-3, add grade 4 | `Duplicate entry 'police' for key 'PRIMARY'`, nothing written | grades 0-3-4 |
| `jobs` row exists with no grades, add grade 0 | same error, nothing written | grade 0 added |
| brand new job | works | unchanged |
| job and grade both already there | early return with a message | same message, same early return |

The second row is reachable without anyone doing anything unusual. `ESX.RefreshJobs` drops any job with no grades out of `ESX.Jobs` and logs `Ignoring job "x" due to no job grades found`, but the `jobs` row stays in the database. The guard only looks at `ESX.Jobs`, sees nothing, and lets it through into the duplicate insert. That job can then never be repaired through `CreateJob`.

The error message points the wrong way too. `transaction_async` returns `false`, so the caller is told `Failed to insert one or more grades`, when the grades were fine and the `jobs` row was the problem.

---

### Implementation Details

Ask the database what is already there, then only insert what is missing:

```lua
local jobExists = MySQL.scalar.await('SELECT 1 FROM `jobs` WHERE `name` = ?', { name }) ~= nil
```

Checking the database rather than `ESX.Jobs` is what covers the grade-less job case. The old guard is gone because `if not queries[1]` now covers the same situation and gives the same message, and it no longer depends on `ESX.Jobs` being in sync.

`generateNewJobTable` starts from the existing entry when there is one. Without that, adding grade 4 to `police` would leave `ESX.Jobs["police"].grades` holding only grade 4 and drop the other four out of memory until the next restart.

Two notes on the grade side. `job_grades` has its primary key on `id`, not on `job_name, grade`, so a repeated grade does not raise anything, it just writes a second row. `existingGrades` stops that. And the old `doesJobAndGradesExist` used `ipairs` while the insert loop uses `pairs`, so a grades table with string keys was never seen by the guard at all.

Checked against a scratch database built from the schema in `[SQL]/legacy.sql`, running the old and the new statement sequence over four cases: grade added to an existing job, grade added to a job with no grades, a brand new job, and nothing to add. The last two behave the same before and after.

---

### Usage Example

```lua
ESX.CreateJob("police", "LSPD", {
    { grade = 4, name = "boss", label = "Captain", salary = 100 },
}, "leo")

-- before: [ERROR] Failed to insert one or more grades for job: `police`
--         and the grade is not there
-- after:  [SUCCESS] Job created successfully: `police`
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
