### PR TITLE
fix(es_extended): resolve vehicle types without a connected player

### DIFF
--- a/[core]/es_extended/client/modules/events.lua
+++ b/[core]/es_extended/client/modules/events.lua
@@ -684,6 +684,21 @@ ESX.RegisterClientCallback("esx:GetVehicleType", function(cb, model)
     cb(ESX.GetVehicleTypeClient(model))
 end)
 
+ESX.RegisterClientCallback("esx:GetVehicleTypes", function(cb)
+    local models = GetAllVehicleModels()
+    local types = {}
+
+    for i = 1, #models do
+        local vehicleType = ESX.GetVehicleTypeClient(models[i])
+
+        if vehicleType then
+            types[models[i]] = vehicleType
+        end
+    end
+
+    cb(types)
+end)
+
 ESX.SecureNetEvent('esx:updatePlayerData', function(key, val)
     ESX.SetPlayerData(key, val)
 end)

--- a/[core]/es_extended/fxmanifest.lua
+++ b/[core]/es_extended/fxmanifest.lua
@@ -27,6 +27,7 @@ server_scripts {
 	'server/classes/vehicle.lua',
 	'server/classes/overrides/*.lua',
 	'server/functions.lua',
+	'server/modules/vehicleTypes.lua',
 	'server/modules/onesync.lua',
 	'server/modules/paycheck.lua',
 

--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -411,7 +411,7 @@ function ESX.GetIdentifier(playerId)
 end
 
 ---@param model string|number
----@param player number
+---@param player? number
 ---@param cb function?
 ---@return string?
 ---@diagnostic disable-next-line: duplicate-set-field
@@ -437,8 +437,12 @@ function ESX.GetVehicleType(model, player, cb)
         return resolve(Core.vehicleTypesByModel[model])
     end
 
+    if not player then
+        return resolve(nil)
+    end
+
     ESX.TriggerClientCallback(player, "esx:GetVehicleType", function(vehicleType)
-        Core.vehicleTypesByModel[model] = vehicleType
+        Core.CacheVehicleType(model, vehicleType)
         resolve(vehicleType)
     end, model)
 

--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -114,14 +114,11 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
 
     CreateThread(function()
         if not vehicleType then
-            local playerId = next(ESX.Players)
-            if playerId then
-                vehicleType = ESX.GetVehicleType(vehicleModel, playerId)
-            end
+            vehicleType = ESX.GetVehicleType(vehicleModel, next(ESX.Players))
         end
 
         if not vehicleType then
-            return reject("No players online to check vehicle type! Alternatively, you can specify the vehicle type manually.")
+            return reject(("Could not resolve the type of vehicle ^5%s^7! The model is unknown and no player is online to check it, you can also specify the vehicle type manually."):format(vehicleModel))
         end
 
         local createdVehicle = CreateVehicleServerSetter(vehicleModel, vehicleType, coords.x, coords.y, coords.z, heading)

--- a/[core]/es_extended/server/modules/vehicleTypes.lua
+++ b/[core]/es_extended/server/modules/vehicleTypes.lua
@@ -1,0 +1,122 @@
+local KVP_KEY <const> = "esx_vehicleTypes"
+local KVP_VERSION <const> = 1
+local MAX_MODELS <const> = 10000
+local MAX_MODEL_LENGTH <const> = 32
+
+local validTypes <const> = {
+    automobile = true,
+    bike = true,
+    boat = true,
+    heli = true,
+    plane = true,
+    submarine = true,
+    trailer = true,
+    train = true,
+}
+
+local storedTypes = {}
+local persistQueued = false
+local warmedUp = false
+local warmingUp = false
+
+---@return nil
+local function persistVehicleTypes()
+    if persistQueued then
+        return
+    end
+
+    persistQueued = true
+
+    SetTimeout(1000, function()
+        persistQueued = false
+
+        if not next(storedTypes) then
+            return DeleteResourceKvp(KVP_KEY)
+        end
+
+        SetResourceKvp(KVP_KEY, json.encode({ version = KVP_VERSION, types = storedTypes }))
+    end)
+end
+
+---@param model number
+---@param vehicleType string
+---@return nil
+function Core.CacheVehicleType(model, vehicleType)
+    if not validTypes[vehicleType] then
+        return
+    end
+
+    Core.vehicleTypesByModel[model] = vehicleType
+    storedTypes[tostring(model)] = vehicleType
+
+    persistVehicleTypes()
+end
+
+---@return nil
+local function restoreVehicleTypes()
+    local stored = GetResourceKvpString(KVP_KEY)
+
+    if not stored then
+        return
+    end
+
+    local ok, decoded = pcall(json.decode, stored)
+
+    if not ok or type(decoded) ~= "table" or decoded.version ~= KVP_VERSION or type(decoded.types) ~= "table" then
+        return DeleteResourceKvp(KVP_KEY)
+    end
+
+    for model, vehicleType in pairs(decoded.types) do
+        model = tonumber(model)
+
+        if model and validTypes[vehicleType] then
+            storedTypes[tostring(model)] = vehicleType
+            Core.vehicleTypesByModel[model] = vehicleType
+        end
+    end
+end
+
+---@param playerId number
+---@return nil
+local function refreshVehicleTypes(playerId)
+    if warmedUp or warmingUp then
+        return
+    end
+
+    warmingUp = true
+
+    SetTimeout(20000, function()
+        warmingUp = false
+    end)
+
+    ESX.TriggerClientCallback(playerId, "esx:GetVehicleTypes", function(types)
+        warmingUp = false
+
+        if type(types) ~= "table" then
+            return
+        end
+
+        warmedUp = true
+
+        local count = 0
+
+        for modelName, vehicleType in pairs(types) do
+            if count >= MAX_MODELS then
+                break
+            end
+
+            if type(modelName) == "string" and #modelName <= MAX_MODEL_LENGTH and validTypes[vehicleType] then
+                count = count + 1
+                Core.CacheVehicleType(joaat(modelName:lower()), vehicleType)
+            end
+        end
+
+        ESX.Trace(("Cached ^5%s^7 vehicle types."):format(count))
+    end)
+end
+
+AddEventHandler("esx:playerLoaded", function(playerId)
+    refreshVehicleTypes(playerId)
+end)
+
+restoreVehicleTypes()


### PR DESCRIPTION
### Description

`ESX.OneSync.SpawnVehicle` fails with `No players online to check vehicle type!` when the server is empty, because the type required by `CreateVehicleServerSetter` could only be resolved by asking a connected client, one model at a time. The first player to load after a restart now hands over the type of every model at once, base game and add-ons alike, and the result is persisted so spawns keep working once the server is empty again. A model still needs one player to have connected since it was installed; after that the answer is served from the cache.

---

### Usage Example

```lua
-- server restarted with nobody online, the type comes from the cache
local netId = ESX.OneSync.SpawnVehicle(`blista`, vector3(215.9, -810.0, 30.7), 0.0, {})

-- add-on models are covered the same way, whatever their manifest looks like
local netId = ESX.OneSync.SpawnVehicle("seyobmx", vector3(215.9, -810.0, 30.7), 0.0, {})

-- unchanged, an explicit type still short circuits the lookup
local netId = ESX.OneSync.SpawnVehicle(`blista`, vector3(215.9, -810.0, 30.7), 0.0, {}, nil, "automobile")
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
