### PR TITLE
fix(esx_skin): guard esx_skin:setWeight against a non-table skin argument

### DIFF
--- a/[core]/esx_skin/server/main.lua
+++ b/[core]/esx_skin/server/main.lua
@@ -39,6 +39,10 @@ RegisterNetEvent("esx_skin:save", function(skin)
 end)
 
 RegisterNetEvent("esx_skin:setWeight", function(skin)
+    if not skin or type(skin) ~= "table" then
+        return
+    end
+
     local xPlayer = ESX.Player(source)
 
     if not ESX.GetConfig().CustomInventory then


### PR DESCRIPTION
### Description
`esx_skin:setWeight` indexed `skin.bags_1` without checking that `skin` is a table first.

### Motivation
`esx_skin:save`, right above it, already rejects a missing/non-table `skin` before touching it. `esx_skin:setWeight` has no equivalent guard, so a bare `TriggerServerEvent("esx_skin:setWeight")` (nil argument) throws instead of failing safely.

### Implementation Details
Added the same `if not skin or type(skin) ~= "table" then return end` guard that `esx_skin:save` already has.

### Usage Example
```lua
-- server-side only, no client API to update
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment).

### Note for maintainers
Both `esx_skin:save` and `esx_skin:setWeight` still derive `MaxWeight` from a client-reported `skin.bags_1`, with nothing to check it against what the player is actually wearing. This PR only closes the crash path, the missing type guard. It doesn't touch that trust boundary. Closing that fully would need either a trusted source for the equipped backpack, or a restriction on when `setWeight` may be called at all. Happy to follow up with a specific direction if that's wanted.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
