### PR TITLE
fix(es_extended/server): reject "bank" in the give/drop inventory events

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -466,6 +466,10 @@ if not Config.CustomInventory then
             sourceXPlayer.showNotification(TranslateCap("gave_item", itemCount, sourceItem.label, targetXPlayer.name))
             targetXPlayer.showNotification(TranslateCap("received_item", itemCount, sourceItem.label, sourceXPlayer.name))
         elseif itemType == "item_account" then
+            if itemName == "bank" then
+                return
+            end
+
             if itemCount < 1 or sourceXPlayer.getAccount(itemName).money < itemCount then
                 return sourceXPlayer.showNotification(TranslateCap("imp_invalid_amount"))
             end
@@ -576,6 +580,10 @@ if not Config.CustomInventory then
             ESX.CreatePickup("item_standard", itemName, itemCount, pickupLabel, playerId)
             xPlayer.showNotification(TranslateCap("threw_standard", itemCount, xItem.label))
         elseif itemType == "item_account" then
+            if itemName == "bank" then
+                return
+            end
+
             if itemCount == nil or itemCount < 1 then
                 return xPlayer.showNotification(TranslateCap("imp_invalid_amount"))
             end


### PR DESCRIPTION
### Description
`esx:giveInventoryItem` and `esx:removeInventoryItem` never checked the account name against `"bank"` for the `item_account` branch.

### Motivation
The client already hides the drop button for the bank account (`esx_inventory/client/main.lua`), but that's only a UI restriction. A direct `TriggerServerEvent` call that skips the UI can still give bank money to another player, or drop it on the ground as a pickup like it was cash.

### Implementation Details
Added an early `if itemName == "bank" then return end` to both `item_account` branches, before any other validation.

### Usage Example
```lua
-- server-side only, no client API to update
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading both branches and confirming the guard matches the client-side restriction it's meant to mirror.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
