### PR TITLE
fix(es_extended/server): validate ammoCount in Player:updateWeaponAmmo

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -743,6 +743,12 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
             return false
         end
 
+        ammoCount = tonumber(ammoCount)
+
+        if not ammoCount or ammoCount < 0 then
+            return false
+        end
+
         weapon.ammo = ammoCount
 
         if weapon.ammo <= 0 then


### PR DESCRIPTION
### Description
`Player:updateWeaponAmmo` wrote its `ammoCount` argument straight into `weapon.ammo` with no type or range check.

### Motivation
`esx:updateWeaponAmmo` (server/main.lua) passes the client-supplied value straight through to this method, so any client can set negative or non-numeric ammo. The class method is also reachable from any other server-side resource (e.g. via the static player export), so the guard belongs in the method itself rather than only at the event handler.

### Implementation Details
Coerces `ammoCount` with `tonumber` and returns `false` early if it's missing or negative.

### Usage Example
```lua
-- no signature change, still xPlayer.updateWeaponAmmo(weaponName, ammoCount)
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading the method and the two call sites that reach it.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
