### PR TITLE
feat(server): expose ESX resource versions to server info

### DIFF
--- a/[core]/esx_lib/fxmanifest.lua
+++ b/[core]/esx_lib/fxmanifest.lua
@@ -5,8 +5,9 @@ use_experimental_fxv2_oal 'yes'
 lua54 'yes'
 
 author 'ESX Team'
-version '0.01'
 description 'Official ESX library'
+version '0.01'
+legacyversion '1.14.2'
 
 ui_page 'html/medal.html'
 

--- a/[core]/esx_lib/resource/version/server.lua
+++ b/[core]/esx_lib/resource/version/server.lua
@@ -32,10 +32,10 @@ local function exposeVersion(name)
     local value
 
     if hasVersion and hasLegacyVersion then
-        value = ('{ legacyVersion: %s, version: %s }'):format(
-            legacyVersion,
-            version
-        )
+        value = json.encode({
+            legacyVersion = legacyVersion,
+            version = version
+        })
     else
         value = hasVersion and version or legacyVersion
     end

--- a/[core]/esx_lib/resource/version/server.lua
+++ b/[core]/esx_lib/resource/version/server.lua
@@ -1,0 +1,66 @@
+local SELF = GetCurrentResourceName()
+
+local function isESXResource(name)
+    if name:find('^esx_') or name:find('^es_') then
+        return true
+    end
+
+    local count = GetNumResourceMetadata(name, 'dependency')
+
+    for i = 0, count - 1 do
+        local dependency = GetResourceMetadata(name, 'dependency', i)
+
+        if dependency == 'es_extended' or dependency == 'esx_lib' then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function exposeVersion(name)
+    local version = GetResourceMetadata(name, 'version', 0)
+    local legacyVersion = GetResourceMetadata(name, 'legacyversion', 0)
+
+    local hasVersion = version and version ~= ''
+    local hasLegacyVersion = legacyVersion and legacyVersion ~= ''
+
+    if not hasVersion and not hasLegacyVersion then
+        return
+    end
+
+    local value
+
+    if hasVersion and hasLegacyVersion then
+        value = ('{ legacyVersion: %s, version: %s }'):format(
+            legacyVersion,
+            version
+        )
+    else
+        value = hasVersion and version or legacyVersion
+    end
+
+    SetConvarServerInfo(name .. '-version', value)
+end
+
+CreateThread(function()
+    Wait(2000)
+
+    for i = 0, GetNumResources() - 1 do
+        local name = GetResourceByFindIndex(i)
+
+        if name and isESXResource(name) then
+            exposeVersion(name)
+        end
+    end
+end)
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if resourceName == SELF then
+        return
+    end
+
+    if isESXResource(resourceName) then
+        exposeVersion(resourceName)
+    end
+end)

--- a/[core]/esx_lib/resource/version/server.lua
+++ b/[core]/esx_lib/resource/version/server.lua
@@ -53,6 +53,7 @@ CreateThread(function()
             exposeVersion(name)
         end
     end
+    exposeVersion(SELF)
 end)
 
 AddEventHandler('onResourceStart', function(resourceName)


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->

Adds automatic version detection and exposure for all ESX resources via ``SetConvarServerInfo``. Reads ``version`` and ``legacyversion`` fields from each resource's ``fxmanifest.lua`` and publishes them to the public server info (``info.json`` and Cfx.re API).

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->

Currently, ESX resources do not expose their versions in a unified way on the server info endpoint. This makes it difficult for server owners, monitoring tools, and the Cfx.re server browser to know which versions of ESX resources are running. This change centralizes version exposure through ``esx_lib`` so no individual resource needs its own logic.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->

- ``resource/version/server.lua`` — new server module picked up automatically by ``fxmanifest.lua``'s ``resource/**/server.lua`` glob.
- ``isESXResource(name)`` — detects ESX resources by ``esx_`` / ``es_`` prefix or dependency on ``es_extended`` / ``esx_lib``.
- ``exposeVersion(name)`` — reads ``version`` and ``legacyversion`` from manifest. If both exist, formats as ``{ legacyVersion: X, version: Y }``. If only version exists, exposes plain string.
- Startup scan — deferred 2-second scan after server boot to ensure all resources are loaded, plus explicit ``exposeVersion(SELF)`` to guarantee ``esx_lib`` exposes itself.
- Late-loading handler — ``onResourceStart`` catches resources restarted via txAdmin or started after server boot.
- No breaking changes — resources without ``version`` / ``legacyversion`` are silently skipped.

---

### Usage Example

```lua
-- fxmanifest.lua in any ESX resource
version '2.0.0'
legacyversion '1.14.2'

-- Result in server info.json:
-- "esx_garage-version": "{ legacyVersion: 1.14.2, version: 2.0.0 }"

-- For core resources with only version:
-- "esx_identity-version": "1.14.1"
```

---

### PR Checklist

-   [ ] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [ ] My PR does not introduce any breaking changes.
-   [ ] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
