### PR TITLE
fix(cron): delay the first Tick() so dependent resources can register jobs first

### DIFF
--- a/[core]/cron/server/main.lua
+++ b/[core]/cron/server/main.lua
@@ -66,8 +66,13 @@ function Tick()
     SetTimeout(60000, Tick)
 end
 
-lastTimestamp = GetUnixTimestamp()
-Tick()
+-- Give other resources a chance to register their jobs via cron:runAt before the
+-- first Tick() runs. cron itself starts before most of its consumers (it has no
+-- dependents to wait on), so calling Tick() synchronously here would always see
+-- an empty cronJobs table and immediately consume the "lastTimestamp == false"
+-- catch-up window for nothing, silently skipping any job that's already due
+-- today by the time it actually gets registered.
+SetTimeout(15000, Tick)
 
 ---@param h number
 ---@param m number


### PR DESCRIPTION
### Description
`cron`'s boot-time catch-up guard could never actually help a real job: it always ran against an empty job list, so a job whose time of day already passed before a server restart stayed silently skipped for the rest of that day.

### Motivation
`lastTimestamp` is typed `number|false` specifically so `false` means "nothing checked yet", and both `OnTime` and `Tick` treat `not lastTimestamp` as a signal to run without the usual `lastTimestamp < scheduledTimestamp` gate, catching up on anything already due.

That catch-up never actually fires for a real job, though. `cron` starts before its consumers (it has nothing to wait on), and `Tick()` used to run synchronously at `cron`'s own load time, before any dependent resource had a chance to call `cron:runAt`. That first, job-less `OnTime` call still sets `lastTimestamp` to boot time as a side effect, so by the time real jobs get registered a moment later, the catch-up window is already gone. Any job whose time of day already passed today stays silently skipped until midnight, on every restart.

### Implementation Details
Replaced the synchronous boot call with `SetTimeout(15000, Tick)`, so the first real `Tick()` runs after other resources have had a chance to register their jobs, with `lastTimestamp` still `false` at that point.

### Usage Example
```lua
-- no API change, still RegisterNetEvent-style cron:runAt(h, m, cb)
```

### Testing
Not run inside a live FXServer this session (attempted it under Wine in the current dev environment, but FXServer.exe crashes there for GPU/EGL reasons unrelated to this change). Instead verified against the actual file, not a rewrite, with a small Lua harness that stubs only `SetTimeout`/`AddEventHandler`/`GetInvokingResource` and drives everything else for real: registered a job for 2 minutes in the past right after load, using real `os.time()` and real wall-clock delays throughout. It fired once the delayed `Tick()` ran, about 15 real seconds after load, and did not refire on the next tick.

Before this fix, the same harness against the unpatched file never fires that job at all, confirming the bug independently of the fix.

### Note for maintainers
The 15 second delay is a heuristic, picked to comfortably cover a typical resource-loading window, not a precise signal that every dependent resource has actually finished starting. A server with an unusually large resource list could in principle still race this on a very slow boot. A cleaner fix would need some actual "all resources have started" signal, which FXServer doesn't expose directly as far as I can tell. Happy to adjust the delay or the approach if you have a preference.

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
