### PR TITLE
refactor(legacy.sql): consolidate addon_account entries and remove legacy Banker Job SQL

### DIFF
--- a/[SQL]/legacy.sql
+++ b/[SQL]/legacy.sql
@@ -16,7 +16,8 @@ INSERT INTO `addon_account` (`name`, `label`, `shared`) VALUES
 ('society_cardealer', 'Cardealer', 1),
 ('society_mechanic', 'Mechanic', 1),
 ('society_police', 'Police', 1),
-('society_taxi', 'Taxi', 1);
+('society_taxi', 'Taxi', 1),
+('bank_savings','Savings account',0);
 
 -- --------------------------------------------------------
 
@@ -990,27 +991,6 @@ INSERT INTO `fine_types` (label, amount, category) VALUES
 	('Involuntary manslaughter', 1800, 3),
 	('Fraud', 2000, 2);
 
-
---
--- ESX Bankerjob
---
-
-INSERT INTO `addon_account` (name, label, shared) VALUES
-	('society_banker','Bank',1),
-	('bank_savings','Savings account',0)
-;
-
-INSERT INTO `jobs` (name, label) VALUES
-	('banker','Banker')
-;
-
-INSERT INTO `job_grades` (job_name, grade, name, label, salary, skin_male, skin_female) VALUES
-	('banker',0,'advisor','Consultant',10,'{}','{}'),
-	('banker',1,'banker','Banker',20,'{}','{}'),
-	('banker',2,'business_banker',"Investment banker",30,'{}','{}'),
-	('banker',3,'trader','Broker',40,'{}','{}'),
-	('banker',4,'boss','Boss',0,'{}','{}')
-;
 
 --
 -- ESX Banking


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Consolidates the `bank_savings` entry into the primary `addon_account` seed data and removes the redundant ESX Banker Job SQL definitions from `legacy.sql`.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

The `bank_savings` account was previously defined in a separate ESX Banker Job SQL section. Moving it into the main `addon_account` seed data keeps all default account definitions together, improves organization, and removes redundant legacy SQL.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- Moved the `bank_savings` entry into the primary `addon_account` INSERT statement.
- Removed the duplicate `bank_savings` definition from the ESX Banker Job section.
- Removed the deprecated ESX Banker Job SQL (accounts, job, and job grades) from `legacy.sql`.

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
