### PR TITLE
fix(es_extended/server): guard against a missing xPlayer in onPlayerSpawn

### DIFF
--- a/[core]/es_extended/server/common.lua
+++ b/[core]/es_extended/server/common.lua
@@ -3,7 +3,11 @@ ESX.Jobs = {}
 ESX.Items = {}
 
 RegisterNetEvent("esx:onPlayerSpawn", function()
-    ESX.Players[source].spawned = true
+    local xPlayer = ESX.Players[source]
+
+    if xPlayer then
+        xPlayer.spawned = true
+    end
 end)
 
 if Config.CustomInventory then


### PR DESCRIPTION
### Description
`esx:onPlayerSpawn` indexed `ESX.Players[source]` directly without checking it exists first.

### Motivation
`esx:onPlayerSpawn` is a `RegisterNetEvent`, so any client can trigger it at any time, including before `ESX.Players[source]` is populated (e.g. right after connecting, before the character finishes loading). When that happens the handler throws instead of failing safely.

### Implementation Details
Reads `ESX.Players[source]` into a local first and only sets `.spawned` if it's there. Same pattern the rest of the file already uses.

### Usage Example
```lua
-- nothing changes for callers, this is a guard against a bad source only
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading the code path and confirming the added guard matches the existing pattern used for the same table elsewhere in server/common.lua and server/main.lua.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
