### PR TITLE
fix(es_extended): expire pending callback requests and fix their timeout

### DIFF
--- a/[core]/es_extended/client/modules/callback.lua
+++ b/[core]/es_extended/client/modules/callback.lua
@@ -10,6 +10,9 @@ Callbacks.requests = {}
 Callbacks.storage = {}
 Callbacks.id = 0
 
+local PENDING <const> = 0
+local TIMEOUT <const> = GetConvarInt("esx:callbackTimeout", 15000)
+
 -- =============================================
 -- MARK: Internal Functions
 -- =============================================
@@ -32,18 +35,38 @@ function Callbacks:Execute(cb, id, ...)
     end
 end
 
+function Callbacks:Expire(requestId)
+    local request = self.requests[requestId]
+
+    if not request then
+        return
+    end
+
+    self.requests[requestId] = nil
+
+    if request.await and request.cb.state == PENDING then
+        request.cb:reject("Server Callback Timed Out")
+    end
+end
+
 function Callbacks:Trigger(event, cb, invoker, ...)
-    self.requests[self.id] = {
+    local requestId = self.id
+    local request = {
         await = type(cb) == "boolean",
         cb = cb or promise:new()
     }
-    local table = self.requests[self.id]
 
-    TriggerServerEvent("esx:triggerServerCallback", event, self.id, invoker, ...)
+    self.requests[requestId] = request
+
+    TriggerServerEvent("esx:triggerServerCallback", event, requestId, invoker, ...)
 
     self.id += 1
 
-    return table.cb
+    SetTimeout(TIMEOUT, function()
+        self:Expire(requestId)
+    end)
+
+    return request.cb
 end
 
 function Callbacks:ServerRecieve(requestId, invoker, ...)
@@ -99,13 +122,6 @@ function ESX.AwaitServerCallback(eventName, ...)
 
     local p = Callbacks:Trigger(eventName, false, invoker, ...)
     if not p then return end
-
-    -- if the server callback takes longer than 15 seconds to respond, reject the promise
-    SetTimeout(15000, function()
-        if p.state == "pending" then
-            p:reject("Server Callback Timed Out")
-        end
-    end)
 
     Citizen.Await(p)
 

--- a/[core]/es_extended/server/modules/callback.lua
+++ b/[core]/es_extended/server/modules/callback.lua
@@ -10,6 +10,11 @@ Callbacks.requests = {}
 Callbacks.storage = {}
 Callbacks.id = 0
 
+local PENDING <const> = 0
+local TIMEOUT <const> = GetConvarInt("esx:callbackTimeout", 15000)
+
+SetConvarReplicated("esx:callbackTimeout", tostring(TIMEOUT))
+
 -- =============================================
 -- MARK: Internal Functions
 -- =============================================
@@ -34,18 +39,39 @@ function Callbacks:Execute(cb, ...)
     self.currentId = nil
 end
 
+function Callbacks:Expire(requestId, reason)
+    local request = self.requests[requestId]
+
+    if not request then
+        return
+    end
+
+    self.requests[requestId] = nil
+
+    if request.await and request.cb.state == PENDING then
+        request.cb:reject(reason or "Server Callback Timed Out")
+    end
+end
+
 function Callbacks:Trigger(player, event, cb, invoker, ...)
-    self.requests[self.id] = {
+    local requestId = self.id
+    local request = {
+        player = player,
         await = type(cb) == "boolean",
         cb = cb or promise:new()
     }
-    local table = self.requests[self.id]
 
-    TriggerClientEvent("esx:triggerClientCallback", player, event, self.id, invoker, ...)
+    self.requests[requestId] = request
+
+    TriggerClientEvent("esx:triggerClientCallback", player, event, requestId, invoker, ...)
 
     self.id += 1
 
-    return table.cb
+    SetTimeout(TIMEOUT, function()
+        self:Expire(requestId)
+    end)
+
+    return request.cb
 end
 
 function Callbacks:ServerRecieve(player, event, requestId, invoker, ...)
@@ -63,20 +89,20 @@ function Callbacks:ServerRecieve(player, event, requestId, invoker, ...)
     self:Execute(callback, player, returnCb, ...)
 end
 
-function Callbacks:RecieveClient(requestId, invoker, ...)
-    self.currentId = requestId
+function Callbacks:RecieveClient(player, requestId, invoker, ...)
+    local request = self.requests[requestId]
 
-    if not self.requests[self.currentId] then
-        return error(("Client Callback with requestId ^5%s^1 Was Called by ^5%s^1 but does not exist."):format(self.currentId, invoker))
+    if not request or tonumber(request.player) ~= player then
+        return ESX.Trace(("Dropped a stale client callback with requestId ^5%s^7 from ^5%s^7."):format(requestId, invoker))
     end
 
-    local callback = self.requests[self.currentId]
-
+    self.currentId = requestId
     self.requests[requestId] = nil
-    if callback.await then
-        callback.cb:resolve({ ... })
+
+    if request.await then
+        request.cb:resolve({ ... })
     else
-        self:Execute(callback.cb, ...)
+        self:Execute(request.cb, ...)
     end
 end
 
@@ -106,12 +132,6 @@ function ESX.AwaitClientCallback(player, eventName, ...)
     local p = Callbacks:Trigger(player, eventName, false, invoker, ...)
     if not p then return end
 
-    SetTimeout(15000, function()
-        if p.state == "pending" then
-            p:reject("Server Callback Timed Out")
-        end
-    end)
-
     Citizen.Await(p)
 
     return table.unpack(p.value)
@@ -138,12 +158,23 @@ end
 -- =============================================
 
 RegisterNetEvent("esx:clientCallback", function(requestId, invoker, ...)
-    Callbacks:RecieveClient(requestId, invoker, ...)
+    local source = source
+    Callbacks:RecieveClient(source, requestId, invoker, ...)
 end)
 
 RegisterNetEvent("esx:triggerServerCallback", function(eventName, requestId, invoker, ...)
     local source = source
     Callbacks:ServerRecieve(source, eventName, requestId, invoker, ...)
+end)
+
+AddEventHandler("playerDropped", function()
+    local player = source
+
+    for requestId, request in pairs(Callbacks.requests) do
+        if tonumber(request.player) == player then
+            Callbacks:Expire(requestId, "Player Dropped")
+        end
+    end
 end)
 
 AddEventHandler("onResourceStop", function(resource)

--- a/server.cfg
+++ b/server.cfg
@@ -35,6 +35,9 @@ set mysql_ui true
 ## if not, it will use the language you have selected in txAdmin.
 #setr esx:locale "en"
 
+## Uncomment to change how long a callback waits for its answer, in milliseconds.
+#setr esx:callbackTimeout 15000
+
 ## These resources will start by default.
 ensure chat
 ensure spawnmanager


### PR DESCRIPTION
### Description

`Callbacks.requests` was only cleared when an answer came back, and the 15s timeout guarding an await compared the promise state against `"pending"` while `deferred.lua` uses numeric states, so it never fired: a request nobody answers stayed pending forever and its await blocked its coroutine for good. Requests now expire on both sides after `esx:callbackTimeout` milliseconds, server side ones are also expired when the player drops, and a response is matched against the player it was sent to before it resolves.

---

### Usage Example

```cfg
# server.cfg, defaults to 15000 when unset
setr esx:callbackTimeout 30000
```

```lua
-- a callback that is never answered now rejects instead of blocking forever
local ok, err = pcall(ESX.AwaitClientCallback, playerId, "my:callback")
local ok, err = pcall(ESX.AwaitServerCallback, "my:callback")
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
