### PR TITLE
feat(server.cfg): add esx_lib to default resources

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -53,6 +53,7 @@ add_ace resource.es_extended command.stop allow
 ensure oxmysql
 
 ## ESX Legacy
+ensure esx_lib
 ensure es_extended
 ensure [core]
 


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Adds `esx_lib` to the default resources list in `server.cfg` so it is started automatically alongside the ESX Legacy resources.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

`esx_lib` is a required dependency for ESX Legacy. Including it in the default startup configuration prevents missing dependency issues and ensures new installations work correctly without requiring users to manually edit `server.cfg`.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- Added `ensure esx_lib` before `ensure es_extended` in `server.cfg`.
- Preserved the existing startup order of ESX resources.
- No other resources or configuration were modified.

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
