### PR TITLE
fix(es_extended/server/classes/player): stop setInventoryItem throwing when nothing changes

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -505,6 +505,10 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
         if item and count >= 0 then
             count = ESX.Math.Round(count)
 
+            if count == item.count then
+                return
+            end
+
             if count > item.count then
                 self.addInventoryItem(item.name, count - item.count)
             else


### PR DESCRIPTION
### Description

`setInventoryItem` sends the difference to `addInventoryItem` or `removeInventoryItem`. When the new count equals the current one that difference is zero, and `removeInventoryItem` treats zero as an error and calls `error()`.

---

### Motivation

`error()` is an exception, not a log line. It unwinds out of `setInventoryItem` and out of whatever called it, so the rest of that handler never runs:

```lua
xPlayer.setInventoryItem("bread", 5)   -- player already has 5
-- everything below this line is skipped
```

Setting an item to a fixed target is what this function is for, and sooner or later the target is what the player already has. Nothing in the signature or the name suggests it can throw.

Ran the real functions, cut out of `player.lua` and loaded under Lua 5.4, over 15 assertions. Before: 13/15, the two failures being the call itself and whether the caller carries on. After: 15/15.

| case | before | after |
| --- | --- | --- |
| 5 → 5 | throws `Tried remove a Invalid count -> 0 of bread` | returns, count stays 5 |
| caller continues after the call | no | yes |
| 5 → 7 | 7 | unchanged |
| 5 → 3 | 3 | unchanged |
| 5 → 0 | 0 | unchanged |
| negative count | ignored | unchanged |
| unknown item | ignored | unchanged |
| `removeInventoryItem(name, 0)` directly | throws | still throws |

The guard in `removeInventoryItem` stays as it is. It was added against cheats passing negative counts and it should keep throwing when something really does ask to remove zero.

---

### Implementation Details

```lua
if count == item.count then
    return
end
```

Placed after the rounding, so `setInventoryItem("bread", 5.2)` on a stack of 5 is also a no-op rather than a throw.

---

### Usage Example

```lua
local xPlayer = ESX.GetPlayerFromId(source)

xPlayer.setInventoryItem("bread", 5)
xPlayer.showNotification("done")
-- before: if the player already had 5, the notification never fires
-- after:  both lines run
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
