### PR TITLE
fix: update vehicle properties function call to use xLib

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -153,7 +153,7 @@ AddStateBagChangeHandler("VehicleProperties", nil, function(bagName, _, value)
         return
     end
 
-    ESX.Game.SetVehicleProperties(vehicle, value)
+    xLib.game.setVehicleProperties(vehicle, value)
 end)
 
 ESX.SecureNetEvent("esx:setAccountMoney", function(account)


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Fixes a client-side script error where ``ESX.Game.SetVehicleProperties`` is called in the ``VehicleProperties`` state bag handler, but that function was removed from es_extended. Replaces the stale call with ``xLib.game.setVehicleProperties``, which is already available via the ``esx_lib`` dependency.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Since the vehicle-spawning refactor (1.14.x), spawning a vehicle server-side via ``ESX.OneSync.SpawnVehicle`` causes the following client error as soon as the ``VehicleProperties`` state bag replicates:
```lua
SCRIPT ERROR: @es_extended/client/modules/events.lua:156: attempt to call a nil value (field 'SetVehicleProperties')
```

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- File changed: ``[core]/es_extended/client/modules/events.lua``
- Line 156: Replaced ``ESX.Game.SetVehicleProperties(vehicle, value)`` with ``xLib.game.setVehicleProperties(vehicle, value)``.
- ``xLib`` is globally available in the client runtime because ``esx_lib`` is a required dependency of ESX.
- The function signatures are identical (``vehicle, properties``), so this is a zero-side-effect drop-in replacement.

---

### Usage Example

```lua
-- Add example usage here
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
