### PR TITLE
fix(es_extended/server): reject a non-positive amount in esx:giveInventoryItem for item_ammo

### DIFF
--- a/[core]/es_extended/server/main.lua
+++ b/[core]/es_extended/server/main.lua
@@ -539,7 +539,7 @@ if not Config.CustomInventory then
             if not weaponObject.ammo then return end
 
             local ammoLabel = weaponObject.ammo.label
-            if weapon.ammo >= itemCount then
+            if itemCount >= 1 and weapon.ammo >= itemCount then
                 sourceXPlayer.removeWeaponAmmo(itemName, itemCount)
                 targetXPlayer.addWeaponAmmo(itemName, itemCount)
 


### PR DESCRIPTION
### Description
The `item_ammo` branch of `esx:giveInventoryItem` didn't reject a non-positive `itemCount`.

### Motivation
The `item_standard` and `item_account` branches right next to it both reject `itemCount < 1`. This branch only checked `weapon.ammo >= itemCount`, which a zero or negative `itemCount` always satisfies, so `removeWeaponAmmo`/`addWeaponAmmo` could run with a non-positive amount between two players.

### Implementation Details
Added `itemCount >= 1` to the existing condition, matching the guard style the neighboring branches already use.

### Usage Example
```lua
-- server-side only, no client API to update
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading the branch and comparing it to the already-correct `item_standard`/`item_account` branches in the same function.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
