### PR TITLE
1.15.2

### DIFF
--- a/[core]/cron/fxmanifest.lua
+++ b/[core]/cron/fxmanifest.lua
@@ -4,6 +4,6 @@ game 'gta5'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 server_script 'server/main.lua'

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'The Core resource that provides the functionalities for all other resources.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 shared_scripts {
 	'@esx_lib/imports.lua',

--- a/[core]/esx_chat_theme/fxmanifest.lua
+++ b/[core]/esx_chat_theme/fxmanifest.lua
@@ -1,4 +1,4 @@
-version '1.15.0'
+version '1.15.2'
 author 'ESX-Framework'
 description 'A ESX Stylised theme for the chat resource.'
 

--- a/[core]/esx_context/fxmanifest.lua
+++ b/[core]/esx_context/fxmanifest.lua
@@ -4,7 +4,7 @@ game 'gta5'
 author 'ESX-Framework & Brayden'
 description 'A simplistic context menu for ESX.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 ui_page 'index.html'
 

--- a/[core]/esx_identity/fxmanifest.lua
+++ b/[core]/esx_identity/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'Allows the player to Pick their characters: Name, Gender, Height and Date-of-birth.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 shared_scripts {
 	'@esx_lib/imports.lua',

--- a/[core]/esx_inventory/fxmanifest.lua
+++ b/[core]/esx_inventory/fxmanifest.lua
@@ -4,7 +4,7 @@ game "gta5"
 description "Inventory for the ESX framework"
 lua54 "yes"
 use_fxv2_oal "yes"
-version '1.15.0'
+version '1.15.2'
 
 shared_scripts {
     '@esx_lib/imports.lua',

--- a/[core]/esx_lib/imports.lua
+++ b/[core]/esx_lib/imports.lua
@@ -82,7 +82,7 @@ local function call(self, index, ...)
 
         if not module then
             local function method(...)
-               return exports[LIB_NAME][index](...)
+               return exports[LIB_NAME][index](nil, ...)
             end
                 
             if not ... then

--- a/[core]/esx_lib/imports/rateLimiter/server.lua
+++ b/[core]/esx_lib/imports/rateLimiter/server.lua
@@ -1,0 +1,268 @@
+---@class RateLimiterOptions
+---@field capacity number Maximum tokens a key can accumulate.
+---@field refill number Tokens restored per interval.
+---@field interval number Refill interval in milliseconds.
+---@field maxEntries? number Maximum keys retained by this limiter.
+---@field staleMs? number Idle time before full buckets can be pruned.
+---@field pruneInterval? number Minimum time between opportunistic stale prunes.
+
+---@class RateLimiter
+---@field consume fun(self: RateLimiter, key: string|number, cost?: number): boolean, number
+---@field reset fun(self: RateLimiter, key: string|number): boolean
+---@field clear fun(self: RateLimiter)
+---@field retryAfter fun(self: RateLimiter, key: string|number, cost?: number): number
+---@field size fun(self: RateLimiter): number
+
+local math_floor = math.floor
+local math_ceil = math.ceil
+local math_min = math.min
+
+local function nowMs()
+    return GetGameTimer()
+end
+
+local function positiveConvarInt(name, fallback)
+    local value = GetConvarInt(name, fallback)
+
+    if value <= 0 then
+        return fallback
+    end
+
+    return value
+end
+
+local function positiveNumber(name, value, default, integer)
+    local number = tonumber(value)
+
+    if not number or number <= 0 then
+        if default ~= nil then
+            number = tonumber(default)
+        end
+
+        if not number or number <= 0 then
+            error(("[xLib] rateLimiter option '%s' must be a positive number"):format(name), 3)
+        end
+    end
+
+    if integer then
+        number = math_floor(number)
+
+        if number <= 0 then
+            error(("[xLib] rateLimiter option '%s' must be at least 1"):format(name), 3)
+        end
+    end
+
+    return number
+end
+
+local function normalizeKey(key)
+    local keyType = type(key)
+
+    if keyType == "number" or keyType == "string" then
+        return tostring(key)
+    end
+end
+
+---@param options RateLimiterOptions
+---@return RateLimiter
+local function createRateLimiter(options)
+    if type(options) ~= "table" then
+        error("[xLib] rateLimiter requires an options table", 2)
+    end
+
+    local capacity = positiveNumber("capacity", options.capacity, nil)
+    local refill = positiveNumber("refill", options.refill, nil)
+    local interval = positiveNumber("interval", options.interval, nil, true)
+    local maxEntries = positiveNumber("maxEntries", options.maxEntries, positiveConvarInt("xLib:rateLimiterMaxEntries", 4096), true)
+    local staleMs = positiveNumber("staleMs", options.staleMs, math.max(60000, math_ceil((capacity / refill) * interval * 4)), true)
+    local pruneInterval = positiveNumber("pruneInterval", options.pruneInterval, staleMs, true)
+
+    local buckets = {}
+    local bucketCount = 0
+    local lastPrune = 0
+
+    local limiter = {}
+
+    local function removeBucket(key)
+        if buckets[key] then
+            buckets[key] = nil
+            bucketCount = bucketCount - 1
+            return true
+        end
+
+        return false
+    end
+
+    local function refillBucket(bucket, now)
+        local elapsed = now - bucket.updated
+
+        if elapsed <= 0 then
+            return
+        end
+
+        bucket.tokens = math_min(capacity, bucket.tokens + (elapsed / interval) * refill)
+        bucket.updated = now
+    end
+
+    local function prune(now, force)
+        if not force and now - lastPrune < pruneInterval and bucketCount < maxEntries then
+            return
+        end
+
+        lastPrune = now
+
+        for key, bucket in pairs(buckets) do
+            refillBucket(bucket, now)
+
+            if bucket.tokens >= capacity and now - bucket.lastUsed >= staleMs then
+                removeBucket(key)
+            end
+        end
+
+        if bucketCount < maxEntries then
+            return
+        end
+
+        local entries = {}
+
+        for key, bucket in pairs(buckets) do
+            entries[#entries + 1] = { key = key, lastUsed = bucket.lastUsed }
+        end
+
+        table.sort(entries, function(a, b)
+            return a.lastUsed < b.lastUsed
+        end)
+
+        local index = 1
+
+        while bucketCount >= maxEntries and entries[index] do
+            removeBucket(entries[index].key)
+            index = index + 1
+        end
+    end
+
+    local function getBucket(key, now)
+        local bucket = buckets[key]
+
+        if bucket then
+            refillBucket(bucket, now)
+            return bucket
+        end
+
+        if bucketCount >= maxEntries then
+            prune(now, true)
+        end
+
+        if bucketCount >= maxEntries then
+            return nil
+        end
+
+        bucket = {
+            tokens = capacity,
+            updated = now,
+            lastUsed = now,
+        }
+
+        buckets[key] = bucket
+        bucketCount = bucketCount + 1
+
+        return bucket
+    end
+
+    function limiter:consume(key, cost)
+        local bucketKey = normalizeKey(key)
+
+        if not bucketKey then
+            return false, 0
+        end
+
+        cost = tonumber(cost) or 1
+
+        if cost <= 0 then
+            return true, 0
+        end
+
+        if cost > capacity then
+            return false, math.huge
+        end
+
+        local now = nowMs()
+        prune(now, false)
+
+        local bucket = getBucket(bucketKey, now)
+        if not bucket then
+            return false, 0
+        end
+
+        if bucket.tokens >= cost then
+            bucket.tokens = bucket.tokens - cost
+            bucket.updated = now
+            bucket.lastUsed = now
+            return true, 0
+        end
+
+        bucket.lastUsed = now
+
+        return false, math_ceil(((cost - bucket.tokens) / refill) * interval)
+    end
+
+    function limiter:retryAfter(key, cost)
+        local bucketKey = normalizeKey(key)
+
+        if not bucketKey then
+            return 0
+        end
+
+        cost = tonumber(cost) or 1
+
+        if cost <= 0 then
+            return 0
+        end
+
+        if cost > capacity then
+            return math.huge
+        end
+
+        local bucket = buckets[bucketKey]
+        if not bucket then
+            return 0
+        end
+
+        local now = nowMs()
+        refillBucket(bucket, now)
+
+        if bucket.tokens >= cost then
+            return 0
+        end
+
+        return math_ceil(((cost - bucket.tokens) / refill) * interval)
+    end
+
+    function limiter:reset(key)
+        local bucketKey = normalizeKey(key)
+
+        if not bucketKey then
+            return false
+        end
+
+        return removeBucket(bucketKey)
+    end
+
+    function limiter:clear()
+        buckets = {}
+        bucketCount = 0
+        lastPrune = 0
+    end
+
+    function limiter:size()
+        return bucketCount
+    end
+
+    AddEventHandler("playerDropped", function()
+        limiter:reset(source)
+    end)
+
+    return limiter
+end
+
+return createRateLimiter

--- a/[core]/esx_lib/imports/token/server.lua
+++ b/[core]/esx_lib/imports/token/server.lua
@@ -1,0 +1,225 @@
+---@class TokenOptions
+---@field source? string|number Player source that is allowed to consume the token.
+---@field ttl number Time to live in milliseconds.
+---@field data? any Data returned when the token is consumed.
+
+local DEFAULT_TTL <const> = 30000
+local DEFAULT_MAX_ENTRIES <const> = 4096
+
+local tokens = {}
+local tokensBySource = {}
+local tokenCount = 0
+
+local function nowMs()
+    return GetGameTimer()
+end
+
+local function normalizeSource(source)
+    if source == nil then
+        return nil
+    end
+
+    local sourceType = type(source)
+    if sourceType ~= "number" and sourceType ~= "string" then
+        return nil
+    end
+
+    return tostring(source)
+end
+
+local function isExpired(entry, now)
+    return now - entry.createdAt >= entry.ttl
+end
+
+local function unindexSource(id, sourceKey)
+    if not sourceKey then
+        return
+    end
+
+    local index = tokensBySource[sourceKey]
+    if not index then
+        return
+    end
+
+    index[id] = nil
+
+    if next(index) == nil then
+        tokensBySource[sourceKey] = nil
+    end
+end
+
+local function removeToken(id)
+    local entry = tokens[id]
+
+    if not entry then
+        return false
+    end
+
+    tokens[id] = nil
+    tokenCount = tokenCount - 1
+    unindexSource(id, entry.source)
+
+    return true
+end
+
+local function pruneExpired(now)
+    for id, entry in pairs(tokens) do
+        if isExpired(entry, now) then
+            removeToken(id)
+        end
+    end
+end
+
+local function createTokenId()
+    local id
+
+    repeat
+        id = ("%s:%s:%s"):format(GetCurrentResourceName(), nowMs(), xLib.string.randomHex(32))
+    until not tokens[id]
+
+    return id
+end
+
+---@class xLibToken
+---@field create fun(options: TokenOptions): string?
+---@field consume fun(id: string, source?: string|number): any
+---@field remove fun(id: string): boolean
+---@field reset fun(source: string|number): number
+---@field clear fun()
+---@field size fun(): number
+local token = {}
+
+---@param options TokenOptions
+---@return string?
+function token.create(options)
+    if type(options) ~= "table" then
+        error("[xLib] token.create requires an options table", 2)
+    end
+
+    local ttl = math.floor(tonumber(options.ttl) or DEFAULT_TTL)
+    if ttl <= 0 then
+        error("[xLib] token ttl must be a positive number", 2)
+    end
+
+    local now = nowMs()
+    local maxEntries = math.floor(GetConvarInt("xLib:tokenMaxEntries", DEFAULT_MAX_ENTRIES))
+    if maxEntries <= 0 then
+        maxEntries = DEFAULT_MAX_ENTRIES
+    end
+
+    pruneExpired(now)
+
+    if tokenCount >= maxEntries then
+        return nil
+    end
+
+    local id = createTokenId()
+    local sourceKey = normalizeSource(options.source)
+
+    tokens[id] = {
+        source = sourceKey,
+        createdAt = now,
+        ttl = ttl,
+        data = options.data,
+    }
+
+    tokenCount = tokenCount + 1
+
+    if sourceKey then
+        tokensBySource[sourceKey] = tokensBySource[sourceKey] or {}
+        tokensBySource[sourceKey][id] = true
+    end
+
+    SetTimeout(ttl, function()
+        removeToken(id)
+    end)
+
+    return id
+end
+
+---@param id string
+---@param source? string|number
+---@return any
+function token.consume(id, source)
+    if type(id) ~= "string" then
+        return nil
+    end
+
+    local entry = tokens[id]
+    if not entry then
+        return nil
+    end
+
+    if isExpired(entry, nowMs()) then
+        removeToken(id)
+        return nil
+    end
+
+    local sourceKey = normalizeSource(source)
+    if entry.source and entry.source ~= sourceKey then
+        return nil
+    end
+
+    removeToken(id)
+
+    if entry.data ~= nil then
+        return entry.data
+    end
+
+    return true
+end
+
+---@param id string
+---@return boolean
+function token.remove(id)
+    if type(id) ~= "string" then
+        return false
+    end
+
+    return removeToken(id)
+end
+
+---@param source string|number
+---@return number
+function token.reset(source)
+    local sourceKey = normalizeSource(source)
+
+    if not sourceKey then
+        return 0
+    end
+
+    local index = tokensBySource[sourceKey]
+    if not index then
+        return 0
+    end
+
+    local removed = 0
+
+    for id in pairs(index) do
+        if removeToken(id) then
+            removed = removed + 1
+        end
+    end
+
+    return removed
+end
+
+function token.clear()
+    tokens = {}
+    tokensBySource = {}
+    tokenCount = 0
+end
+
+---@return number
+function token.size()
+    pruneExpired(nowMs())
+    return tokenCount
+end
+
+AddEventHandler("playerDropped", function()
+    token.reset(source)
+end)
+
+xLib.token = token
+
+return token

--- a/[core]/esx_lib/resource/callback/shared.lua
+++ b/[core]/esx_lib/resource/callback/shared.lua
@@ -9,7 +9,7 @@
 local registeredCallbacks = {}
 local resource_name = GetCurrentResourceName() --TODO: Add cache
 local IS_DEBUG <const> = GetConvar("xLib:debug", "false") == "true"
-local VALIDATION_GRACE_MS <const> = GetConvarInt("xLib:callbackValidationGrace", 1000)
+local VALIDATION_GRACE_MS <const> = GetConvarInt("xLib:callbackValidationGrace", 15000)
 
 
 AddEventHandler('onResourceStop', function(resourceName)

--- a/[core]/esx_loadingscreen/fxmanifest.lua
+++ b/[core]/esx_loadingscreen/fxmanifest.lua
@@ -5,7 +5,7 @@ lua54 "yes"
 fx_version 'cerulean'
 author 'ESX-Framework'
 description 'Allows resources to Run tasks at specific intervals.'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 loadscreen "web/index.html"

--- a/[core]/esx_menu_default/fxmanifest.lua
+++ b/[core]/esx_menu_default/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'cerulean'
 game 'gta5'
 description 'A basic menu system for ESX Legacy.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 shared_script '@esx_lib/imports.lua'
 client_scripts { '@es_extended/imports.lua', 'client/main.lua' }

--- a/[core]/esx_menu_dialog/fxmanifest.lua
+++ b/[core]/esx_menu_dialog/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic input dialog for ESX Legacy.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 shared_script '@esx_lib/imports.lua'
 client_scripts {

--- a/[core]/esx_menu_list/fxmanifest.lua
+++ b/[core]/esx_menu_list/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 description 'A basic table-based menu system for ESX Legacy.'
 lua54 'yes'
-version '1.15.0'
+version '1.15.2'
 
 
 client_scripts {

--- a/[core]/esx_multicharacter/fxmanifest.lua
+++ b/[core]/esx_multicharacter/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 author 'ESX-Framework - Linden - KASH'
 description 'Allows players to have multiple characters on the same account.'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 shared_script '@esx_lib/imports.lua'

--- a/[core]/esx_notify/fxmanifest.lua
+++ b/[core]/esx_notify/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 lua54 'yes'
 game 'gta5'
-version '1.15.0'
+version '1.15.2'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI notification system for ESX'
 

--- a/[core]/esx_progressbar/fxmanifest.lua
+++ b/[core]/esx_progressbar/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple NUI progress bar for ESX'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 shared_script '@esx_lib/imports.lua'

--- a/[core]/esx_skin/fxmanifest.lua
+++ b/[core]/esx_skin/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Allows players to customise their character\'s appearance'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 shared_scripts {

--- a/[core]/esx_textui/fxmanifest.lua
+++ b/[core]/esx_textui/fxmanifest.lua
@@ -3,7 +3,7 @@ fx_version 'adamant'
 game 'gta5'
 author 'ESX-Framework'
 description 'A beautiful and simple Persistent Notification system for ESX.'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 client_scripts { 'TextUI.lua' }

--- a/[core]/skinchanger/fxmanifest.lua
+++ b/[core]/skinchanger/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 description 'Saves/loads character appearances for ESX Legacy.'
-version '1.15.0'
+version '1.15.2'
 lua54 'yes'
 
 client_scripts {


### PR DESCRIPTION
### Description

Fixes incorrect parameter forwarding in `esx_lib` when falling back to exported library methods.

The fallback call was forwarding arguments directly:

---

### Motivation

Recent ESX versions using esx_lib could incorrectly report registered callbacks as missing

---

### Implementation Details

The fallback method in [core]/esx_lib/imports.lua has been changed from:

```lua
return exports[LIB_NAME][index](...)
```

to:

```lua
return exports[LIB_NAME][index](nil, ...)
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
