### PR TITLE
fix(es_extended/server): check the ox_inventory result before touching the ESX ledger

### DIFF
--- a/[core]/es_extended/server/classes/overrides/oxinventory.lua
+++ b/[core]/es_extended/server/classes/overrides/oxinventory.lua
@@ -221,6 +221,13 @@ Core.PlayerFunctionOverrides.OxInventory = {
             end
 
             money = account.round and ESX.Math.Round(money) or money
+
+            local inventory = getOxInventory()
+
+            if inventory.accounts[accountName] and not inventory.SetItem(self.source, accountName, money) then
+                return
+            end
+
             self.accounts[account.index].money = money
 
             self.triggerEvent("esx:setAccountMoney", account)
@@ -231,12 +238,6 @@ Core.PlayerFunctionOverrides.OxInventory = {
                 money,
                 reason
             )
-
-            local inventory = getOxInventory()
-
-            if inventory.accounts[accountName] then
-                inventory.SetItem(self.source, accountName, money)
-            end
         end
     end,
 
@@ -255,6 +256,13 @@ Core.PlayerFunctionOverrides.OxInventory = {
             end
 
             money = account.round and ESX.Math.Round(money) or money
+
+            local inventory = getOxInventory()
+
+            if inventory.accounts[accountName] and not inventory.AddItem(self.source, accountName, money) then
+                return
+            end
+
             self.accounts[account.index].money =
                 self.accounts[account.index].money + money
 
@@ -266,12 +274,6 @@ Core.PlayerFunctionOverrides.OxInventory = {
                 money,
                 reason
             )
-
-            local inventory = getOxInventory()
-
-            if inventory.accounts[accountName] then
-                inventory.AddItem(self.source, accountName, money)
-            end
         end
     end,
 
@@ -290,6 +292,13 @@ Core.PlayerFunctionOverrides.OxInventory = {
             end
 
             money = account.round and ESX.Math.Round(money) or money
+
+            local inventory = getOxInventory()
+
+            if inventory.accounts[accountName] and not inventory.RemoveItem(self.source, accountName, money) then
+                return
+            end
+
             self.accounts[account.index].money =
                 self.accounts[account.index].money - money
 
@@ -301,12 +310,6 @@ Core.PlayerFunctionOverrides.OxInventory = {
                 money,
                 reason
             )
-
-            local inventory = getOxInventory()
-
-            if inventory.accounts[accountName] then
-                inventory.RemoveItem(self.source, accountName, money)
-            end
         end
     end,
 


### PR DESCRIPTION
### Description
The ox_inventory override for `setAccountMoney`/`addAccountMoney`/`removeAccountMoney` updated ESX's own account balance before calling into ox_inventory, and never checked whether that call actually succeeded.

### Motivation
If `SetItem`/`AddItem`/`RemoveItem` fails (weight limit, item cap), ESX's account balance had already been changed and stays permanently out of sync with what ox_inventory actually holds for that account item.

### Implementation Details
Reordered each of the three functions so the ox_inventory call runs first. The ESX-side ledger update and `esx:*AccountMoney` events now only fire once ox_inventory reports success, when that account is backed by an ox_inventory item at all (accounts that aren't stay on the previous behavior).

### Usage Example
```lua
-- server-side only, no client API to update
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment, and this override only applies when ox_inventory is the active inventory bridge). Verified by reading the reordered functions against ox_inventory's documented Add/Remove/SetItem return convention (truthy on success).

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
