### PR TITLE
fix(esx_identity): populate alreadyRegistered for multichar characters

### DIFF
--- a/[core]/esx_identity/server/main.lua
+++ b/[core]/esx_identity/server/main.lua
@@ -249,6 +249,14 @@ if not multichar then
             TriggerClientEvent("esx_identity:showRegisterIdentity", xPlayer.source)
         end
     end)
+else
+    RegisterNetEvent("esx:playerLoaded", function(_, xPlayer, isNew)
+        -- populates alreadyRegistered[xPlayer.getIdentifier()] from the database, same as
+        -- the non-multichar path above, so an existing character can't be re-registered
+        if not isNew then
+            checkIdentity(xPlayer)
+        end
+    end)
 end
 
 xLib.callback.registerCompat("esx_identity:registerIdentity", function(source, cb, data)


### PR DESCRIPTION
### Description
With `Config.Multichar` on, `esx_identity`'s `alreadyRegistered` table was never populated for any identifier, so a character that already registered its identity could call `esx_identity:registerIdentity` again at any time and overwrite it.

### Motivation
The `alreadyRegistered` guard inside `registerIdentity` only gets filled by the `playerConnecting`/`esx:playerLoaded` handlers near the top of the file, and both of those are wrapped in `if not multichar then`. That leaves the multichar case with no equivalent, so the guard at the top of `registerIdentity` never fires there.

### Implementation Details
Added an `esx:playerLoaded` handler for the multichar case, the `else` branch next to the existing `if not multichar then` block. It reuses the existing `checkIdentity()` helper to populate `alreadyRegistered`/`playerIdentity` from the database for existing (non-new) characters, the same thing the non-multichar path already does.

### Usage Example
```lua
-- server-side only, no client API to update
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading `checkIdentity()` and confirming it's already used for the same purpose in the non-multichar `esx:playerLoaded` handler right above.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
