### PR TITLE
fix(es_extended): widen the identifier columns that are too short

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -364,7 +364,7 @@ CREATE TABLE `rented_vehicles` (
   `player_name` varchar(255) NOT NULL,
   `base_price` int(11) NOT NULL,
   `rent_price` int(11) NOT NULL,
-  `owner` varchar(22) NOT NULL
+  `owner` varchar(60) NOT NULL
 ) ENGINE=InnoDB;
 
 --

--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -89,7 +89,7 @@ CREATE TABLE `billing` (
   `identifier` varchar(60) NOT NULL,
   `sender` varchar(60) NOT NULL,
   `target_type` varchar(50) NOT NULL,
-  `target` varchar(40) NOT NULL,
+  `target` varchar(60) NOT NULL,
   `label` varchar(255) NOT NULL,
   `amount` int(11) NOT NULL
 ) ENGINE=InnoDB;

--- a/[core]/es_extended/server/migration/v1.14.2/billingTargetLength/main.lua
+++ b/[core]/es_extended/server/migration/v1.14.2/billingTargetLength/main.lua
@@ -1,0 +1,41 @@
+local esxVersion = "v1.14.2"
+
+Core.Migrations = Core.Migrations or {}
+Core.Migrations[esxVersion] = Core.Migrations[esxVersion] or {}
+
+if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
+  return
+end
+
+---@return boolean restartRequired
+Core.Migrations[esxVersion].billingTargetLength = function()
+  print("^4[esx_migration:v1.14.2:billingTargetLength]^7 Checking the length of billing.target.")
+
+  local length = MySQL.scalar.await([[
+    SELECT CHARACTER_MAXIMUM_LENGTH
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'billing'
+      AND COLUMN_NAME = 'target'
+  ]])
+
+  if not length then
+    print("^4[esx_migration:v1.14.2:billingTargetLength]^7 Column not found, migration not needed.")
+    return false
+  end
+
+  if length >= 60 then
+    print(("^4[esx_migration:v1.14.2:billingTargetLength]^7 Column is already varchar(%s), migration not needed."):format(length))
+    return false
+  end
+
+  print(("^4[esx_migration:v1.14.2:billingTargetLength]^7 Column is varchar(%s), widening it to 60."):format(length))
+
+  MySQL.update.await([[
+    ALTER TABLE `billing`
+      MODIFY `target` VARCHAR(60) NOT NULL
+  ]])
+
+  print("^4[esx_migration:v1.14.2:billingTargetLength]^7 Migration complete.")
+  return true
+end

--- a/[core]/es_extended/server/migration/v1.14.2/rentedVehiclesOwnerLength/main.lua
+++ b/[core]/es_extended/server/migration/v1.14.2/rentedVehiclesOwnerLength/main.lua
@@ -1,0 +1,41 @@
+local esxVersion = "v1.14.2"
+
+Core.Migrations = Core.Migrations or {}
+Core.Migrations[esxVersion] = Core.Migrations[esxVersion] or {}
+
+if GetResourceKvpInt(("esx_migration:%s"):format(esxVersion)) == 1 then
+  return
+end
+
+---@return boolean restartRequired
+Core.Migrations[esxVersion].rentedVehiclesOwnerLength = function()
+  print("^4[esx_migration:v1.14.2:rentedVehiclesOwnerLength]^7 Checking the length of rented_vehicles.owner.")
+
+  local length = MySQL.scalar.await([[
+    SELECT CHARACTER_MAXIMUM_LENGTH
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'rented_vehicles'
+      AND COLUMN_NAME = 'owner'
+  ]])
+
+  if not length then
+    print("^4[esx_migration:v1.14.2:rentedVehiclesOwnerLength]^7 Column not found, migration not needed.")
+    return false
+  end
+
+  if length >= 60 then
+    print(("^4[esx_migration:v1.14.2:rentedVehiclesOwnerLength]^7 Column is already varchar(%s), migration not needed."):format(length))
+    return false
+  end
+
+  print(("^4[esx_migration:v1.14.2:rentedVehiclesOwnerLength]^7 Column is varchar(%s), widening it to 60."):format(length))
+
+  MySQL.update.await([[
+    ALTER TABLE `rented_vehicles`
+      MODIFY `owner` VARCHAR(60) NOT NULL
+  ]])
+
+  print("^4[esx_migration:v1.14.2:rentedVehiclesOwnerLength]^7 Migration complete.")
+  return true
+end


### PR DESCRIPTION
### Description

Two columns in `legacy.sql` are too short for the identifier that gets written into them, so the insert fails and the feature behind it quietly stops working.

`billing.target` is `varchar(40)` and `rented_vehicles.owner` is `varchar(22)`. With multicharacter enabled an identifier is 46 characters. Both addons that write these columns already declare `varchar(60)` in their own SQL files, so the two schemas have drifted apart.

---

### Motivation

`esx_billing` writes an identifier into `billing.target`:

```lua
MySQL.insert.await(
    'INSERT INTO billing (identifier, sender, target_type, target, label, amount) VALUES (?, ?, ?, ?, ?, ?)',
    { targetIdentifier, senderIdentifier, 'player', senderIdentifier, label, amount })
```

The other two identifier columns in that table, `identifier` and `sender`, are already `varchar(60)`. The handler dies on the insert before it reaches `xTarget.showNotification`, so neither player is told anything. Society invoices keep working, because those put a society name in the column rather than an identifier.

`rented_vehicles.owner` is left over from Steam identifiers. `esx_vehicleshop` deletes the car from the dealer stock first and inserts the rental afterwards:

```lua
MySQL.update('DELETE FROM cardealer_vehicles WHERE id = ?', {result.id}, function(rowsChanged)
    if rowsChanged ~= 1 then return end
    MySQL.insert('INSERT INTO rented_vehicles (vehicle, plate, player_name, base_price, rent_price, owner) VALUES (?, ?, ?, ?, ?, ?)',
        {vehicle, plate, xTargetName, result.price, rentPrice, xTarget.getIdentifier()}, ...)
```

The delete goes through and the insert fails, so the dealer has lost the car and no rental contract exists. The notification sits inside the insert callback, so again nobody finds out.

Against the shipped schema, both:

```
ERROR 1406 (22001): Data too long for column 'target' at row 1
ERROR 1406 (22001): Data too long for column 'owner' at row 1
```

A server running a relaxed `sql_mode` gets the rental case wrong in a worse way. The identifier is truncated to 22 characters, the insert succeeds, and `PayRent` then joins on it:

```sql
LEFT JOIN users ON rented_vehicles.owner = users.identifier
```

That join stops matching, `users.accounts` comes back `NULL`, and `json.decode(nil)` takes down the nightly rent run for every owner, not just the one with the truncated row.

The column length fix in `esx_multicharacter/server/modules/database.lua` does not catch either case. It only widens columns named `identifier` or `owner` on the `users` table.

---

### Implementation Details

`legacy.sql` gets `varchar(60)` for new installs, and one migration per column widens existing ones, built the same way as the migrations already in the tree.

Both migrations read `CHARACTER_MAXIMUM_LENGTH` first and only ever widen:

```lua
if length >= 60 then
    return false
end
```

That keeps them idempotent, and it means they will never shrink a column somebody has already widened themselves. Widening a `varchar` is an instant metadata change on InnoDB, while shrinking needs a full table copy and truncates data, which is why this only goes one way.

I checked both against a scratch database built from the shipped schema. The insert fails at the shipped width and succeeds at 60 for either column, and in the rental case the dealer row is already gone by the time it fails (`ROW_COUNT() = 1`, stock table empty). Under a relaxed `sql_mode` the owner is stored as 22 characters and the `PayRent` join returns `accounts = NULL`, while at 60 it finds the user.

For the migrations themselves: each one reads the short width, widens to 60, and skips on a second run. A column somebody had already set to `varchar(100)` was left alone, and a row holding an old Steam identifier survived the widening unchanged.

---

### Usage Example

```lua
-- player A bills player B on a multicharacter server
TriggerServerEvent('esx_billing:sendBill', targetId, 'society_police', 'Fine', 500)

-- before: ERROR 1406, nothing written, neither player is notified
-- after:  invoice stored, both notified

-- a cardealer rents a vehicle out
TriggerServerEvent('esx_vehicleshop:rentVehicle', 'adder', plate, 500, targetId)

-- before: ERROR 1406, the car is gone from cardealer_vehicles and no rental exists
-- after:  rental stored, PayRent picks it up
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
