### PR TITLE
fix(es_extended/server): fix the removeAccountMoney underflow guard

### DIFF
--- a/[core]/es_extended/server/classes/player.lua
+++ b/[core]/es_extended/server/classes/player.lua
@@ -471,7 +471,7 @@ function CreateExtendedPlayer(playerId, identifier, ssn, group, accounts, invent
 
             if account then
                 money = account.round and ESX.Math.Round(money) or money
-                if self.accounts[account.index].money - money > self.accounts[account.index].money then
+                if money > self.accounts[account.index].money then
                     error(("Tried To Underflow Account ^5%s^1 For Player ^5%s^1!"):format(accountName, self.playerId))
                     return
                 end


### PR DESCRIPTION
### Description
The underflow check in `Player:removeAccountMoney` could never trigger, so accounts could be pushed arbitrarily negative.

### Motivation
The guard was `self.accounts[account.index].money - money > self.accounts[account.index].money`. Since `money > 0` is already established above that line, `A - money > A` can never be true, so the check was dead code.

### Implementation Details
Changed the condition to `money > self.accounts[account.index].money`, which is what an underflow check actually needs to compare.

### Usage Example
```lua
-- still xPlayer.removeAccountMoney(accountName, money, reason), no signature change
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading the surrounding function and confirming the corrected condition can now actually be reached.

### Note for maintainers
This is a behavior change, not just a bugfix. If any server or third-party resource relies on `removeAccountMoney` silently letting an account go negative, this will start throwing where it used to succeed. That's the same shape as the account-rounding case that's already on record as a reason to be careful with this function. I kept `error()` for consistency with the rest of the function, but I'm not attached to it. Happy to switch it to a non-throwing `return false` instead, if that's the safer default for existing servers.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [ ] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
