### PR TITLE
fix(es_extended/server/functions): dispatch overridden commands to the latest callback

### DIFF
--- a/[core]/es_extended/server/functions.lua
+++ b/[core]/es_extended/server/functions.lua
@@ -37,7 +37,9 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
         return
     end
 
-    if Core.RegisteredCommands[name] then
+    local isOverride = Core.RegisteredCommands[name] ~= nil
+
+    if isOverride then
         print(('[^3WARNING^7] Command ^5"%s" ^7already registered, overriding command'):format(name))
 
         if Core.RegisteredCommands[name].suggestion then
@@ -57,6 +59,18 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
     end
 
     Core.RegisteredCommands[name] = { group = group, cb = cb, allowConsole = allowConsole, suggestion = suggestion }
+
+    if type(group) == "table" then
+        for _, v in ipairs(group) do
+            ExecuteCommand(("add_ace group.%s command.%s allow"):format(v, name))
+        end
+    else
+        ExecuteCommand(("add_ace group.%s command.%s allow"):format(group, name))
+    end
+
+    if isOverride then
+        return
+    end
 
     RegisterCommand(name, function(playerId, args)
         local command = Core.RegisteredCommands[name]
@@ -176,7 +190,7 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
                     xPlayer.showNotification(err)
                 end
             else
-                cb(xPlayer or false, args, function(msg)
+                command.cb(xPlayer or false, args, function(msg)
                     if playerId == 0 then
                         print(("[^3WARNING^7] %s^7"):format(msg))
                     else
@@ -186,14 +200,6 @@ function ESX.RegisterCommand(name, group, cb, allowConsole, suggestion)
             end
         end
     end, true)
-
-    if type(group) == "table" then
-        for _, v in ipairs(group) do
-            ExecuteCommand(("add_ace group.%s command.%s allow"):format(v, name))
-        end
-    else
-        ExecuteCommand(("add_ace group.%s command.%s allow"):format(group, name))
-    end
 end
 
 local function updateHealthAndArmorInMetadata(xPlayer)


### PR DESCRIPTION
### Description

Overriding a command through `ESX.RegisterCommand` called the native `RegisterCommand` a second time, while the native handler kept running the `cb` captured by whichever registration FiveM held on to instead of the one stored in `Core.RegisteredCommands`. GTA V Enhanced logs `Command X is already registered.` on that second call and keeps the first handler, so an override such as esx_adminmenu's `/goto` ran the original callback against the override's arguments. The handler now reads the callback from `Core.RegisteredCommands` when the command runs, and an override only replaces that entry and adds its ACEs.

---

### Usage Example

```lua
ESX.RegisterCommand("goto", "admin", function(xPlayer, args)
    print("original")
end)

-- registered later from another resource, this is now the callback that runs
ESX.RegisterCommand("goto", "admin", function(xPlayer, args, showError)
    print("override")
end, true)
```

---

### PR Checklist

-   [x] My commit messages and PR title follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] My changes have been tested locally and function as expected.
-   [x] My PR does not introduce any breaking changes.
-   [x] I have provided a clear explanation of what my PR does, including the reasoning behind the changes and any relevant context.
