### PR TITLE
fix: update inventory accounts convar to include black_money

### DIFF
--- a/[core]/es_extended/server/classes/overrides/oxinventory.lua
+++ b/[core]/es_extended/server/classes/overrides/oxinventory.lua
@@ -15,10 +15,10 @@ local requiredMethods = {
 }
 
 ---Parses the inventory:accounts convar to build a lookup table.
----Uses the same default and JSON format as ox_inventory.
+---Uses the same default and JSON format as ox_inventory ["money", "black_money"].
 ---@return table<string, boolean>
 local function getAccountList()
-    local convar = GetConvar("inventory:accounts", '["money"]')
+    local convar = GetConvar("inventory:accounts", '["money", "black_money"]')
     local ok, list = pcall(json.decode, convar)
 
     if not ok or type(list) ~= "table" then


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Updates the fallback default in ``getAccountList()`` to include ``black_money`` alongside ``money``, aligning the ESX bridge's default behavior with ESX's standard account setup.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

ESX ships with ``money`` and ``black_money`` as default accounts. However, ox_inventory's default ``inventory:accounts`` convar only includes ``["money"]``. When server owners don't explicitly set the convar in ``server.cfg``, the ESX bridge's proxy fallback uses the same narrow default causing ``black_money`` to silently fail syncing with ``ox_inventory``. This leads to confusing behavior where ESX tracks the account internally but the physical item never appears or updates in ox_inventory.
By including ``black_money`` in the fallback default, we ensure out-of-the-box compatibility for standard ESX setups without requiring every server owner to configure the convar manually.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- Changed ``GetConvar("inventory:accounts", ...)`` fallback from ``'["money"]'`` to ``'["money", "black_money"]'``.
- No changes to JSON parsing, validation, or the account lookup table logic.
- The convar still takes precedence if explicitly set by the server owner.

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
