### PR TITLE
fix(esx_lib/points): start the scan loop when the first point is created

### DIFF
--- a/[core]/esx_lib/imports/points/client.lua
+++ b/[core]/esx_lib/imports/points/client.lua
@@ -27,6 +27,8 @@ function xLib.points.create(coords, distance, hidden, enter, leave, inside)
         resource = GetInvokingResource()
     }
 
+    xLib.points.startLoop()
+
     return handle
 end
 


### PR DESCRIPTION
### Description
`xLib.points.create()` never started the scan loop that actually checks distances and fires `enter`/`leave`/`inside`.

### Motivation
`xLib.points.startLoop()` is only ever called from `es_extended`'s own `esx:playerLoaded` handler. `@esx_lib/imports.lua` compiles each import into the calling resource's own environment, so every other resource that uses `xLib.points`/`xLib.point` gets its own private copy of the module state (`points`, `insidePoints`, `loopStarted`), and nothing in that private copy calls `startLoop()`. Their points get registered but `enter`/`leave`/`inside` never fire, silently.

### Implementation Details
Calls `xLib.points.startLoop()` at the end of `create()`. It already guards against being started twice (`if loopStarted then return end`), so this is safe no matter who calls `create()` first, `es_extended` or a third-party resource.

### Usage Example
```lua
local point = xLib.point:new({
    coords = vector3(0, 0, 0),
    distance = 2,
    enter = function() print("entered") end,
})
-- enter now actually fires from any resource, not just es_extended
```

### Testing
Not tested against a live client this session (no client join possible in the current dev environment). Verified by reading `startLoop()`'s idempotency guard and confirming `create()` is the only entry point both `xLib.points` and `xLib.point` share.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [ ] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
