### PR TITLE
fix(callbacks): clean up handlers when the owning resource stops

### DIFF
--- a/[core]/es_extended/client/modules/callback.lua
+++ b/[core]/es_extended/client/modules/callback.lua
@@ -19,7 +19,8 @@ end
 ---@param callback function
 ---@return nil
 function ESX.RegisterClientCallback(eventName, callback)
-    return xLib.callback.registerCompat(eventName, callback)
+    local owner = GetInvokingResource() or GetCurrentResourceName()
+    return xLib.callback.registerCompat(eventName, callback, owner)
 end
 
 ---@param eventName string

--- a/[core]/es_extended/server/modules/callback.lua
+++ b/[core]/es_extended/server/modules/callback.lua
@@ -21,7 +21,8 @@ end
 ---@param callback function
 ---@return nil
 function ESX.RegisterServerCallback(eventName, callback)
-    return xLib.callback.registerCompat(eventName, callback)
+    local owner = GetInvokingResource() or GetCurrentResourceName()
+    return xLib.callback.registerCompat(eventName, callback, owner)
 end
 
 ---@param eventName string

--- a/[core]/esx_lib/imports/callback/client.lua
+++ b/[core]/esx_lib/imports/callback/client.lua
@@ -39,6 +39,20 @@ AddEventHandler('onClientResourceStart', function(resource)
     end
 end)
 
+-- Compat callbacks may belong to another resource while their handlers live here.
+AddEventHandler('onClientResourceStop', function(resource)
+    for name, registration in pairs(registeredCallbackNames) do
+        if registration.owner == resource then
+            RemoveEventHandler(registration.handler)
+            registeredCallbackNames[name] = nil
+
+            if GetResourceState('esx_lib') == 'started' then
+                xLib.setValidCallback(name, false)
+            end
+        end
+    end
+end)
+
 RegisterNetEvent(cbEvent:format(resource_name), function(key, ...)
     if source == '' then return end
 
@@ -160,23 +174,34 @@ local pcall = pcall
 
 ---@param name string
 ---@param cb function
+---@param owner? string Resource whose lifetime owns the callback.
 ---Registers an event handler and callback function to respond to server requests.
 ---@diagnostic disable-next-line: duplicate-set-field
-function xLib.callback.register(name, cb)
+function xLib.callback.register(name, cb, owner)
     local event = cbEvent:format(name)
 
-    registeredCallbackNames[name] = true
-    publishValidCallback(name)
+    local previous = registeredCallbackNames[name]
+    if previous then
+        RemoveEventHandler(previous.handler)
+    end
 
-    RegisterNetEvent(event, function(resource, key, ...)
+    RegisterNetEvent(event)
+    local handler = AddEventHandler(event, function(resource, key, ...)
         TriggerServerEvent(cbEvent:format(resource), key, callbackResponse(pcall(cb, ...)))
     end)
+
+    registeredCallbackNames[name] = {
+        owner = owner or resource_name,
+        handler = handler
+    }
+    publishValidCallback(name)
 end
 
 ---@param name string
 ---@param cb function
+---@param owner? string Resource whose lifetime owns the callback.
 ---Registers a callback using the old ESX client callback signature: function(cb, ...).
-function xLib.callback.registerCompat(name, cb)
+function xLib.callback.registerCompat(name, cb, owner)
     return xLib.callback.register(name, function(...)
         local response = promise.new()
         local responded = false
@@ -195,7 +220,7 @@ function xLib.callback.registerCompat(name, cb)
         cb(reply, ...)
 
         return table.unpack(Citizen.Await(response))
-    end)
+    end, owner)
 end
 
 return xLib.callback

--- a/[core]/esx_lib/imports/callback/server.lua
+++ b/[core]/esx_lib/imports/callback/server.lua
@@ -38,6 +38,20 @@ AddEventHandler('onResourceStart', function(resource)
     end
 end)
 
+-- Compat callbacks may belong to another resource while their handlers live here.
+AddEventHandler('onResourceStop', function(resource)
+    for name, registration in pairs(registeredCallbackNames) do
+        if registration.owner == resource then
+            RemoveEventHandler(registration.handler)
+            registeredCallbackNames[name] = nil
+
+            if GetResourceState('esx_lib') == 'started' then
+                xLib.setValidCallback(name, false)
+            end
+        end
+    end
+end)
+
 RegisterNetEvent(cbEvent:format(resource_name), function(key, ...)
     local cb = pendingCallbacks[key]
 
@@ -139,23 +153,34 @@ local pcall = pcall
 
 ---@param name string
 ---@param cb function
+---@param owner? string Resource whose lifetime owns the callback.
 ---Registers an event handler and callback function to respond to client requests.
 ---@diagnostic disable-next-line: duplicate-set-field
-function xLib.callback.register(name, cb)
+function xLib.callback.register(name, cb, owner)
     local event = cbEvent:format(name)
 
-    registeredCallbackNames[name] = true
-    publishValidCallback(name)
+    local previous = registeredCallbackNames[name]
+    if previous then
+        RemoveEventHandler(previous.handler)
+    end
 
-    RegisterNetEvent(event, function(resource, key, ...)
+    RegisterNetEvent(event)
+    local handler = AddEventHandler(event, function(resource, key, ...)
         TriggerClientEvent(cbEvent:format(resource), source, key, callbackResponse(pcall(cb, source, ...)))
     end)
+
+    registeredCallbackNames[name] = {
+        owner = owner or resource_name,
+        handler = handler
+    }
+    publishValidCallback(name)
 end
 
 ---@param name string
 ---@param cb function
+---@param owner? string Resource whose lifetime owns the callback.
 ---Registers a callback using the old ESX server callback signature: function(source, cb, ...).
-function xLib.callback.registerCompat(name, cb)
+function xLib.callback.registerCompat(name, cb, owner)
     return xLib.callback.register(name, function(source, ...)
         local response = promise.new()
         local responded = false
@@ -174,7 +199,7 @@ function xLib.callback.registerCompat(name, cb)
         cb(source, reply, ...)
 
         return table.unpack(Citizen.Await(response))
-    end)
+    end, owner)
 end
 
 return xLib.callback

--- a/[core]/esx_lib/resource/callback/shared.lua
+++ b/[core]/esx_lib/resource/callback/shared.lua
@@ -31,12 +31,14 @@ function xLib.setValidCallback(callbackName, isValid)
     local resourceName = GetInvokingResource() or resource_name
     local callbackResource = registeredCallbacks[callbackName]
 
-    if callbackResource then
-        if not isValid then
+    if not isValid then
+        if callbackResource == resourceName then
             registeredCallbacks[callbackName] = nil
-            return
         end
+        return
+    end
 
+    if callbackResource then
         if callbackResource == resourceName then return end
 
         if IS_DEBUG then


### PR DESCRIPTION
### Description

Fix stale callback function references and duplicate responses after restarting resources that use ESX.RegisterServerCallback or ESX.RegisterClientCallback. Only five existing Lua files change; no tests, README files, dependencies, or public ESX signature changes are included.

### Motivation

The ESX adapters delegate to xLib.callback.registerCompat inside es_extended. The original callback belongs to the calling resource, but its event handler lives in es_extended. Previously, every registration appended another handler without retaining its handle.

After the calling resource stopped, its ESX-owned handler survived with a function reference to the stopped instance. Registering again after a restart added another handler. The next request could execute both: the stale handler raised "Execution of function reference in script host failed", while the new handler could still succeed. Repeated restarts accumulated handlers and could produce duplicate or empty responses.

### Implementation Details

**Capture the original resource.** Both ESX registration adapters obtain GetInvokingResource(), falling back to GetCurrentResourceName() for local registrations. This owner passes through an optional third argument to xLib.callback.registerCompat and xLib.callback.register. Existing callers need no changes.

**Keep one handler per name.** The xLib registration table stores the owner and event-handler handle. Re-registering removes the previous handler before attaching its replacement. RegisterNetEvent and AddEventHandler are separate because the removable handle is returned by AddEventHandler.

**Remove handlers when their owner stops.** Server cleanup uses onResourceStop; client cleanup uses onClientResourceStop. Matching registrations remove both the handler and the local publication entry. When esx_lib is running, the callback is also invalidated. An unrelated resource stop leaves active callbacks intact; stopping a previous owner does not remove a registration replaced by another owner.

**Prevent stale republishing.** Removing the local entry prevents publication retries and the existing esx_lib restart logic from republishing stopped callbacks. If esx_lib is unavailable during cleanup, the handler is still removed without invoking unavailable exports.

**Make invalidation idempotent and publisher-aware.** Previously, setValidCallback(name, false) registered a name if it was already absent. That could recreate entries when the shared registry processed shutdown before the importing resource's handler. Invalidation now returns without registering absent names and removes existing entries only for the matching publishing resource. The original callback owner and its importing/publishing resource remain distinct intentionally.

### Compatibility and scope

Legacy cb-style signatures, return-value callbacks, deferred responses, and event names are preserved. Direct xLib registrations default to the importing resource's lifetime.

This addresses registered handler ownership. Pending outbound callback timeout behavior and cancellation of requests already executing during shutdown are outside this change.

Install with a clean server start: the old implementation discarded the handles needed to recover already-leaked handlers.

### Validation

All 24 local Lua 5.4 regression cases pass using the actual ESX adapters, xLib imports, and validation registry in a simulated FiveM runtime. The original registration failures were reproduced before the fix. Coverage includes repeated restarts, replacement ownership, deferred replies, publishing retries, library restart, and invalidation ordering. The validation code remains local and is not included in this PR. No live FiveM integration run was performed. Whitespace checks pass.

### Target branch

This PR targets main because the affected implementation delegates to esx_lib there. The dev branch still uses the earlier callback implementation and does not contain esx_lib, so it cannot receive this isolated fix despite the general CONTRIBUTING.md guidance.

### PR Checklist

- [x] My commit message and PR title follow the Conventional Commits standard.
- [x] My changes have been tested locally in the simulated runtime described above.
- [x] My PR does not introduce breaking changes to the public ESX APIs.
- [x] I have provided the reasoning, implementation details, and validation limits.
