### PR TITLE
fix(es_extended/server/modules/onesync): report spawn failures to the callback

### DIFF
--- a/[core]/es_extended/server/modules/onesync.lua
+++ b/[core]/es_extended/server/modules/onesync.lua
@@ -107,8 +107,13 @@ function ESX.OneSync.SpawnVehicle(vehicleModel, coords, heading, vehicleProperti
 
     local function reject(err)
         if promise then
-            promise:reject(err)
+            return promise:reject(err)
         end
+
+        if cb then
+            cb(false)
+        end
+
         error(err)
     end
 
@@ -177,8 +182,13 @@ function ESX.OneSync.SpawnObject(model, coords, heading, cb)
 
     local function reject(err)
         if promise then
-            promise:reject(err)
+            return promise:reject(err)
         end
+
+        if cb then
+            cb(false)
+        end
+
         error(err)
     end
 
@@ -229,8 +239,13 @@ function ESX.OneSync.SpawnPed(model, coords, heading, cb)
 
     local function reject(err)
         if promise then
-            promise:reject(err)
+            return promise:reject(err)
         end
+
+        if cb then
+            cb(false)
+        end
+
         error(err)
     end
 
@@ -279,8 +294,13 @@ function ESX.OneSync.SpawnPedInVehicle(model, vehicle, seat, cb)
 
     local function reject(err)
         if promise then
-            promise:reject(err)
+            return promise:reject(err)
         end
+
+        if cb then
+            cb(false)
+        end
+
         error(err)
     end
 
@@ -294,7 +314,7 @@ function ESX.OneSync.SpawnPedInVehicle(model, vehicle, seat, cb)
             tries = tries + 1
 
             if tries > 40 then
-                reject(("Could not spawn ped - ^5%s^7!"):format(model))
+                return reject(("Could not spawn ped - ^5%s^7!"):format(model))
             end
         end
 


### PR DESCRIPTION
### Description

When a spawn fails, `reject` throws inside its own thread instead of answering the caller, so a callback is never fired: `/car` already guards its callback with `if networkId then`, a branch that could never be reached. The callback now receives `false`, and the promise path leaves the rejection to `Citizen.Await`, which already raises it in the calling thread rather than reporting the same failure twice. `SpawnPedInVehicle` was also missing a `return` in its retry loop, so it kept rejecting every 200ms once it ran out of tries.

---

### Usage Example

```lua
ESX.OneSync.SpawnPed(`a_m_m_business_01`, coords, 0.0, function(netId)
    if not netId then
        return print("spawn failed")
    end
end)

local spawned, err = pcall(ESX.OneSync.SpawnVehicle, `blista`, coords, 0.0, {})
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
