### PR TITLE
fix(client/events): move fade in for non-multichar only

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -35,11 +35,11 @@ RegisterNetEvent("esx:playerLoaded", function(xPlayer, _, skin)
 
     if not Config.Multichar then
         Core.FreezePlayer(false)
+        if IsScreenFadedOut() then
+            DoScreenFadeIn(500)
+        end
     end
 
-    if IsScreenFadedOut() then
-        DoScreenFadeIn(500)
-    end
 
     Actions:Init()
     xLib.points.startLoop()
@@ -138,7 +138,7 @@ AddStateBagChangeHandler("VehicleProperties", nil, function(bagName, _, value)
     end
 
     local tries = 0
-    
+
     while not NetworkDoesEntityExistWithNetworkId(netId) do
         Wait(200)
         tries = tries + 1


### PR DESCRIPTION
### Description

<!-- What does this PR do? Summarize the feature, fix, or improvement. -->
This moves the screen fade in to trigger only when multicharacter scripts are not in use.

---

### Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
Multicharacter resources control the screen fade in. This prevents screen fade in from occurring before the player is ready.

---

### Implementation Details

<!-- How is it implemented? Highlight key technical decisions or logic. -->
Moved under existing if branch for non-multicharacter configurations

---

### Usage Example
n/a

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
